### PR TITLE
Fix Renderer to return page.url as path

### DIFF
--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -42,7 +42,7 @@ module InertiaRails
       {
         component: component,
         props: props,
-        url: @request.original_url,
+        url: @request.original_fullpath,
         version: ::InertiaRails.version,
       }
     end

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -39,6 +39,10 @@ RSpec.describe 'rendering inertia views', type: :request do
       expect(response.headers['Vary']).to eq 'Accept'
       expect(response.headers['Content-Type']).to eq 'application/json; charset=utf-8'
     end
+
+    it 'has the proper body' do
+      expect(JSON.parse(response.body)).to include('url' => '/props')
+    end
   end
 end
 


### PR DESCRIPTION
Inertia.js expects a **path** (without host name) in `page.url`, see here:
https://github.com/inertiajs/inertia/blob/v0.1.7/src/inertia.js#L137

With the current implementation of this gem, Inertia's history management is failing. Each visit leads to a `window.history.pushState`, which is wrong.

This PR contains a fix by returning `original_fullpath` instead of `original_url`.