### PR TITLE
Rewrite "inertia_share" to drop `InertiaRails.reset!`

### DIFF
--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -5,19 +5,46 @@ module InertiaRails
     extend ActiveSupport::Concern
 
     included do
-      before_action do
+      error_sharing = proc do
         # :inertia_errors are deleted from the session by the middleware
-        InertiaRails.share(errors: session[:inertia_errors]) if session[:inertia_errors].present?
+        if @_request && session[:inertia_errors].present?
+          { errors: session[:inertia_errors] }
+        else
+          {}
+        end
+      end
+
+      if Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new('5.2.0')
+        class_attribute :shared_plain_data, default: {}
+        class_attribute :shared_blocks, default: [error_sharing]
+      else
+        # In older Rails there is no `default` for class_attribute. This was
+        # introduced with Rails 5.2: https://github.com/rails/rails/pull/29270
+        class_attribute :shared_plain_data
+        class_attribute :shared_blocks
+
+        self.shared_plain_data = {}
+        self.shared_blocks = [error_sharing]
       end
     end
 
-    module ClassMethods
-      def inertia_share(**args, &block)
-        before_action do
-          InertiaRails.share(**args) if args
-          InertiaRails.share_block(block) if block
-        end
+    class_methods do
+      def inertia_share(hash = nil, &block)
+        share_plain_data(hash) if hash
+        share_block(&block) if block_given?
       end
+
+      def share_plain_data(hash)
+        self.shared_plain_data = shared_plain_data.merge(hash)
+      end
+
+      def share_block(&block)
+        self.shared_blocks = shared_blocks + [ block ]
+      end
+    end
+
+    def shared_data
+      shared_plain_data.merge(evaluated_blocks)
     end
 
     def redirect_to(options = {}, response_options = {})
@@ -45,6 +72,12 @@ module InertiaRails
       if (inertia_errors = options.dig(:inertia, :errors))
         session[:inertia_errors] = inertia_errors
       end
+    end
+
+    private
+
+    def evaluated_blocks
+      shared_blocks.map { |block| instance_exec(&block) }.reduce(&:merge) || {}
     end
   end
 end

--- a/lib/inertia_rails/inertia_rails.rb
+++ b/lib/inertia_rails/inertia_rails.rb
@@ -3,16 +3,8 @@ require 'active_support/core_ext/module/attribute_accessors_per_thread'
 require 'inertia_rails/lazy'
 
 module InertiaRails
-  thread_mattr_accessor :threadsafe_shared_plain_data
-  thread_mattr_accessor :threadsafe_shared_blocks
-
   def self.configure
     yield(Configuration)
-  end
-
-  # "Getters"
-  def self.shared_data(controller)
-    shared_plain_data.merge!(evaluated_blocks(controller, shared_blocks))
   end
 
   def self.version
@@ -21,20 +13,6 @@ module InertiaRails
 
   def self.layout
     Configuration.layout
-  end
-
-  # "Setters"
-  def self.share(**args)
-    self.shared_plain_data = self.shared_plain_data.merge(args)
-  end
-
-  def self.share_block(block)
-    self.shared_blocks = self.shared_blocks + [block]
-  end
-
-  def self.reset!
-    self.shared_plain_data = {}
-    self.shared_blocks = []
   end
 
   def self.lazy(value = nil, &block)
@@ -67,9 +45,5 @@ module InertiaRails
 
   def self.shared_blocks=(val)
     self.threadsafe_shared_blocks = val
-  end
-
-  def self.evaluated_blocks(controller,  blocks)
-    blocks.flat_map { |block| controller.instance_exec(&block) }.reduce(&:merge) || {}
   end
 end

--- a/lib/inertia_rails/middleware.rb
+++ b/lib/inertia_rails/middleware.rb
@@ -19,9 +19,7 @@ module InertiaRails
         status, headers, body = @app.call(@env)
         request = ActionDispatch::Request.new(@env)
 
-        ::InertiaRails.reset!
-
-        # Inertia errors are added to the session via redirect_to 
+        # Inertia errors are added to the session via redirect_to
         request.session.delete(:inertia_errors) unless keep_inertia_errors?(status)
 
         status = 303 if inertia_non_post_redirect?(status)
@@ -92,4 +90,3 @@ module InertiaRails
     end
   end
 end
-

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -27,7 +27,7 @@ module InertiaRails
     private
 
     def props
-      _props = ::InertiaRails.shared_data(@controller).merge(@props).select do |key, prop|
+      _props = @controller.shared_data.merge(@props).select do |key, prop|
         if rendering_partial_component?
           key.in? partial_keys
         else

--- a/spec/dummy/app/controllers/inertia_share_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_share_test_controller.rb
@@ -4,11 +4,21 @@ class InertiaShareTestController < ApplicationController
   inertia_share do
     {
       position: 'center',
-      number: 29,
+      number: number,
     }
   end
   
   def share
     render inertia: 'ShareTestComponent'
+  end
+
+  def error
+    raise RuntimeError
+  end
+
+  private
+
+  def number
+    29
   end
 end

--- a/spec/dummy/app/controllers/inertia_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_test_controller.rb
@@ -58,4 +58,8 @@ class InertiaTestController < ApplicationController
       format.xml { render xml: [ 1, 2, 3 ] }
     end
   end
+
+  def redirect_to_share_test
+    redirect_to share_path
+  end
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -32,6 +32,15 @@ module Dummy
 
     # Required for Rails 5.0 and 5.1
     config.secret_key_base = SecureRandom.hex
+
+    config.exceptions_app = ->(env) do
+      Class.new(ActionController::Base) do
+        def show
+          render inertia: 'Error', props: {
+            status: request.path_info[1..-1].to_i
+          }
+        end
+      end.action(:show).call(env)
+    end
   end
 end
-

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -24,12 +24,12 @@ Rails.application.configure do
   }
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local       = false
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = true
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   get 'view_data' => 'inertia_render_test#view_data'
   get 'component' => 'inertia_render_test#component'
   get 'share' => 'inertia_share_test#share'
+  get 'error' => 'inertia_share_test#error'
   get 'share_with_inherited' => 'inertia_child_share_test#share_with_inherited'
   get 'empty_test' => 'inertia_test#empty_test'
   get 'redirect_test' => 'inertia_test#redirect_test'

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -16,7 +16,6 @@ Rails.application.routes.draw do
   put 'redirect_test' => 'inertia_test#redirect_test'
   delete 'redirect_test' => 'inertia_test#redirect_test'
   get 'my_location' => 'inertia_test#my_location'
-  get 'share_multithreaded' => 'inertia_multithreaded_share#share_multithreaded'
   get 'redirect_with_inertia_errors' => 'inertia_test#redirect_with_inertia_errors'
   post 'redirect_with_inertia_errors' => 'inertia_test#redirect_with_inertia_errors'
   post 'redirect_back_with_inertia_errors' => 'inertia_test#redirect_back_with_inertia_errors'
@@ -26,5 +25,6 @@ Rails.application.routes.draw do
   get 'lazy_props' => 'inertia_render_test#lazy_props'
   get 'non_inertiafied' => 'inertia_test#non_inertiafied'
 
+  post 'redirect_to_share_test' => 'inertia_test#redirect_to_share_test'
   inertia 'inertia_route' => 'TestComponent'
 end

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -1,11 +1,13 @@
 RSpec.describe 'rendering inertia views', type: :request do
   subject { response.body }
 
+  let(:controller) { ApplicationController.new }
+
   context 'first load' do
-    let(:page) { InertiaRails::Renderer.new('TestComponent', '', request, response, '', props: nil, view_data: nil).send(:page) }
     
+    let(:page) { InertiaRails::Renderer.new('TestComponent', controller, request, response, '', props: nil, view_data: nil).send(:page) }
     context 'with props' do
-      let(:page) { InertiaRails::Renderer.new('TestComponent', '', request, response, '', props: {name: 'Brandon', sport: 'hockey'}, view_data: nil).send(:page) }
+      let(:page) { InertiaRails::Renderer.new('TestComponent', controller, request, response, '', props: {name: 'Brandon', sport: 'hockey'}, view_data: nil).send(:page) }
       before { get props_path }
 
       it { is_expected.to include inertia_div(page) }
@@ -37,7 +39,7 @@ RSpec.describe 'rendering inertia views', type: :request do
   end
 
   context 'subsequent requests' do
-    let(:page) { InertiaRails::Renderer.new('TestComponent', '', request, response, '', props: {name: 'Brandon', sport: 'hockey'}, view_data: nil).send(:page) }
+    let(:page) { InertiaRails::Renderer.new('TestComponent', controller, request, response, '', props: {name: 'Brandon', sport: 'hockey'}, view_data: nil).send(:page) }
     let(:headers) { {'X-Inertia' => true} }
 
     before { get props_path, headers: headers }
@@ -62,7 +64,7 @@ RSpec.describe 'rendering inertia views', type: :request do
 
   context 'partial rendering' do
     let (:page) {
-      InertiaRails::Renderer.new('TestComponent', '', request, response, '', props: { sport: 'hockey'}, view_data: nil).send(:page)
+      InertiaRails::Renderer.new('TestComponent', controller, request, response, '', props: { sport: 'hockey'}, view_data: nil).send(:page)
     }
     let(:headers) {{
       'X-Inertia' => true,
@@ -92,7 +94,7 @@ RSpec.describe 'rendering inertia views', type: :request do
   context 'lazy prop rendering' do
     context 'on first load' do
       let (:page) {
-        InertiaRails::Renderer.new('TestComponent', '', request, response, '', props: { name: 'Brian'}, view_data: nil).send(:page)
+        InertiaRails::Renderer.new('TestComponent', controller, request, response, '', props: { name: 'Brian'}, view_data: nil).send(:page)
       }
       before { get lazy_props_path }
 
@@ -101,7 +103,7 @@ RSpec.describe 'rendering inertia views', type: :request do
 
     context 'with a partial reload' do
       let (:page) {
-        InertiaRails::Renderer.new('TestComponent', '', request, response, '', props: { sport: 'basketball', level: 'worse than he believes', grit: 'intense'}, view_data: nil).send(:page)
+        InertiaRails::Renderer.new('TestComponent', controller, request, response, '', props: { sport: 'basketball', level: 'worse than he believes', grit: 'intense'}, view_data: nil).send(:page)
       }
       let(:headers) {{
         'X-Inertia' => true,

--- a/spec/inertia/sharing_spec.rb
+++ b/spec/inertia/sharing_spec.rb
@@ -63,4 +63,14 @@ RSpec.describe 'using inertia share when rendering views', type: :request do
 
     it { is_expected.to eq props }
   end
+
+  context 'using inertia share with exception handler' do
+    let(:props) { { status: 500 } }
+
+    before do
+      get error_path, headers: {'X-Inertia' => true}
+    end
+
+    it { is_expected.to eq props }
+  end
 end

--- a/spec/inertia/sharing_spec.rb
+++ b/spec/inertia/sharing_spec.rb
@@ -50,40 +50,4 @@ RSpec.describe 'using inertia share when rendering views', type: :request do
 
     it { is_expected.to eq props.merge({ errors: errors }) }
   end
-
-  context 'multithreaded intertia share' do
-    let(:props) { { name: 'Michael', has_goat_status: true } }
-    it 'is expected to render props even when another thread shares Inertia data' do
-      start_thread1 = false
-      start_thread2 = false
-
-      thread1 = Thread.new do
-        sleep 0.1 until start_thread1
-
-        get share_multithreaded_path, headers: {'X-Inertia' => true}
-        expect(subject).to eq props
-      end
-
-      thread2 = Thread.new do
-        sleep 0.1 until start_thread2
-
-        # Would prefer to make this a second get request, but RSpec will overwrite
-        # the @response variable if another request is made in the second thread.
-        # This simulates the relevant effects of another call to a different
-        # controller with different values for inertia_share
-        InertiaRails.reset!
-        InertiaRails.share(name: 'Brian', has_goat_status: false)
-      end
-
-      # Thread 1 starts. The controller method runs inertia_share, then sleeps.
-      # Thread 2 then modifies the shared inertia data before Thread 1 stops sleeping
-      start_thread1 = true
-      sleep 0.5
-      start_thread2 = true
-
-      # Make sure that both threads finish before the block returns
-      thread1.join
-      thread2.join
-    end
-  end
 end

--- a/spec/inertia/sharing_spec.rb
+++ b/spec/inertia/sharing_spec.rb
@@ -50,4 +50,17 @@ RSpec.describe 'using inertia share when rendering views', type: :request do
 
     it { is_expected.to eq props.merge({ errors: errors }) }
   end
+
+  context 'using inertia share in redirected requests' do
+    let(:props) { {name: 'Brandon', sport: 'hockey', position: 'center', number: 29} }
+
+    before do
+      post redirect_to_share_test_path, headers: {'X-Inertia' => true}
+      expect(response).to be_redirect
+
+      get response.location, headers: {'X-Inertia' => true}
+    end
+
+    it { is_expected.to eq props }
+  end
 end


### PR DESCRIPTION
Fixing #15 needs some rewrite. Why this is important, please see the added test in `spec/inertia/sharing_spec.rb`: Because of `InertiaRails.reset!`, all shared data is lost on second request of the same URL. 

My rewrite of `inertia_share` makes the added test pass, without touching the existing tests (except for small details) or changing the API.

Background: Managing shared data via `mattr_accessor` of the `InertiaRails` module does not allow to use class inheritance at controller level, e.g. defining some global shared data in `ApplicationController` and some additional in `UsersController` but not in `SomeOtherController`. This can't be achieved by managing them in **one** global array. In addition, it can't handle code changes which was described in #8.

What the rewrite does:

- It uses `class_attribute` placed in the base controller, so every controller can define it's own shared data. Some code from the module `InertiaRails` is moved over.
- It removes `InertiaRails.reset!`, because it's not needed anymore

This fixes #15 and is a better fix for #8. It reverts the changes from #13.