### PR TITLE
Fix condition where inertia_share data gets erased for forever on second request

### DIFF
--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -6,8 +6,10 @@ module InertiaRails
 
     module ClassMethods
       def inertia_share(**args, &block)
-        InertiaRails.share(args) if args
-        InertiaRails.share_block(block) if block
+        before_action do
+          InertiaRails.share(args) if args
+          InertiaRails.share_block(block) if block
+        end
       end
     end
   end

--- a/spec/dummy/app/controllers/inertia_child_share_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_child_share_test_controller.rb
@@ -1,0 +1,7 @@
+class InertiaChildShareTestController < InertiaShareTestController
+  inertia_share name: 'No Longer Brandon'
+
+  def share_with_inherited
+    render inertia: 'ShareTestComponent'
+  end
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   get 'view_data' => 'inertia_render_test#view_data'
   get 'component' => 'inertia_render_test#component'
   get 'share' => 'inertia_share_test#share'
+  get 'share_with_inherited' => 'inertia_child_share_test#share_with_inherited'
   get 'empty_test' => 'inertia_test#empty_test'
   get 'redirect_test' => 'inertia_test#redirect_test'
   post 'redirect_test' => 'inertia_test#redirect_test'

--- a/spec/inertia/sharing_spec.rb
+++ b/spec/inertia/sharing_spec.rb
@@ -1,19 +1,40 @@
 RSpec.describe 'using inertia share when rendering views', type: :request do
   subject { JSON.parse(response.body)['props'].symbolize_keys }
-  
+
   context 'using inertia share' do
     let(:props) { {name: 'Brandon', sport: 'hockey', position: 'center', number: 29} }
     before { get share_path, headers: {'X-Inertia' => true} }
-    
+
     it { is_expected.to eq props }
   end
 
-  context 'inertia share across requests' do 
+  context 'inertia share across requests' do
     before do
-      get share_path, headers: {'X-Inertia' => true} 
+      get share_path, headers: {'X-Inertia' => true}
       get empty_test_path, headers: {'X-Inertia' => true}
     end
-  
+
     it { is_expected.to eq({}) }
+  end
+
+  context 'using inertia share in subsequent requests' do
+    let(:props) { {name: 'Brandon', sport: 'hockey', position: 'center', number: 29} }
+
+    before do
+      get share_path, headers: {'X-Inertia' => true}
+      get share_path, headers: {'X-Inertia' => true}
+    end
+
+    it { is_expected.to eq props }
+  end
+
+  context 'using inertia share with inheritance' do
+    let(:props) { {name: 'No Longer Brandon', sport: 'hockey', position: 'center', number: 29} }
+
+    before do
+      get share_with_inherited_path, headers: {'X-Inertia' => true}
+    end
+
+    it { is_expected.to eq props }
   end
 end


### PR DESCRIPTION
Closes #15 

As @ledermann points out in #15 and PR #17 , the calls to `inertia_share` from a controller only run the first time the class is loaded and the data is subsequently deleted forever on the next request, because of the `InertiaRails.reset!` call in the middleware... presumably, we didn't notice this in development either due to classes reloading when changed, or maybe because `config.cache_classes = false` in development environments.

The PR does a lot of refactoring that we want to discuss before merging in, so I created this PR, which solves the bug without changing much code.

The basic idea is to wrap the `InertiaRails.share` calls inside a block given to `before_action`. This, combined with the current `InertiaRails.reset!` call in the middleware, ensures that shared data is recalculated from scratch on each request.

I wrote a test to check inheritance as well, which seems to work as well, though this change isn't explicitly intended to add support for inheritance.