### PR TITLE
Fix breaking rack change

### DIFF
--- a/lib/inertia_rails/middleware.rb
+++ b/lib/inertia_rails/middleware.rb
@@ -40,7 +40,7 @@ module InertiaRails
   
     def force_refresh(request)
       request.flash.keep
-      Rack::Response.new('', 409, {'X-Inertia-Location' => request.original_url})
+      Rack::Response.new('', 409, {'X-Inertia-Location' => request.original_url}).finish
     end
   end
 end


### PR DESCRIPTION
As @ledermann identified in #22 , Rack released a breaking change in a patch release.

This commit https://github.com/rack/rack/commit/72959ebc2f300f3b2ccb7ae2aae9f199e611dfb6#diff-10b933d2c1fdc82ceecade456c64e1c2 removed the implicit cast to array `to_ary` method from `Rack::Response`, which we were unintentionally relying on.

I switched to using the `finish` method as the rack::response code comments suggest. It's an alias to `to_a` that has been in the codebase for over a decade, so I feel pretty safe :smile: