### PR TITLE
Add an inertia? method onto request

### DIFF
--- a/lib/inertia_rails.rb
+++ b/lib/inertia_rails.rb
@@ -3,6 +3,7 @@ require 'inertia_rails/engine'
 
 require 'patches/debug_exceptions'
 require 'patches/better_errors'
+require 'patches/request'
 
 ActionController::Renderers.add :inertia do |component, options|
   InertiaRails::Renderer.new(

--- a/lib/patches/request.rb
+++ b/lib/patches/request.rb
@@ -1,7 +1,5 @@
-if defined?(ActionDispatch::Request)
-  ActionDispatch::Request.class_eval do
-    def inertia?
-      headers['HTTP_X_INERTIA'].present?
-    end
+ActionDispatch::Request.class_eval do
+  def inertia?
+    key? 'HTTP_X_INERTIA'
   end
 end

--- a/lib/patches/request.rb
+++ b/lib/patches/request.rb
@@ -1,0 +1,7 @@
+if defined?(ActionDispatch::Request)
+  ActionDispatch::Request.class_eval do
+    def inertia?
+      headers['HTTP_X_INERTIA'].present?
+    end
+  end
+end

--- a/spec/dummy/app/controllers/inertia_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_test_controller.rb
@@ -6,4 +6,12 @@ class InertiaTestController < ApplicationController
   def redirect_test
     redirect_to :empty_test
   end
+
+  def inertia_request_test
+    if request.inertia?
+      head 202
+    else
+      head 200
+    end
+  end
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   get 'share_with_inherited' => 'inertia_child_share_test#share_with_inherited'
   get 'empty_test' => 'inertia_test#empty_test'
   get 'redirect_test' => 'inertia_test#redirect_test'
+  get 'inertia_request_test' => 'inertia_test#inertia_request_test'
   post 'redirect_test' => 'inertia_test#redirect_test'
   patch 'redirect_test' => 'inertia_test#redirect_test'
   put 'redirect_test' => 'inertia_test#redirect_test'

--- a/spec/inertia/request_spec.rb
+++ b/spec/inertia/request_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe 'Inertia::Request', type: :request do
+  describe 'it tests whether a call is an inertia call' do
+    subject { response.status }
+    before { get inertia_request_test_path, headers: headers }
+
+    context 'it is an inertia call' do
+      let(:headers) { {'X-Inertia' => true} }
+
+      it { is_expected.to eq 202 }
+    end
+
+    context 'it is not an inertia call' do
+      let(:headers) { Hash.new }
+
+      it { is_expected.to eq 200 }
+    end
+  end 
+end


### PR DESCRIPTION
I've been using this in my own project and noticed that @reinink added it to the laravel version. 

So why not send it upstream!

`request.inertia?` is an easy way to check in your controller whether or not you're dealing with an inertia request. In my project, I use it to decide whether to return an http status or an inertia response when I'm handling things like auto-save.