### PR TITLE
Add base path configuration option

### DIFF
--- a/lib/inertia_rails/inertia_rails.rb
+++ b/lib/inertia_rails/inertia_rails.rb
@@ -19,6 +19,10 @@ module InertiaRails
     Configuration.layout
   end
 
+  def self.base_path
+    Configuration.base_path
+  end
+
   # "Setters"
   def self.share(**args)
     shared_plain_data.merge!(args)
@@ -38,6 +42,7 @@ module InertiaRails
   module Configuration
     mattr_accessor(:layout) { 'application' }
     mattr_accessor(:version) { nil }
+    mattr_accessor(:base_path) { nil }
 
     def self.evaluated_version
       self.version.respond_to?(:call) ? self.version.call : self.version

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -42,9 +42,15 @@ module InertiaRails
       {
         component: component,
         props: props,
-        url: @request.original_fullpath,
+        url: page_url,
         version: ::InertiaRails.version,
       }
+    end
+
+    def page_url
+      ::InertiaRails.base_path ?
+        @request.original_fullpath.split(::InertiaRails.base_path)[1] :
+        @request.original_fullpath
     end
 
     def deep_transform_values(hash, proc)


### PR DESCRIPTION
Hey there 👋 

I ran into an issue with Inertia that I think could be fixed quite easily. I'm using nginx to reverse proxy my subdomain to a nested route in Rails, the configuration looks like this:
![Screen Shot 2020-05-05 at 11 26 26 am](https://user-images.githubusercontent.com/7920702/81028197-c0a49580-8ec3-11ea-8912-dbb7f2c21c27.png)

Which causes Inertia to rewrite the current path to `/admin` rather than just `/`

![inertia-base-path](https://user-images.githubusercontent.com/7920702/81028229-d5812900-8ec3-11ea-93c9-71a0d2c7dd69.gif)

Ive managed to fix this by setting a before action in my controller as such:

![Screen Shot 2020-05-05 at 11 27 43 am](https://user-images.githubusercontent.com/7920702/81028247-e5990880-8ec3-11ea-9b4f-993a5b7ab298.png)

And this works correctly:
![inertia-base-path-fixed](https://user-images.githubusercontent.com/7920702/81028255-ec278000-8ec3-11ea-965f-414fee1891ef.gif)

It seemed easy enough to add this as a configuration option to the Rails gem and I would imagine it being set in the initializer

FYI I havn't tested this code, but I hope it illustrates the point :)
