### PR TITLE
Fix Ruby 2.7 deprecation warnings

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,10 +12,10 @@ jobs:
       - name: Setup System
         run: sudo apt-get install libsqlite3-dev
 
-      - name: Set up Ruby 2.6
+      - name: Set up Ruby 2.7
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
+          ruby-version: 2.7.x
 
       - name: Install gems
         run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,18 +4,24 @@ on: [push]
 
 jobs:
   test:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [2.6, 2.7]
+
     runs-on: ubuntu-latest
+    name: Test against Ruby ${{ matrix.ruby }}
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Setup System
         run: sudo apt-get install libsqlite3-dev
 
-      - name: Set up Ruby 2.7
-        uses: actions/setup-ruby@v1
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.x
+          ruby-version: ${{ matrix.ruby }}
 
       - name: Install gems
         run: |

--- a/inertia_rails.gemspec
+++ b/inertia_rails.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec-rails", "~> 3.0"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rspec-rails", "~> 4.0"
   spec.add_development_dependency "rails"
   spec.add_development_dependency "rails-controller-testing"
   spec.add_development_dependency "sqlite3"

--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -7,7 +7,7 @@ module InertiaRails
     module ClassMethods
       def inertia_share(**args, &block)
         before_action do
-          InertiaRails.share(args) if args
+          InertiaRails.share(**args) if args
           InertiaRails.share_block(block) if block
         end
       end

--- a/lib/inertia_rails/rspec.rb
+++ b/lib/inertia_rails/rspec.rb
@@ -61,7 +61,7 @@ RSpec.configure do |config|
   config.before(:each, inertia: true) do
     new_renderer = InertiaRails::Renderer.method(:new)
     allow(InertiaRails::Renderer).to receive(:new) do |component, controller, request, response, render, named_args|
-      new_renderer.call(component, controller, request, response, inertia_wrap_render(render), named_args)
+      new_renderer.call(component, controller, request, response, inertia_wrap_render(render), **named_args)
     end
   end
 end


### PR DESCRIPTION
When using Ruby 2.7, the gem displays same deprecation warnings:

```
lib/inertia_rails/rspec.rb:64: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
...
lib/inertia_rails/controller.rb:10: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

I fixed them and enabled matrix testing to ensure I didn't break anything for Ruby 2.6.

I updated some development dependencies as well - this reduces warnings while running tests.