### PR TITLE
Add an inertia_partial? method onto request

### DIFF
--- a/lib/patches/request.rb
+++ b/lib/patches/request.rb
@@ -2,4 +2,8 @@ ActionDispatch::Request.class_eval do
   def inertia?
     key? 'HTTP_X_INERTIA'
   end
+
+  def inertia_partial?
+    key? 'HTTP_X_INERTIA_PARTIAL_DATA'
+  end
 end

--- a/spec/dummy/app/controllers/inertia_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_test_controller.rb
@@ -14,4 +14,12 @@ class InertiaTestController < ApplicationController
       head 200
     end
   end
+
+  def inertia_partial_request_test
+    if request.inertia_partial?
+      head 202
+    else
+      head 200
+    end
+  end
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   get 'empty_test' => 'inertia_test#empty_test'
   get 'redirect_test' => 'inertia_test#redirect_test'
   get 'inertia_request_test' => 'inertia_test#inertia_request_test'
+  get 'inertia_partial_request_test' => 'inertia_test#inertia_partial_request_test'
   post 'redirect_test' => 'inertia_test#redirect_test'
   patch 'redirect_test' => 'inertia_test#redirect_test'
   put 'redirect_test' => 'inertia_test#redirect_test'

--- a/spec/inertia/request_spec.rb
+++ b/spec/inertia/request_spec.rb
@@ -14,5 +14,22 @@ RSpec.describe 'Inertia::Request', type: :request do
 
       it { is_expected.to eq 200 }
     end
-  end 
+  end
+
+  describe 'it tests whether a call is a partial inertia call' do
+    subject { response.status }
+    before { get inertia_partial_request_test_path, headers: headers }
+
+    context 'it is a partial inertia call' do
+      let(:headers) { { 'X-Inertia' => true, 'X-Inertia-Partial-Data' => 'foo,bar,baz' } }
+
+      it { is_expected.to eq 202 }
+    end
+
+    context 'it is not a partial inertia call' do
+      let(:headers) { { 'X-Inertia' => true } }
+
+      it { is_expected.to eq 200 }
+    end
+  end
 end


### PR DESCRIPTION
Similar to #24 this PR adds `#inertia_partial?` to the request. It checks the header for `X-Inertia-Partial-Data` to distinguish between a full or partial request.

Example use case: In an application showing posts, I want to Increase the post's view counter for full requests only. Code from the controller:

```ruby
class PostsController < ApplicationController 
  after_action :increase_view_count, only: [ :show ]
  # ...

  private

  def increase_view_count
    @post.punch(request) unless request.inertia_partial?
  end
end
```
