### PR TITLE
Make inertia_share threadsafe

### DIFF
--- a/lib/inertia_rails/inertia_rails.rb
+++ b/lib/inertia_rails/inertia_rails.rb
@@ -1,6 +1,6 @@
 module InertiaRails
-  thread_mattr_accessor :shared_plain_data
-  thread_mattr_accessor :shared_blocks
+  thread_mattr_accessor :threadsafe_shared_plain_data
+  thread_mattr_accessor :threadsafe_shared_blocks
 
   def self.configure
     yield(Configuration)
@@ -8,7 +8,7 @@ module InertiaRails
 
   # "Getters"
   def self.shared_data(controller)
-    threadsafe_shared_plain_data.merge!(evaluated_blocks(controller, threadsafe_shared_blocks))
+    shared_plain_data.merge!(evaluated_blocks(controller, shared_blocks))
   end
 
   def self.version
@@ -21,11 +21,11 @@ module InertiaRails
 
   # "Setters"
   def self.share(**args)
-    self.shared_plain_data = threadsafe_shared_plain_data.merge(args)
+    self.shared_plain_data = self.shared_plain_data.merge(args)
   end
 
   def self.share_block(block)
-    self.shared_blocks = threadsafe_shared_blocks + [block]
+    self.shared_blocks = self.shared_blocks + [block]
   end
 
   def self.reset!
@@ -44,20 +44,24 @@ module InertiaRails
     end
   end
 
+  # Getters and setters to provide default values for the threadsafe attributes
+  def self.shared_plain_data
+    self.threadsafe_shared_plain_data || {}
+  end
+
+  def self.shared_plain_data=(val)
+    self.threadsafe_shared_plain_data = val
+  end
+
+  def self.shared_blocks
+    self.threadsafe_shared_blocks || []
+  end
+
+  def self.shared_blocks=(val)
+    self.threadsafe_shared_blocks = val
+  end
+
   def self.evaluated_blocks(controller,  blocks)
     blocks.flat_map { |block| controller.instance_exec(&block) }.reduce(&:merge) || {}
-  end
-
-  # thread_mattr_accessor doesn't accept :default as an option, and since the method
-  # is actually defined in the context of Thread.current, we can't do something like:
-  # def self.shared_plain_data
-  #   @@shared_plain_data || {}
-  # end
-  def self.threadsafe_shared_plain_data
-    self.shared_plain_data || {}
-  end
-
-  def self.threadsafe_shared_blocks
-    self.shared_blocks || []
   end
 end

--- a/lib/inertia_rails/inertia_rails.rb
+++ b/lib/inertia_rails/inertia_rails.rb
@@ -36,11 +36,19 @@ module InertiaRails
   private
 
   module Configuration
-    mattr_accessor(:layout) { 'application' }
+    thread_mattr_accessor :threadsafe_layout
     mattr_accessor(:version) { nil }
 
     def self.evaluated_version
       self.version.respond_to?(:call) ? self.version.call : self.version
+    end
+
+    def self.layout
+      self.threadsafe_layout || 'application'
+    end
+
+    def self.layout=(val)
+      self.threadsafe_layout = val
     end
   end
 

--- a/lib/inertia_rails/inertia_rails.rb
+++ b/lib/inertia_rails/inertia_rails.rb
@@ -37,7 +37,7 @@ module InertiaRails
 
   module Configuration
     thread_mattr_accessor :threadsafe_layout
-    mattr_accessor(:version) { nil }
+    thread_mattr_accessor :threadsafe_version
 
     def self.evaluated_version
       self.version.respond_to?(:call) ? self.version.call : self.version
@@ -49,6 +49,14 @@ module InertiaRails
 
     def self.layout=(val)
       self.threadsafe_layout = val
+    end
+
+    def self.version
+      self.threadsafe_version
+    end
+
+    def self.version=(val)
+      self.threadsafe_version = val
     end
   end
 

--- a/spec/dummy/app/controllers/inertia_multithreaded_share_controller.rb
+++ b/spec/dummy/app/controllers/inertia_multithreaded_share_controller.rb
@@ -1,0 +1,9 @@
+class InertiaMultithreadedShareController < ApplicationController
+  inertia_share name: 'Michael'
+  inertia_share has_goat_status: true
+
+  def share_multithreaded
+    sleep 1
+    render inertia: 'ShareTestComponent'
+  end
+end

--- a/spec/dummy/app/controllers/inertia_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_test_controller.rb
@@ -7,6 +7,11 @@ class InertiaTestController < ApplicationController
     redirect_to :empty_test
   end
 
+  def long_request_test
+    sleep 1
+    render inertia: 'EmptyTestComponent'
+  end
+
   def inertia_request_test
     if request.inertia?
       head 202

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   get 'share_with_inherited' => 'inertia_child_share_test#share_with_inherited'
   get 'empty_test' => 'inertia_test#empty_test'
   get 'redirect_test' => 'inertia_test#redirect_test'
+  get 'long_request_test' => 'inertia_test#long_request_test'
   get 'inertia_request_test' => 'inertia_test#inertia_request_test'
   get 'inertia_partial_request_test' => 'inertia_test#inertia_partial_request_test'
   post 'redirect_test' => 'inertia_test#redirect_test'

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -14,4 +14,5 @@ Rails.application.routes.draw do
   patch 'redirect_test' => 'inertia_test#redirect_test'
   put 'redirect_test' => 'inertia_test#redirect_test'
   delete 'redirect_test' => 'inertia_test#redirect_test'
+  get 'share_multithreaded' => 'inertia_multithreaded_share#share_multithreaded'
 end

--- a/spec/inertia/configuration_spec.rb
+++ b/spec/inertia/configuration_spec.rb
@@ -39,11 +39,11 @@ RSpec.describe 'Inertia configuration', type: :request do
 
     context 'multithreaded' do
       it 'does not share the version across threads' do
-        thread1_waits = true
-        thread2_waits = true
+        start_thread1 = false
+        start_thread2 = false
 
         thread1 = Thread.new do
-          sleep 0.1 while thread1_waits
+          sleep 0.1 until start_thread1
 
           InertiaRails.configure do |config|
             config.version = 'The original version'
@@ -54,16 +54,16 @@ RSpec.describe 'Inertia configuration', type: :request do
         end
 
         thread2 = Thread.new do
-          sleep 0.1 while thread2_waits
+          sleep 0.1 until start_thread2
 
           InertiaRails.configure do |config|
             config.version = 'Not the original version'
           end
         end
 
-        thread1_waits = false
+        start_thread1 = true
         sleep 0.5
-        thread2_waits = false
+        start_thread2 = true
 
         # Make sure that both threads finish before the block returns
         thread1.join
@@ -100,7 +100,7 @@ RSpec.describe 'Inertia configuration', type: :request do
         start_thread2 = false
 
         thread1 = Thread.new do
-          sleep 0.1 unless start_thread1
+          sleep 0.1 until start_thread1
 
           get long_request_test_path
           expect(subject).not_to render_template 'testing'
@@ -108,7 +108,7 @@ RSpec.describe 'Inertia configuration', type: :request do
         end
 
         thread2 = Thread.new do
-          sleep 0.1 unless start_thread2
+          sleep 0.1 until start_thread2
 
           InertiaRails.configure do |config|
             config.layout = 'testing'

--- a/spec/inertia/configuration_spec.rb
+++ b/spec/inertia/configuration_spec.rb
@@ -59,6 +59,37 @@ RSpec.describe 'Inertia configuration', type: :request do
       it { is_expected.to render_template 'testing' }
       it { is_expected.not_to render_template 'application' }
     end
+
+    context 'multithreaded' do
+      it 'does not share configuration between threads' do
+        start_thread1 = false
+        start_thread2 = false
+
+        thread1 = Thread.new do
+          sleep 0.1 unless start_thread1
+
+          get long_request_test_path
+          expect(subject).not_to render_template 'testing'
+          expect(subject).to render_template 'application'
+        end
+
+        thread2 = Thread.new do
+          sleep 0.1 unless start_thread2
+
+          InertiaRails.configure do |config|
+            config.layout = 'testing'
+          end
+        end
+
+        start_thread1 = true
+        sleep 0.5
+        start_thread2 = true
+
+        # Make sure that both threads finish before the block returns
+        thread1.join
+        thread2.join
+      end
+    end
   end
 
 end

--- a/spec/inertia/sharing_spec.rb
+++ b/spec/inertia/sharing_spec.rb
@@ -37,4 +37,40 @@ RSpec.describe 'using inertia share when rendering views', type: :request do
 
     it { is_expected.to eq props }
   end
+
+  context 'multithreaded intertia share' do
+    let(:props) { { name: 'Michael', has_goat_status: true } }
+    it 'is expected to render props even when another thread shares Inertia data' do
+      start_thread1 = false
+      start_thread2 = false
+
+      thread1 = Thread.new do
+        sleep 0.1 unless start_thread1
+
+        get share_multithreaded_path, headers: {'X-Inertia' => true}
+        expect(subject).to eq props
+      end
+
+      thread2 = Thread.new do
+        sleep 0.1 unless start_thread2
+
+        # Would prefer to make this a second get request, but RSpec will overwrite
+        # the @response variable if another request is made in the second thread.
+        # This simulates the relevant effects of another call to a different
+        # controller with different values for inertia_share
+        InertiaRails.reset!
+        InertiaRails.share(name: 'Brian', has_goat_status: false)
+      end
+
+      # Thread 1 starts. The controller method runs inertia_share, then sleeps.
+      # Thread 2 then modifies the shared inertia data before Thread 1 stops sleeping
+      start_thread1 = true
+      sleep 0.5
+      start_thread2 = true
+
+      # Make sure that both threads finish before the block returns
+      thread1.join
+      thread2.join
+    end
+  end
 end

--- a/spec/inertia/sharing_spec.rb
+++ b/spec/inertia/sharing_spec.rb
@@ -45,14 +45,14 @@ RSpec.describe 'using inertia share when rendering views', type: :request do
       start_thread2 = false
 
       thread1 = Thread.new do
-        sleep 0.1 unless start_thread1
+        sleep 0.1 until start_thread1
 
         get share_multithreaded_path, headers: {'X-Inertia' => true}
         expect(subject).to eq props
       end
 
       thread2 = Thread.new do
-        sleep 0.1 unless start_thread2
+        sleep 0.1 until start_thread2
 
         # Would prefer to make this a second get request, but RSpec will overwrite
         # the @response variable if another request is made in the second thread.


### PR DESCRIPTION
Resolves #35 

`mattr_accessor` is not thread safe... this can cause rendered props to be incorrect through the following process:

1. request 1 hits server
2. The middleware runs `Inertia.reset!` and clears shared data
3. `inertia_share` stores data in the `InertiaRails` module variables
4. request 2 hits server to a _different controller_
5. The middleware runs `Inertia.reset!` and clears shared data
6. request 1 renders data to the view. since shared data has been cleared, the shared data from step 3 is not included in the response to request 1

My knowledge of threading in Rails goes as deep as the ~50 articles/docs pages that i read about it today. This solution assumes that a single thread only processes a single request at a time.
