### PR TITLE
Fix error handling by returning original HTTP status

### DIFF
--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -18,7 +18,7 @@ module InertiaRails
       if @request.headers['X-Inertia']
         @response.set_header('Vary', 'Accept')
         @response.set_header('X-Inertia', 'true')
-        @render_method.call json: page, status: 200
+        @render_method.call json: page, status: @response.status
       else
         @render_method.call template: 'inertia', layout: ::InertiaRails.layout, locals: (view_data).merge({page: page})
       end

--- a/spec/dummy/app/controllers/inertia_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_test_controller.rb
@@ -23,11 +23,18 @@ class InertiaTestController < ApplicationController
     end
   end
 
-
   # Calling it my_location to avoid this in Rails 5.0
   # https://github.com/rails/rails/issues/28033
   def my_location
     puts "Got to location for some reason?"
     inertia_location empty_test_path
+  end
+
+  def error_404
+    render inertia: 'ErrorComponent', status: 404
+  end
+
+  def error_500
+    render inertia: 'ErrorComponent', status: 500
   end
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -16,4 +16,6 @@ Rails.application.routes.draw do
   delete 'redirect_test' => 'inertia_test#redirect_test'
   get 'my_location' => 'inertia_test#my_location'
   get 'share_multithreaded' => 'inertia_multithreaded_share#share_multithreaded'
+  get 'error_404' => 'inertia_test#error_404'
+  get 'error_500' => 'inertia_test#error_500'
 end

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe 'rendering inertia views', type: :request do
 
       it { is_expected.to include inertia_div(page) }
     end
+
+    it 'has the proper status code' do
+      get component_path
+      expect(response.status).to eq 200
+    end
   end
 
   context 'subsequent requests' do
@@ -42,6 +47,10 @@ RSpec.describe 'rendering inertia views', type: :request do
 
     it 'has the proper body' do
       expect(JSON.parse(response.body)).to include('url' => '/props')
+    end
+
+    it 'has the proper status code' do
+      expect(response.status).to eq 200
     end
   end
 end

--- a/spec/inertia/request_spec.rb
+++ b/spec/inertia/request_spec.rb
@@ -32,4 +32,38 @@ RSpec.describe 'Inertia::Request', type: :request do
       it { is_expected.to eq 200 }
     end
   end
+
+  describe 'it tests error 404' do
+    subject { response.status }
+    before { get '/error_404', headers: headers }
+
+    context 'it is a inertia call' do
+      let(:headers) { { 'X-Inertia' => true } }
+
+      it { is_expected.to eq 404 }
+    end
+
+    context 'it is not a inertia call' do
+      let(:headers) { {} }
+
+      it { is_expected.to eq 404 }
+    end
+  end
+
+  describe 'it tests error 500' do
+    subject { response.status }
+    before { get '/error_500', headers: headers }
+
+    context 'it is a inertia call' do
+      let(:headers) { { 'X-Inertia' => true } }
+
+      it { is_expected.to eq 500 }
+    end
+
+    context 'it is not a inertia call' do
+      let(:headers) { {} }
+
+      it { is_expected.to eq 500 }
+    end
+  end
 end


### PR DESCRIPTION
Currently, an InertiaRails response [has always the status code 200](https://github.com/inertiajs/inertia-rails/blob/v1.5.0/lib/inertia_rails/renderer.rb#L21). This seems wrong to me, because if there was an error (like 404 or 500), the corresponding status code should be returned, not 200.

The Laravel adapter [does the same thing](https://github.com/inertiajs/inertia-laravel/blob/v0.2.15/src/Response.php#L81), but the docs recommends [overriding this behavior in the application](https://inertiajs.com/error-handling#production) - from what I understand.

This thing was [discussed for the Laravel adapter](https://github.com/inertiajs/inertia-laravel/issues/56) some time ago. In Rails, error handling is different than in Laravel, so in my opinion returning the original status code should be returned. This fix allows [handling errors I am doing in the PingCRM demo application](https://github.com/ledermann/pingcrm/blob/master/config/application.rb#L34-L41).

Demo using the PingCRM for Rails demo application:

* Go to https://pingcrm.ledermann.dev and login
* Open developer console and open the Network tab
* Klick on the "404 error" button => The error is returned with code 200, which is **wrong**
* Open https://pingcrm.ledermann.dev/error-404 directly in the address line or do a full page reload, so a non-Inertia-request is made => Now the error is returned with code 404, which is **correct**