### PR TITLE
Set content_type for JSON response

### DIFF
--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -18,7 +18,7 @@ module InertiaRails
       if @request.headers['X-Inertia']
         @response.set_header('Vary', 'Accept')
         @response.set_header('X-Inertia', 'true')
-        @render_method.call json: page, status: 200
+        @render_method.call json: page, status: 200, content_type: Mime[:json]
       else
         @render_method.call template: 'inertia', layout: ::InertiaRails.layout, locals: (view_data).merge({page: page})
       end

--- a/spec/dummy/app/controllers/inertia_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_test_controller.rb
@@ -23,11 +23,17 @@ class InertiaTestController < ApplicationController
     end
   end
 
-
   # Calling it my_location to avoid this in Rails 5.0
   # https://github.com/rails/rails/issues/28033
   def my_location
     puts "Got to location for some reason?"
     inertia_location empty_test_path
+  end
+
+  def content_type_test
+    respond_to do |format|
+      format.html { render inertia: 'EmptyTestComponent' }
+      format.xml { render xml: [ 1, 2, 3 ] }
+    end
   end
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -16,4 +16,5 @@ Rails.application.routes.draw do
   delete 'redirect_test' => 'inertia_test#redirect_test'
   get 'my_location' => 'inertia_test#my_location'
   get 'share_multithreaded' => 'inertia_multithreaded_share#share_multithreaded'
+  get 'content_type_test' => 'inertia_test#content_type_test'
 end

--- a/spec/inertia/request_spec.rb
+++ b/spec/inertia/request_spec.rb
@@ -32,4 +32,27 @@ RSpec.describe 'Inertia::Request', type: :request do
       it { is_expected.to eq 200 }
     end
   end
+
+  describe 'it tests media_type of the response' do
+    subject { response.media_type }
+    before { get content_type_test_path, headers: headers }
+
+    context 'it is an inertia call' do
+      let(:headers) { {'X-Inertia' => true} }
+
+      it { is_expected.to eq 'application/json' }
+    end
+
+    context 'it is not an inertia call' do
+      let(:headers) { Hash.new }
+
+      it { is_expected.to eq 'text/html' }
+    end
+
+    context 'it is an XML request' do
+      let(:headers) { { accept: 'application/xml' } }
+
+      it { is_expected.to eq 'application/xml' }
+    end
+  end
 end


### PR DESCRIPTION
Currently, a JSON response from `inertia-rails` does not always have the right content-type. See this example:

```ruby
class PostsController < ApplicationController
  def index
    respond_to do |format|
      format.xml
      format.html do
        render inertia: 'Posts/Index', props: {
          ......
        }
      end
    end
  end
```

An Inertia request sets the header `Accept: text/html, application/xhtml+xml` and `X-Inertia: true` - but it gets JSON from the backend. If using the above code, the `content_type` (or `media_type`) of this JSON response is wrong: It is set to `text/html` instead of `application/json`. **This is caused by using `respond_to` !**

This PR fixes this, so Inertia is compatible with `respond_to`. Please see #42 for another fix of the JSON response.