### PR TITLE
Configuration: Fix thread handling

### DIFF
--- a/lib/inertia_rails/inertia_rails.rb
+++ b/lib/inertia_rails/inertia_rails.rb
@@ -39,19 +39,11 @@ module InertiaRails
   private
 
   module Configuration
-    thread_mattr_accessor :threadsafe_layout
+    mattr_accessor(:layout) { 'application' }
     mattr_accessor(:version) { nil }
 
     def self.evaluated_version
       self.version.respond_to?(:call) ? self.version.call : self.version
-    end
-
-    def self.layout
-      self.threadsafe_layout || 'application'
-    end
-
-    def self.layout=(val)
-      self.threadsafe_layout = val
     end
   end
 

--- a/lib/inertia_rails/inertia_rails.rb
+++ b/lib/inertia_rails/inertia_rails.rb
@@ -40,7 +40,7 @@ module InertiaRails
 
   module Configuration
     thread_mattr_accessor :threadsafe_layout
-    thread_mattr_accessor :threadsafe_version
+    mattr_accessor(:version) { nil }
 
     def self.evaluated_version
       self.version.respond_to?(:call) ? self.version.call : self.version
@@ -52,14 +52,6 @@ module InertiaRails
 
     def self.layout=(val)
       self.threadsafe_layout = val
-    end
-
-    def self.version
-      self.threadsafe_version
-    end
-
-    def self.version=(val)
-      self.threadsafe_version = val
     end
   end
 

--- a/spec/dummy/app/controllers/inertia_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_test_controller.rb
@@ -7,11 +7,6 @@ class InertiaTestController < ApplicationController
     redirect_to :empty_test
   end
 
-  def long_request_test
-    sleep 1
-    render inertia: 'EmptyTestComponent'
-  end
-
   def inertia_request_test
     if request.inertia?
       head 202

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -8,7 +8,6 @@ Rails.application.routes.draw do
   get 'share_with_inherited' => 'inertia_child_share_test#share_with_inherited'
   get 'empty_test' => 'inertia_test#empty_test'
   get 'redirect_test' => 'inertia_test#redirect_test'
-  get 'long_request_test' => 'inertia_test#long_request_test'
   get 'inertia_request_test' => 'inertia_test#inertia_request_test'
   get 'inertia_partial_request_test' => 'inertia_test#inertia_partial_request_test'
   post 'redirect_test' => 'inertia_test#redirect_test'

--- a/spec/inertia/configuration_spec.rb
+++ b/spec/inertia/configuration_spec.rb
@@ -59,37 +59,6 @@ RSpec.describe 'Inertia configuration', type: :request do
       it { is_expected.to render_template 'testing' }
       it { is_expected.not_to render_template 'application' }
     end
-
-    context 'multithreaded' do
-      it 'does not share configuration between threads' do
-        start_thread1 = false
-        start_thread2 = false
-
-        thread1 = Thread.new do
-          sleep 0.1 until start_thread1
-
-          get long_request_test_path
-          expect(subject).not_to render_template 'testing'
-          expect(subject).to render_template 'application'
-        end
-
-        thread2 = Thread.new do
-          sleep 0.1 until start_thread2
-
-          InertiaRails.configure do |config|
-            config.layout = 'testing'
-          end
-        end
-
-        start_thread1 = true
-        sleep 0.5
-        start_thread2 = true
-
-        # Make sure that both threads finish before the block returns
-        thread1.join
-        thread2.join
-      end
-    end
   end
 
 end

--- a/spec/inertia/configuration_spec.rb
+++ b/spec/inertia/configuration_spec.rb
@@ -36,40 +36,6 @@ RSpec.describe 'Inertia configuration', type: :request do
 
       it { is_expected.to eq 1.0 }
     end
-
-    context 'multithreaded' do
-      it 'does not share the version across threads' do
-        start_thread1 = false
-        start_thread2 = false
-
-        thread1 = Thread.new do
-          sleep 0.1 until start_thread1
-
-          InertiaRails.configure do |config|
-            config.version = 'The original version'
-          end
-          get long_request_test_path, headers: {'X-Inertia' => true, 'HTTP_X_INERTIA_VERSION' => 'The original version'}
-
-          expect(subject).to eq 'The original version'
-        end
-
-        thread2 = Thread.new do
-          sleep 0.1 until start_thread2
-
-          InertiaRails.configure do |config|
-            config.version = 'Not the original version'
-          end
-        end
-
-        start_thread1 = true
-        sleep 0.5
-        start_thread2 = true
-
-        # Make sure that both threads finish before the block returns
-        thread1.join
-        thread2.join
-      end
-    end
   end
 
   describe '.layout' do


### PR DESCRIPTION
This fixes #45 by reverting parts of #38. IMHO, `layout` and `version` are global and **must** be shared across threads.

To change `layout` or `version` at runtime, maybe we need another approach, e.g. by setting parameters in the `render :inertia`. Using `InertiaRails.configure` within a controller action seems not right to me.