### PR TITLE
Add inertia_location controller method

### DIFF
--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -12,5 +12,10 @@ module InertiaRails
         end
       end
     end
+
+    def inertia_location(url)
+      headers['X-Inertia-Location'] = url
+      head :conflict
+    end
   end
 end

--- a/spec/dummy/app/controllers/inertia_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_test_controller.rb
@@ -24,7 +24,10 @@ class InertiaTestController < ApplicationController
   end
 
 
-  def location
+  # Calling it my_location to avoid this in Rails 5.0
+  # https://github.com/rails/rails/issues/28033
+  def my_location
+    puts "Got to location for some reason?"
     inertia_location empty_test_path
   end
 end

--- a/spec/dummy/app/controllers/inertia_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_test_controller.rb
@@ -22,4 +22,9 @@ class InertiaTestController < ApplicationController
       head 200
     end
   end
+
+
+  def location
+    inertia_location empty_test_path
+  end
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -14,6 +14,6 @@ Rails.application.routes.draw do
   patch 'redirect_test' => 'inertia_test#redirect_test'
   put 'redirect_test' => 'inertia_test#redirect_test'
   delete 'redirect_test' => 'inertia_test#redirect_test'
-  get 'location' => 'inertia_test#location'
+  get 'my_location' => 'inertia_test#my_location'
   get 'share_multithreaded' => 'inertia_multithreaded_share#share_multithreaded'
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -14,5 +14,6 @@ Rails.application.routes.draw do
   patch 'redirect_test' => 'inertia_test#redirect_test'
   put 'redirect_test' => 'inertia_test#redirect_test'
   delete 'redirect_test' => 'inertia_test#redirect_test'
+  get 'location' => 'inertia_test#location'
   get 'share_multithreaded' => 'inertia_multithreaded_share#share_multithreaded'
 end

--- a/spec/inertia/response_spec.rb
+++ b/spec/inertia/response_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe 'Inertia::Response', type: :request do
+  describe 'inertia location response' do
+    it 'returns an inertia location response' do
+      get location_path
+
+      expect(response.status).to eq 409
+      expect(response.headers['X-Inertia-Location']).to eq empty_test_path
+    end
+  end  
+end

--- a/spec/inertia/response_spec.rb
+++ b/spec/inertia/response_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'Inertia::Response', type: :request do
   describe 'inertia location response' do
     it 'returns an inertia location response' do
-      get location_path
+      get my_location_path
 
       expect(response.status).to eq 409
       expect(response.headers['X-Inertia-Location']).to eq empty_test_path


### PR DESCRIPTION
This adds an `inertia_location` method to keep feature parity with the Laravel version of Inertia.

## Usage

```ruby
def create
   inertia_location index_path
end
```

## Further Reading 

https://github.com/inertiajs/inertia-laravel/pull/154
https://github.com/inertiajs/inertia-laravel/issues/57