### PR TITLE
Built in error sharing in redirects

### DIFF
--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -25,12 +25,12 @@ module InertiaRails
       head :conflict
     end
 
-    def inertia_redirect_to(options = {}, response_options = {})
-      if (errors = response_options.delete(:errors))
-        session[:inertia_errors] = errors
+    def redirect_to(options = {}, response_options = {})
+      if (inertia_errors = response_options.fetch(:inertia, {}).fetch(:errors, nil))
+        session[:inertia_errors] = inertia_errors
       end
 
-      redirect_to(options, response_options)
+      super(options, response_options)
     end
   end
 end

--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -4,6 +4,13 @@ module InertiaRails
   module Controller
     extend ActiveSupport::Concern
 
+    included do
+      before_action do
+        # :inertia_errors are deleted from the session by the middleware
+        InertiaRails.share(errors: session[:inertia_errors]) if session[:inertia_errors].present?
+      end
+    end
+
     module ClassMethods
       def inertia_share(**args, &block)
         before_action do
@@ -16,6 +23,14 @@ module InertiaRails
     def inertia_location(url)
       headers['X-Inertia-Location'] = url
       head :conflict
+    end
+
+    def inertia_redirect_to(options = {}, response_options = {})
+      if (errors = response_options.delete(:errors))
+        session[:inertia_errors] = errors
+      end
+
+      redirect_to(options, response_options)
     end
   end
 end

--- a/lib/inertia_rails/middleware.rb
+++ b/lib/inertia_rails/middleware.rb
@@ -3,41 +3,78 @@ module InertiaRails
     def initialize(app)
       @app = app
     end
-  
+
     def call(env)
+      @env = env
+
       status, headers, body = @app.call(env)
       request = ActionDispatch::Request.new(env)
 
       ::InertiaRails.reset!
-  
-      return [status, headers, body] unless env['HTTP_X_INERTIA'].present?
-  
-      return force_refresh(request) if stale?(env['REQUEST_METHOD'], env['HTTP_X_INERTIA_VERSION'])
-  
-      if is_redirect_status?(status) &&
-          is_non_get_redirectable_method?(env['REQUEST_METHOD'])
-        status = 303
-      end
-  
-      [status, headers, body]
+
+      # Inertia errors are added to the session via inertia_redirect_to 
+      request.session.delete(:inertia_errors) unless keep_inertia_errors?(status)
+
+      status = 303 if inertia_non_post_redirect?(status)
+
+      return stale_inertia_get? ? force_refresh(request) : [status, headers, body]
     end
-  
+
     private
-  
-    def is_redirect_status?(status)
+
+    def keep_inertia_errors?(status)
+      redirect_status?(status) || stale_inertia_request?
+    end
+
+    def stale_inertia_request?
+      inertia_request? && version_stale?
+    end
+
+    def redirect_status?(status)
       [301, 302].include? status
     end
-  
-    def is_non_get_redirectable_method?(request_method)
+
+    def non_get_redirectable_method?
       ['PUT', 'PATCH', 'DELETE'].include? request_method
     end
-  
-    def stale?(request_method, inertia_version)
-      sent_version = InertiaRails.version.is_a?(Numeric) ? inertia_version.to_f : inertia_version
-      saved_version = InertiaRails.version.is_a?(Numeric) ? InertiaRails.version.to_f : InertiaRails.version
-      request_method == 'GET' && sent_version != saved_version
+
+    def inertia_non_post_redirect?(status)
+      inertia_request? && redirect_status?(status) && non_get_redirectable_method?
     end
-  
+
+    def stale_inertia_get?
+      get? && stale_inertia_request?
+    end
+
+    def get?
+      request_method == 'GET'
+    end
+
+    def request_method
+      @env['REQUEST_METHOD']
+    end
+
+    def inertia_version
+      @env['HTTP_X_INERTIA_VERSION']
+    end
+
+    def inertia_request?
+      @env['HTTP_X_INERTIA'].present?
+    end
+
+    def version_stale?
+      sent_version != saved_version
+    end
+
+    def sent_version
+      return nil if inertia_version.nil?
+      InertiaRails.version.is_a?(Numeric) ? inertia_version.to_f : inertia_version
+    end
+
+    def saved_version
+      InertiaRails.version.is_a?(Numeric) ? InertiaRails.version.to_f : InertiaRails.version
+    end
+
     def force_refresh(request)
       request.flash.keep
       Rack::Response.new('', 409, {'X-Inertia-Location' => request.original_url}).finish

--- a/lib/inertia_rails/middleware.rb
+++ b/lib/inertia_rails/middleware.rb
@@ -12,7 +12,7 @@ module InertiaRails
 
       ::InertiaRails.reset!
 
-      # Inertia errors are added to the session via inertia_redirect_to 
+      # Inertia errors are added to the session via redirect_to 
       request.session.delete(:inertia_errors) unless keep_inertia_errors?(status)
 
       status = 303 if inertia_non_post_redirect?(status)

--- a/spec/dummy/app/controllers/inertia_errors_controller.rb
+++ b/spec/dummy/app/controllers/inertia_errors_controller.rb
@@ -1,5 +1,0 @@
-class InertiaErrorsController < ApplicationController
-  def redirect_with_errors
-    inertia_redirect_to empty_test_path, errors: { uh: 'oh' }
-  end
-end

--- a/spec/dummy/app/controllers/inertia_errors_controller.rb
+++ b/spec/dummy/app/controllers/inertia_errors_controller.rb
@@ -1,0 +1,5 @@
+class InertiaErrorsController < ApplicationController
+  def redirect_with_errors
+    inertia_redirect_to empty_test_path, errors: { uh: 'oh' }
+  end
+end

--- a/spec/dummy/app/controllers/inertia_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_test_controller.rb
@@ -27,7 +27,6 @@ class InertiaTestController < ApplicationController
   # Calling it my_location to avoid this in Rails 5.0
   # https://github.com/rails/rails/issues/28033
   def my_location
-    puts "Got to location for some reason?"
     inertia_location empty_test_path
   end
 

--- a/spec/dummy/app/controllers/inertia_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_test_controller.rb
@@ -30,11 +30,7 @@ class InertiaTestController < ApplicationController
     inertia_location empty_test_path
   end
 
-  def regular_inertia_redirect_to
-    inertia_redirect_to empty_test_path
-  end
-
-  def inertia_redirect_to_with_errors
-    inertia_redirect_to empty_test_path, errors: 'oh bother'
+  def redirect_with_inertia_errors
+    redirect_to empty_test_path, inertia: { errors: { uh: 'oh' } }
   end
 end

--- a/spec/dummy/app/controllers/inertia_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_test_controller.rb
@@ -30,4 +30,12 @@ class InertiaTestController < ApplicationController
     puts "Got to location for some reason?"
     inertia_location empty_test_path
   end
+
+  def regular_inertia_redirect_to
+    inertia_redirect_to empty_test_path
+  end
+
+  def inertia_redirect_to_with_errors
+    inertia_redirect_to empty_test_path, errors: 'oh bother'
+  end
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -16,8 +16,6 @@ Rails.application.routes.draw do
   delete 'redirect_test' => 'inertia_test#redirect_test'
   get 'my_location' => 'inertia_test#my_location'
   get 'share_multithreaded' => 'inertia_multithreaded_share#share_multithreaded'
-  post 'redirect_with_errors' => 'inertia_errors#redirect_with_errors'
-  post 'regular_inertia_redirect_to' => 'inertia_test#regular_inertia_redirect_to'
-  get 'inertia_redirect_to_with_errors' => 'inertia_test#inertia_redirect_to_with_errors'
-  post 'inertia_redirect_to_with_errors' => 'inertia_test#inertia_redirect_to_with_errors'
+  get 'redirect_with_inertia_errors' => 'inertia_test#redirect_with_inertia_errors'
+  post 'redirect_with_inertia_errors' => 'inertia_test#redirect_with_inertia_errors'
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -16,4 +16,8 @@ Rails.application.routes.draw do
   delete 'redirect_test' => 'inertia_test#redirect_test'
   get 'my_location' => 'inertia_test#my_location'
   get 'share_multithreaded' => 'inertia_multithreaded_share#share_multithreaded'
+  post 'redirect_with_errors' => 'inertia_errors#redirect_with_errors'
+  post 'regular_inertia_redirect_to' => 'inertia_test#regular_inertia_redirect_to'
+  get 'inertia_redirect_to_with_errors' => 'inertia_test#inertia_redirect_to_with_errors'
+  post 'inertia_redirect_to_with_errors' => 'inertia_test#inertia_redirect_to_with_errors'
 end

--- a/spec/inertia/error_sharing_spec.rb
+++ b/spec/inertia/error_sharing_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe 'errors shared automatically', type: :request do
+  context 'rendering errors across redirects' do
+    let(:server_version){ 1.0 }
+    let(:headers){ { 'X-Inertia' => true, 'X-Inertia-Version' => server_version } }
+
+    before { InertiaRails.configure{|c| c.version = server_version} }
+    after { InertiaRails.configure{|c| c.version = nil } }
+
+    it 'automatically renders errors in inertia' do
+      post redirect_with_errors_path, headers: headers
+      expect(response.headers['Location']).to eq(empty_test_url)
+      expect(session[:inertia_errors]).to include({ uh: 'oh' })
+
+      # Follow the redirect
+      get response.headers['Location'], headers: headers
+      expect(response.body).to include({ errors: { uh: 'oh' } }.to_json)
+      expect(session[:inertia_errors]).not_to be
+    end
+
+    it 'keeps errors around when the post has a stale version' do
+      post redirect_with_errors_path, headers: headers
+      expect(response.headers['Location']).to eq(empty_test_url)
+      expect(session[:inertia_errors]).to include({ uh: 'oh' })
+
+      # Simulate that the POST was using a stale version
+      get empty_test_path, headers: headers.merge({ 'X-Inertia-Version' => 'stale' })
+      expect(response.status).to eq(409)
+      # Inertia errors are _not_ deleted
+      expect(session[:inertia_errors]).to include({ uh: 'oh' }.as_json)
+
+      # Simulate the page refresh that Inertia triggers in response to a 409
+      get empty_test_path
+      expect(response.body).to include(CGI::escape_html({ errors: { uh: 'oh' } }.to_json))
+      expect(session[:inertia_errors]).not_to be
+    end
+  end
+end

--- a/spec/inertia/error_sharing_spec.rb
+++ b/spec/inertia/error_sharing_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'errors shared automatically', type: :request do
     after { InertiaRails.configure{|c| c.version = nil } }
 
     it 'automatically renders errors in inertia' do
-      post redirect_with_errors_path, headers: headers
+      post redirect_with_inertia_errors_path, headers: headers
       expect(response.headers['Location']).to eq(empty_test_url)
       expect(session[:inertia_errors]).to include({ uh: 'oh' })
 
@@ -18,7 +18,7 @@ RSpec.describe 'errors shared automatically', type: :request do
     end
 
     it 'keeps errors around when the post has a stale version' do
-      post redirect_with_errors_path, headers: headers
+      post redirect_with_inertia_errors_path, headers: headers
       expect(response.headers['Location']).to eq(empty_test_url)
       expect(session[:inertia_errors]).to include({ uh: 'oh' })
 

--- a/spec/inertia/response_spec.rb
+++ b/spec/inertia/response_spec.rb
@@ -8,33 +8,24 @@ RSpec.describe 'InertiaRails::Response', type: :request do
     end
   end
 
-  describe 'inertia_redirect_to' do
-    context 'without an :errors option' do
-      it 'behaves like a regular redirect_to' do
-        post regular_inertia_redirect_to_path
-        expect(response.status).to eq 302
-        expect(response.headers['Location']).to eq(empty_test_url)
-        expect(session[:inertia_errors]).not_to be
-      end
-    end
-
-    context 'with an :errors option' do
+  describe 'redirect_to' do
+    context 'with an [:inertia][:errors] option' do
       # In practice, a GET -> redirect + errors probably shouldn't happen
       context 'with a get request' do
         it 'adds :inertia_errors to the session'  do
-          get inertia_redirect_to_with_errors_path
+          get redirect_with_inertia_errors_path
           expect(response.status).to eq 302
           expect(response.headers['Location']).to eq(empty_test_url)
-          expect(session[:inertia_errors]).to include('oh bother')
+          expect(session[:inertia_errors]).to include({ uh: 'oh' })
         end
       end
 
       context 'with a post request' do
         it 'adds :inertia_errors to the session' do
-          post inertia_redirect_to_with_errors_path, headers: { 'X-Inertia' => true }
+          post redirect_with_inertia_errors_path, headers: { 'X-Inertia' => true }
           expect(response.status).to eq 302
           expect(response.headers['Location']).to eq(empty_test_url)
-          expect(session[:inertia_errors]).to include('oh bother')
+          expect(session[:inertia_errors]).to include({ uh: 'oh' })
         end
       end
     end

--- a/spec/inertia/response_spec.rb
+++ b/spec/inertia/response_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'Inertia::Response', type: :request do
+RSpec.describe 'InertiaRails::Response', type: :request do
   describe 'inertia location response' do
     it 'returns an inertia location response' do
       get my_location_path
@@ -6,5 +6,37 @@ RSpec.describe 'Inertia::Response', type: :request do
       expect(response.status).to eq 409
       expect(response.headers['X-Inertia-Location']).to eq empty_test_path
     end
-  end  
+  end
+
+  describe 'inertia_redirect_to' do
+    context 'without an :errors option' do
+      it 'behaves like a regular redirect_to' do
+        post regular_inertia_redirect_to_path
+        expect(response.status).to eq 302
+        expect(response.headers['Location']).to eq(empty_test_url)
+        expect(session[:inertia_errors]).not_to be
+      end
+    end
+
+    context 'with an :errors option' do
+      # In practice, a GET -> redirect + errors probably shouldn't happen
+      context 'with a get request' do
+        it 'adds :inertia_errors to the session'  do
+          get inertia_redirect_to_with_errors_path
+          expect(response.status).to eq 302
+          expect(response.headers['Location']).to eq(empty_test_url)
+          expect(session[:inertia_errors]).to include('oh bother')
+        end
+      end
+
+      context 'with a post request' do
+        it 'adds :inertia_errors to the session' do
+          post inertia_redirect_to_with_errors_path, headers: { 'X-Inertia' => true }
+          expect(response.status).to eq 302
+          expect(response.headers['Location']).to eq(empty_test_url)
+          expect(session[:inertia_errors]).to include('oh bother')
+        end
+      end
+    end
+  end
 end

--- a/spec/inertia/sharing_spec.rb
+++ b/spec/inertia/sharing_spec.rb
@@ -38,6 +38,19 @@ RSpec.describe 'using inertia share when rendering views', type: :request do
     it { is_expected.to eq props }
   end
 
+  context 'with errors' do
+    let(:props) { {name: 'Brandon', sport: 'hockey', position: 'center', number: 29} }
+    let(:errors) { 'rearview mirror is present' }
+    before {
+      allow_any_instance_of(ActionDispatch::Request).to receive(:session) {
+        { inertia_errors: errors }
+      }
+      get share_path, headers: {'X-Inertia' => true}
+    }
+
+    it { is_expected.to eq props.merge({ errors: errors }) }
+  end
+
   context 'multithreaded intertia share' do
     let(:props) { { name: 'Michael', has_goat_status: true } }
     it 'is expected to render props even when another thread shares Inertia data' do


### PR DESCRIPTION
Resolves #47 

The above issue and https://github.com/inertiajs/inertiajs.com/pull/31 both deal with validation error handling in Rails.

## Background

Initially, as noted in #47, my instinct was to try to handle error states without a redirect, as you would do within a vanilla Rails app. The discussion in https://github.com/inertiajs/inertiajs.com/pull/31 made it clear that real world apps are using the session to store errors across redirects.

I played around in my local environment with trying to implement the non-redirect pattern, which roughly looks like this in the controller:

```ruby
if contact.save
  redirect_to contacts_path, notice: 'Contact created.'
else
  render inertia: 'Users/new', {
    contact: contact,
    errors: contact.errors,
  }
end
```

I got _really close_ to making it work, but I couldn't find a satisfying UX for what happens if you submit a form with a stale version of inertia (to trigger assets reloading).

So, it makes sense to move forward with the solution in https://github.com/inertiajs/inertiajs.com/pull/31 as the "official" technique for the Rails library.

This PR copies in the work from @ledermann into the gem, with a few tweaks to make things work with `409` conflict situations.

## Notes

@ledermann suggested overwriting `redirect_to` to improve the API. I was hesitant to override the method globally, so instead I created an `inertia_redirect_to` method instead, which does the same thing that Georg wrote out.

Dealing with stale versions is tricky. I wanted to do exactly what Georg did, which was delete the errors from the session when they get shared into the Inertia store. Unfortunately, the Inertia sharing runs even when there is an assets conflict resulting in a `409`. That makes it impossible for the middleware to forward the errors from the session onto the subsequent responses in a `PATCH` -> `redirect` -> `GET` -> `409` -> re-`GET` pattern (this is the basic pattern that happens when a user submits a form with a stale Inertia version). I ended up moving the code that deletes the inertia errors into the middleware, instead of the controller. That way the middleware can keep the errors around during a stale version situation. I don't love that the single feature is split into two places, so any suggestions are welcome there!

The final API from the Rails side looks like this:

```ruby
# things_controller.rb
def new
  thing = Thing.new
  render inertia: 'NewThingComponent`, props: { thing: thing }
end

def create
  thing = Thing.new(thing_params)
  if thing.save
    # a regular redirect_to will work here also
    inertia_redirect_to thing_path(thing)
  else
    inertia_redirect_to new_thing_path, errors: thing.errors
  end
end
```

If a user tries to create a new `thing` with bad data, the `NewThingComponent` will get rendered and receive an `errors` prop. Thanks to Inertia (pointed out by both @ledermann and @BilalBudhani), the malformed data will still be around in the form.

If the user does the same thing, but with a stale version, the `things/new` page will hard refresh (due to the assets conflict). The submitted data is lost, but the errors will remain. The user would see a blank form that at least has helpful information like `Thing's name cannot be blank!` (assuming the `NewThingComponent` prints out the errors it receives). It would be really cool if the actual model data could persist across the hard refresh, but I think that might be out of the scope of the library. In any case, since this is probably an infrequent event for most applications, my opinion is that this UX is acceptable.

Thanks to @reinink and @ledermann for leading the way on this (and for being patient!)

I would love feedback here, as the middleware and error handling is a bit of a juggling act. There are specs testing it, and I actually spun up a small dummy app to verify the behavior, but I would not be surprised if there's a use case or unintended consequence that I missed.