### PR TITLE
Lazy props

### DIFF
--- a/lib/inertia_rails/inertia_rails.rb
+++ b/lib/inertia_rails/inertia_rails.rb
@@ -1,5 +1,6 @@
 # Needed for `thread_mattr_accessor`
 require 'active_support/core_ext/module/attribute_accessors_per_thread'
+require 'inertia_rails/lazy'
 
 module InertiaRails
   thread_mattr_accessor :threadsafe_shared_plain_data
@@ -34,6 +35,10 @@ module InertiaRails
   def self.reset!
     self.shared_plain_data = {}
     self.shared_blocks = []
+  end
+
+  def self.lazy(value = nil, &block)
+    InertiaRails::Lazy.new(value, &block)
   end
 
   private

--- a/lib/inertia_rails/lazy.rb
+++ b/lib/inertia_rails/lazy.rb
@@ -1,0 +1,23 @@
+class InertiaRails::Lazy
+  def initialize(value = nil, &block)
+    @value = value
+    @block = block
+  end
+
+  def call
+    to_proc.call
+  end
+
+  def to_proc
+    # copy to local variables so they are in scope for controller.instance_exec
+    value = @value
+    block = @block
+    if value.respond_to?(:call)
+      value
+    elsif value
+      Proc.new { value }
+    else
+      block
+    end
+  end
+end

--- a/lib/inertia_rails/lazy.rb
+++ b/lib/inertia_rails/lazy.rb
@@ -9,7 +9,10 @@ class InertiaRails::Lazy
   end
 
   def to_proc
-    # copy to local variables so they are in scope for controller.instance_exec
+    # This is called by controller.instance_exec, which changes self to the
+    # controller instance. That makes the instance variables unavailable to the
+    # proc via closure. Copying the instance variables to local variables before
+    # the proc is returned keeps them in scope for the returned proc.
     value = @value
     block = @block
     if value.respond_to?(:call)

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -27,11 +27,11 @@ module InertiaRails
     private
 
     def props
-      _props = ::InertiaRails.shared_data(@controller).merge(@props).select do |key|
+      _props = ::InertiaRails.shared_data(@controller).merge(@props).select do |key, prop|
         if rendering_partial_component?
           key.in? partial_keys
         else
-          true
+          !prop.is_a?(InertiaRails::Lazy)
         end
       end
 

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -27,13 +27,13 @@ module InertiaRails
     private
 
     def props
-      only = (@request.headers['X-Inertia-Partial-Data'] || '').split(',').compact.map(&:to_sym)
-
-      _props = ::InertiaRails.shared_data(@controller).merge(@props)
-
-      _props = (only.any? && @request.headers['X-Inertia-Partial-Component'] == component) ?
-        _props.select {|key| key.in? only} :
-        _props
+      _props = ::InertiaRails.shared_data(@controller).merge(@props).select do |key|
+        if rendering_partial_component?
+          key.in? partial_keys
+        else
+          true
+        end
+      end
 
       deep_transform_values(_props, lambda {|prop| prop.respond_to?(:call) ? @controller.instance_exec(&prop) : prop })
     end
@@ -51,6 +51,14 @@ module InertiaRails
       return proc.call(hash) unless hash.is_a? Hash
 
       hash.transform_values {|value| deep_transform_values(value, proc)}
+    end
+
+    def partial_keys
+      (@request.headers['X-Inertia-Partial-Data'] || '').split(',').compact.map(&:to_sym)
+    end
+
+    def rendering_partial_component?
+      @request.inertia_partial? && @request.headers['X-Inertia-Partial-Component'] == component
     end
   end
 end

--- a/spec/dummy/app/controllers/inertia_render_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_render_test_controller.rb
@@ -17,4 +17,15 @@ class InertiaRenderTestController < ApplicationController
   def component
     render inertia: 'TestComponent'
   end
+
+  def lazy_props
+    render inertia: 'TestComponent', props: {
+      name: 'Brian',
+      sport: InertiaRails.lazy('basketball'),
+      level: InertiaRails.lazy do
+        'worse than he believes'
+      end,
+      grit: InertiaRails.lazy(->{ 'intense' })
+    }
+  end
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -21,4 +21,5 @@ Rails.application.routes.draw do
   get 'error_404' => 'inertia_test#error_404'
   get 'error_500' => 'inertia_test#error_500'
   get 'content_type_test' => 'inertia_test#content_type_test'
+  get 'lazy_props' => 'inertia_render_test#lazy_props'
 end

--- a/spec/inertia/lazy_spec.rb
+++ b/spec/inertia/lazy_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe InertiaRails::Lazy do
+  describe '#call' do
+    context 'with a value' do
+      it 'returns the value' do
+        expect(InertiaRails::Lazy.new('thing').call).to eq('thing')
+      end
+    end
+
+    context 'with a callable value' do
+      it 'returns the result of the callable value' do
+        expect(InertiaRails::Lazy.new(->{ 'thing' }).call).to eq('thing')
+      end
+    end
+
+    context 'with a block' do
+      it 'returns the result of the block' do
+        expect(InertiaRails::Lazy.new{'thing'}.call).to eq('thing')
+      end
+    end
+  end
+end

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -53,6 +53,35 @@ RSpec.describe 'rendering inertia views', type: :request do
       expect(response.status).to eq 200
     end
   end
+
+  context 'partial rendering' do
+    let (:page) {
+      InertiaRails::Renderer.new('TestComponent', '', request, response, '', props: { sport: 'hockey'}, view_data: nil).send(:page)
+    }
+    let(:headers) {{
+      'X-Inertia' => true,
+      'X-Inertia-Partial-Data' => 'sport',
+      'X-Inertia-Partial-Component' => 'TestComponent',
+    }}
+
+    context 'with the correct partial component header' do
+      before { get props_path, headers: headers }
+
+      it { is_expected.to eq page.to_json }
+    end
+
+    context 'with a non matching partial component header' do
+      before {
+        headers['X-Inertia-Partial-Component'] = 'NotTheTestComponent'
+        get props_path, headers: headers
+      }
+
+      it { is_expected.not_to eq page.to_json }
+      it 'includes all of the props' do
+        is_expected.to include('Brandon')
+      end
+    end
+  end
 end
 
 def inertia_div(page)

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -82,6 +82,32 @@ RSpec.describe 'rendering inertia views', type: :request do
       end
     end
   end
+
+  context 'lazy prop rendering' do
+    context 'on first load' do
+      let (:page) {
+        InertiaRails::Renderer.new('TestComponent', '', request, response, '', props: { name: 'Brian'}, view_data: nil).send(:page)
+      }
+      before { get lazy_props_path }
+
+      it { is_expected.to include inertia_div(page) }
+    end
+
+    context 'with a partial reload' do
+      let (:page) {
+        InertiaRails::Renderer.new('TestComponent', '', request, response, '', props: { sport: 'basketball', level: 'worse than he believes', grit: 'intense'}, view_data: nil).send(:page)
+      }
+      let(:headers) {{
+        'X-Inertia' => true,
+        'X-Inertia-Partial-Data' => 'sport,level,grit',
+        'X-Inertia-Partial-Component' => 'TestComponent',
+      }}
+
+      before { get lazy_props_path, headers: headers }
+
+      it { is_expected.to eq page.to_json }
+    end
+  end
 end
 
 def inertia_div(page)


### PR DESCRIPTION
Resolves #51 

The code follows the design of the Laravel adapter pretty closely. The basic idea is to filter out any "lazy" props from initial page loads.

There's a new `InertiaRails::Lazy` class that acts like a callable prop.

I also took the opportunity to refactor the code that decides which props get filtered out within the renderer. 