### PR TITLE
Create inertia route helper

### DIFF
--- a/app/controllers/inertia_rails/static_controller.rb
+++ b/app/controllers/inertia_rails/static_controller.rb
@@ -1,0 +1,7 @@
+module InertiaRails
+  class StaticController < ::ApplicationController
+    def static
+      render inertia: params[:component]
+    end
+  end
+end

--- a/lib/inertia_rails.rb
+++ b/lib/inertia_rails.rb
@@ -20,3 +20,12 @@ end
 module InertiaRails
   class Error < StandardError; end
 end
+
+class ActionDispatch::Routing::Mapper
+  def inertia(args, &block)
+    route = args.keys.first
+    component = args.values.first
+
+    get(route => 'inertia_rails/static#static', defaults: {component: component})
+  end
+end

--- a/lib/inertia_rails.rb
+++ b/lib/inertia_rails.rb
@@ -4,6 +4,7 @@ require 'inertia_rails/engine'
 require 'patches/debug_exceptions'
 require 'patches/better_errors'
 require 'patches/request'
+require 'patches/mapper'
 
 ActionController::Renderers.add :inertia do |component, options|
   InertiaRails::Renderer.new(
@@ -19,13 +20,4 @@ end
 
 module InertiaRails
   class Error < StandardError; end
-end
-
-class ActionDispatch::Routing::Mapper
-  def inertia(args, &block)
-    route = args.keys.first
-    component = args.values.first
-
-    get(route => 'inertia_rails/static#static', defaults: {component: component})
-  end
 end

--- a/lib/patches/mapper.rb
+++ b/lib/patches/mapper.rb
@@ -1,0 +1,8 @@
+ActionDispatch::Routing::Mapper.class_eval do
+  def inertia(args, &block)
+    route = args.keys.first
+    component = args.values.first
+
+    get(route => 'inertia_rails/static#static', defaults: {component: component})
+  end
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -22,4 +22,6 @@ Rails.application.routes.draw do
   get 'error_500' => 'inertia_test#error_500'
   get 'content_type_test' => 'inertia_test#content_type_test'
   get 'lazy_props' => 'inertia_render_test#lazy_props'
+
+  inertia 'inertia_route' => 'TestComponent'
 end

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -28,6 +28,12 @@ RSpec.describe 'rendering inertia views', type: :request do
       get component_path
       expect(response.status).to eq 200
     end
+
+    context 'via an inertia route' do
+      before { get inertia_route_path }
+
+      it { is_expected.to include inertia_div(page) }
+    end
   end
 
   context 'subsequent requests' do


### PR DESCRIPTION
This PR creates the `inertia` route helper verb so that our routes file can contain an entry like this:

```ruby
inertia 'about' => 'AboutComponent'
```

Which will route the `/about` URI directly to your `Pages/AboutComponent` without setting up the boilerplate of a controller and render. By design it does not support passing props, if you need that, continue to use the normal controller setup.

**Background:**
@euggra and I were working on an inertia rails app that had some static content-only pages like an About page. We wanted to write these pages in react like the rest of the app, but had to write too much boilerplate for my liking just to render a prop-less component. Turns out that inertia-laravel already had a solution for this, so it was time for us to join them in the future!
