### PR TITLE
Add redirect_back w/ inertia errors support

### DIFF
--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -20,17 +20,31 @@ module InertiaRails
       end
     end
 
+    private
+
     def inertia_location(url)
       headers['X-Inertia-Location'] = url
       head :conflict
     end
 
     def redirect_to(options = {}, response_options = {})
-      if (inertia_errors = response_options.fetch(:inertia, {}).fetch(:errors, nil))
+      capture_inertia_errors(response_options)
+      super(options, response_options)
+    end
+
+    def redirect_back(fallback_location:, allow_other_host: true, **options)
+      capture_inertia_errors(options)
+      super(
+        fallback_location: fallback_location,
+        allow_other_host: allow_other_host,
+        **options,
+      )
+    end
+
+    def capture_inertia_errors(options)
+      if (inertia_errors = options.dig(:inertia, :errors))
         session[:inertia_errors] = inertia_errors
       end
-
-      super(options, response_options)
     end
   end
 end

--- a/spec/dummy/app/controllers/inertia_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_test_controller.rb
@@ -33,6 +33,13 @@ class InertiaTestController < ApplicationController
     redirect_to empty_test_path, inertia: { errors: { uh: 'oh' } }
   end
 
+  def redirect_back_with_inertia_errors
+    redirect_back(
+      fallback_location: empty_test_path,
+      inertia: { errors: { go: 'back!' } }
+    )
+  end
+
   def error_404
     render inertia: 'ErrorComponent', status: 404
   end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   get 'share_multithreaded' => 'inertia_multithreaded_share#share_multithreaded'
   get 'redirect_with_inertia_errors' => 'inertia_test#redirect_with_inertia_errors'
   post 'redirect_with_inertia_errors' => 'inertia_test#redirect_with_inertia_errors'
+  post 'redirect_back_with_inertia_errors' => 'inertia_test#redirect_back_with_inertia_errors'
   get 'error_404' => 'inertia_test#error_404'
   get 'error_500' => 'inertia_test#error_500'
   get 'content_type_test' => 'inertia_test#content_type_test'

--- a/spec/inertia/response_spec.rb
+++ b/spec/inertia/response_spec.rb
@@ -30,4 +30,23 @@ RSpec.describe 'InertiaRails::Response', type: :request do
       end
     end
   end
+
+  describe 'redirect_back' do
+    context 'with an [:inertia][:errors] option' do
+      context 'with a post request' do
+        it 'adds :inertia_errors to the session' do
+          post(
+            redirect_back_with_inertia_errors_path,
+            headers: {
+              'X-Inertia' => true,
+              'HTTP_REFERER' => "http://example.com/current-path"
+            }
+          )
+          expect(response.status).to eq 302
+          expect(response.headers['Location']).to eq('http://example.com/current-path')
+          expect(session[:inertia_errors]).to include({ go: 'back!' })
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This builds on the work in 40f36a5580a3362ed2e9dbd23373b61e82dfc98d which added an inertia-aware wrapper around `redirect_to`.

This change implements the same inertia errors handling for
`redirect_back`, which I've found to be particularly useful when working
with Inertia, especially with error handling.

---

Note: I, unfortunately, wasn't able to get the specs running locally (see notes in https://github.com/inertiajs/inertia-rails/issues/55).

Also, I noticed that this behavior is currently [undocumented on the inertia site](https://inertiajs.com/forms#server-side-validation), and
I only discovered this feature by reading through recent PRs. I'd be happy to add to
the documentation, assuming that's something that would of interest.