### PR TITLE
Fix compatibility with "responders" gem (and thus "devise")

### DIFF
--- a/inertia_rails.gemspec
+++ b/inertia_rails.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rails-controller-testing"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "appraisal"
+  spec.add_development_dependency "responders"
 end

--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -20,13 +20,6 @@ module InertiaRails
       end
     end
 
-    private
-
-    def inertia_location(url)
-      headers['X-Inertia-Location'] = url
-      head :conflict
-    end
-
     def redirect_to(options = {}, response_options = {})
       capture_inertia_errors(response_options)
       super(options, response_options)
@@ -39,6 +32,13 @@ module InertiaRails
         allow_other_host: allow_other_host,
         **options,
       )
+    end
+
+    private
+
+    def inertia_location(url)
+      headers['X-Inertia-Location'] = url
+      head :conflict
     end
 
     def capture_inertia_errors(options)

--- a/spec/dummy/app/controllers/inertia_responders_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_responders_test_controller.rb
@@ -1,0 +1,13 @@
+require 'responders'
+
+class Thing
+end
+
+class InertiaRespondersTestController < ApplicationController
+  self.responder = ActionController::Responder
+  respond_to :html
+
+  def redirect_test
+    respond_with Thing.new, location: '/foo'
+  end
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   get 'redirect_test' => 'inertia_test#redirect_test'
   get 'inertia_request_test' => 'inertia_test#inertia_request_test'
   get 'inertia_partial_request_test' => 'inertia_test#inertia_partial_request_test'
+  post 'redirect_with_responders' => 'inertia_responders_test#redirect_test'
   post 'redirect_test' => 'inertia_test#redirect_test'
   patch 'redirect_test' => 'inertia_test#redirect_test'
   put 'redirect_test' => 'inertia_test#redirect_test'

--- a/spec/inertia/request_spec.rb
+++ b/spec/inertia/request_spec.rb
@@ -89,4 +89,11 @@ RSpec.describe 'Inertia::Request', type: :request do
       it { is_expected.to eq 'application/xml' }
     end
   end
+
+  describe 'it tests redirecting with responders gem' do
+    subject { response.status }
+    before { post redirect_with_responders_path }
+
+    it { is_expected.to eq 302 }
+  end
 end


### PR DESCRIPTION
In v1.9.0, the methods `redirect_to`(and `redirect_back`) were changed to be `private` by #56. IMHO this is not correct, because these methods are `public` by default:

```ruby
irb(main):001:0> ApplicationController.new.public_methods.include?(:redirect_to)
=> true
irb(main):002:0> ApplicationController.new.public_methods.include?(:redirect_back)
=> true
```

The changed visibility causes issues when using the gem [devise](https://github.com/heartcombo/devise), which uses the gem [responders](https://github.com/heartcombo/responders/) internally - see [this error](https://github.com/ledermann/pingcrm/pull/487/checks?check_run_id=1738638934) in my PingCRM demo application:

```ruby
LoginTest#test_Login_with_valid_credentials_will_be_successful:
NoMethodError: private method `redirect_to' called for #<Users::SessionsController:0x00000000009dd0>
    app/controllers/users/sessions_controller.rb:9:in `create'
```

This PR restores the original method visibility and adds testing against the `responders` gem.