### PR TITLE
Better setup specs warning

### DIFF
--- a/lib/inertia_rails/rspec.rb
+++ b/lib/inertia_rails/rspec.rb
@@ -49,7 +49,7 @@ module InertiaRails
       protected 
       
       def inertia_tests_setup?
-        @_inertia_render_wrapper.present?
+        ::RSpec.current_example.metadata.fetch(:inertia, false)
       end
     end
   end

--- a/lib/inertia_rails/rspec.rb
+++ b/lib/inertia_rails/rspec.rb
@@ -35,6 +35,9 @@ module InertiaRails
       def inertia
         raise 'Inertia test helpers aren\'t set up! Make sure you add inertia: true to describe blocks using inertia tests.' unless inertia_tests_setup?
 
+        if @_inertia_render_wrapper.nil? && !::RSpec.configuration.inertia[:skip_missing_renderer_warnings]
+          warn 'WARNING: the test never created an Inertia renderer. Maybe the code wasn\'t able to reach a `render inertia:` call? If this was intended, or you don\'t want to see this message, set ::RSpec.configuration.inertia[:skip_missing_renderer_warnings] = true'
+        end
         @_inertia_render_wrapper
       end
 
@@ -57,6 +60,9 @@ end
 
 RSpec.configure do |config|
   config.include ::InertiaRails::RSpec::Helpers
+  config.add_setting :inertia, default: {
+    skip_missing_renderer_warnings: false
+  }
 
   config.before(:each, inertia: true) do
     new_renderer = InertiaRails::Renderer.method(:new)

--- a/spec/dummy/app/controllers/inertia_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_test_controller.rb
@@ -23,6 +23,10 @@ class InertiaTestController < ApplicationController
     end
   end
 
+  def non_inertiafied
+    render plain: 'hey'
+  end
+
   # Calling it my_location to avoid this in Rails 5.0
   # https://github.com/rails/rails/issues/28033
   def my_location

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
   get 'error_500' => 'inertia_test#error_500'
   get 'content_type_test' => 'inertia_test#content_type_test'
   get 'lazy_props' => 'inertia_render_test#lazy_props'
+  get 'non_inertiafied' => 'inertia_test#non_inertiafied'
 
   inertia 'inertia_route' => 'TestComponent'
 end

--- a/spec/inertia/rspec_helper_spec.rb
+++ b/spec/inertia/rspec_helper_spec.rb
@@ -1,5 +1,17 @@
 require_relative '../../lib/inertia_rails/rspec'
 
+class FakeStdErr
+  attr_accessor :messages
+
+  def initialize
+    @messages = []
+  end
+
+  def write(msg)
+    @messages << msg
+  end
+end
+
 RSpec.describe InertiaRails::RSpec, type: :request do
   describe 'correctly set up inertia tests with inertia: true', inertia: true do
     context 'with props' do
@@ -60,6 +72,42 @@ RSpec.describe InertiaRails::RSpec, type: :request do
 
     it 'does not complain about test helpers' do
       expect { expect_inertia }.not_to raise_error
+    end
+
+    # h/t for this technique:
+    # https://blog.arkency.com/testing-deprecations-warnings-with-rspec/
+    it 'warns that the renderer was never created' do
+      begin
+        original_stderr = $stderr
+        fake_std_err    = FakeStdErr.new
+        $stderr         = fake_std_err
+        expect_inertia
+        warn_message = 'WARNING: the test never created an Inertia renderer. Maybe the code wasn\'t able to reach a `render inertia:` call? If this was intended, or you don\'t want to see this message, set ::RSpec.configuration.inertia[:skip_missing_renderer_warnings] = true'
+        expect(fake_std_err.messages[0].chomp).to(eq(warn_message))
+      ensure
+        $std_err = original_stderr
+      end
+    end
+
+    context 'with the :skip_missing_renderer_warnings setting set to true' do
+      before {
+        @original = ::RSpec.configuration.inertia[:skip_missing_renderer_warnings]
+        ::RSpec.configuration.inertia[:skip_missing_renderer_warnings] = true
+      }
+      after {
+        ::RSpec.configuration.inertia[:skip_missing_renderer_warnings] = @original
+      }
+      it 'skips the warning' do
+        begin
+          original_stderr = $stderr
+          fake_std_err    = FakeStdErr.new
+          $stderr         = fake_std_err
+          expect_inertia
+          expect(fake_std_err.messages).to be_empty
+        ensure
+          $std_err = original_stderr
+        end
+      end
     end
   end
 end

--- a/spec/inertia/rspec_helper_spec.rb
+++ b/spec/inertia/rspec_helper_spec.rb
@@ -10,6 +10,10 @@ class FakeStdErr
   def write(msg)
     @messages << msg
   end
+
+  # Rails 5.0 + Ruby 2.6 require puts to be a public method
+  def puts(thing)
+  end
 end
 
 RSpec.describe InertiaRails::RSpec, type: :request do

--- a/spec/inertia/rspec_helper_spec.rb
+++ b/spec/inertia/rspec_helper_spec.rb
@@ -54,4 +54,12 @@ RSpec.describe InertiaRails::RSpec, type: :request do
       expect { expect_inertia }.to raise_error(/inertia: true/)
     end
   end
+
+  describe 'expecting inertia on a non inertia route', inertia: true do
+    before { get non_inertiafied_path }
+
+    it 'does not complain about test helpers' do
+      expect { expect_inertia }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
Resolves #61 

As noted by @christoomey , the error message for ensuring users set `inertia: true` in RSpec specs can be misleading.

This PR changes the code to check the actual example metadata before warning about the test setup.

Additionally, it adds a warning when you create a spec that expects inertia but never creates an inertia renderer. This isn't directly part of #61, but is something that has tripped me up in the past.