### PR TITLE
Set up generator

### DIFF
--- a/lib/generators/inertia_rails/install/controller.rb
+++ b/lib/generators/inertia_rails/install/controller.rb
@@ -1,0 +1,7 @@
+class InertiaExampleController < ApplicationController
+  def index
+    render inertia: 'InertiaExample', props: {
+      name: 'World',
+    }
+  end
+end

--- a/lib/generators/inertia_rails/install/inertia.jsx
+++ b/lib/generators/inertia_rails/install/inertia.jsx
@@ -8,6 +8,9 @@ document.addEventListener('DOMContentLoaded', () => {
   InertiaProgress.init();
   const el = document.getElementById('app')
 
+  const csrfToken = document.querySelector('meta[name=csrf-token]').content;
+  axios.defaults.headers.common['X-CSRF-Token'] = csrfToken;
+
   render(
     <App
       initialPage={JSON.parse(el.dataset.page)}
@@ -15,7 +18,4 @@ document.addEventListener('DOMContentLoaded', () => {
     />,
     el
   )
-
-  const csrfToken = document.querySelector('meta[name=csrf-token]').content;
-  axios.defaults.headers.common['X-CSRF-Token'] = csrfToken;
 });

--- a/lib/generators/inertia_rails/install/inertia.jsx
+++ b/lib/generators/inertia_rails/install/inertia.jsx
@@ -1,0 +1,21 @@
+import { App } from '@inertiajs/inertia-react';
+import React from 'react';
+import { render } from 'react-dom';
+import axios from 'axios';
+import { InertiaProgress } from '@inertiajs/progress';
+
+document.addEventListener('DOMContentLoaded', () => {
+  InertiaProgress.init();
+  const el = document.getElementById('app')
+
+  render(
+    <App
+      initialPage={JSON.parse(el.dataset.page)}
+      resolveComponent={name => require(`../Pages/${name}`).default}
+    />,
+    el
+  )
+
+  const csrfToken = document.querySelector('meta[name=csrf-token]').content;
+  axios.defaults.headers.common['X-CSRF-Token'] = csrfToken;
+});

--- a/lib/generators/inertia_rails/install/react.jsx
+++ b/lib/generators/inertia_rails/install/react.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const InertiaExample = ({name}) => (
+  <>
+    <h1>Hello {name}!</h1>
+  </>
+);
+
+export default InertiaExample;

--- a/lib/generators/inertia_rails/install_generator.rb
+++ b/lib/generators/inertia_rails/install_generator.rb
@@ -1,27 +1,53 @@
 module InertiaRails
   class InstallGenerator < Rails::Generators::Base
     source_root File.expand_path('./install', __dir__)
+    class_option :front_end, type: :string, default: 'react'
+
+    FRONT_END_INSTALLERS = [
+      'react',
+    ]
 
     def install
-      say "Copying inertia.jsx into webpacker's packs folder..."
+      unless options[:front_end].in? FRONT_END_INSTALLERS
+        say "Sorry, there is no generator for #{options[:front_end]}!\n\n", :red
+        say "If you are a #{options[:front_end]} developer, please help us improve inertia_rails by contributing an installer.\n\n"
+        say "https://github.com/inertiajs/inertia-rails/\n\n"
 
-      template "inertia.jsx", Rails.root.join("app/javascript/packs/inertia.jsx").to_s
-      say "done!", :green
+        return
+      end
 
-      say "Adding inertia pack tag to application layout"
+      install_base!
+
+      send "install_#{options[:front_end]}!"
+
+      say "You're all set! Run rails s and checkout localhost:3000/inertia-example", :green
+    end
+
+    protected
+
+    def install_base!
+      say "Adding inertia pack tag to application layout", :blue
       insert_into_file Rails.root.join("app/views/layouts/application.html.erb").to_s, after: "<%= javascript_pack_tag 'application' %>\n" do
         "\t\t<%= javascript_pack_tag 'inertia' %>\n"
       end
 
-      say "Installing inertia client packages"
-      run "yarn add @inertiajs/inertia @inertiajs/inertia-react @inertiajs/progress"
+      say "Installing inertia client packages", :blue
+      run "yarn add @inertiajs/inertia @inertiajs/progress"
 
-      say "Copying example files"
+      say "Copying example files", :blue
       template "controller.rb", Rails.root.join("app/controllers/inertia_example_controller.rb").to_s
-      template "react.jsx", Rails.root.join("app/javascript/Pages/InertiaExample.js").to_s
-      route "get 'inertia-example', to: 'inertia_example#index'"
 
-      say "You're all set! Run rails s and checkout localhost:3000/inertia-example"
+      say "Adding a route for the example inertia controller...", :blue
+      route "get 'inertia-example', to: 'inertia_example#index'"
+    end
+
+    def install_react!
+      say "Creating a React page component...", :blue
+      run 'yarn add @inertiajs/inertia-react'
+      template "react.jsx", Rails.root.join("app/javascript/Pages/InertiaExample.js").to_s
+      say "Copying inertia.jsx into webpacker's packs folder...", :blue
+      template "inertia.jsx", Rails.root.join("app/javascript/packs/inertia.jsx").to_s
+      say "done!", :green
     end
   end
 end

--- a/lib/generators/inertia_rails/install_generator.rb
+++ b/lib/generators/inertia_rails/install_generator.rb
@@ -1,0 +1,27 @@
+module InertiaRails
+  class InstallGenerator < Rails::Generators::Base
+    source_root File.expand_path('./install', __dir__)
+
+    def install
+      say "Copying inertia.jsx into webpacker's packs folder..."
+
+      template "inertia.jsx", Rails.root.join("app/javascript/packs/inertia.jsx").to_s
+      say "done!", :green
+
+      say "Adding inertia pack tag to application layout"
+      insert_into_file Rails.root.join("app/views/layouts/application.html.erb").to_s, after: "<%= javascript_pack_tag 'application' %>\n" do
+        "\t\t<%= javascript_pack_tag 'inertia' %>\n"
+      end
+
+      say "Installing inertia client packages"
+      run "yarn add @inertiajs/inertia @inertiajs/inertia-react @inertiajs/progress"
+
+      say "Copying example files"
+      template "controller.rb", Rails.root.join("app/controllers/inertia_example_controller.rb").to_s
+      template "react.jsx", Rails.root.join("app/javascript/Pages/InertiaExample.js").to_s
+      route "get 'inertia-example', to: 'inertia_example#index'"
+
+      say "You're all set! Run rails s and checkout localhost:3000/inertia-example"
+    end
+  end
+end

--- a/lib/generators/inertia_rails/install_generator.rb
+++ b/lib/generators/inertia_rails/install_generator.rb
@@ -8,13 +8,7 @@ module InertiaRails
     ]
 
     def install
-      unless options[:front_end].in? FRONT_END_INSTALLERS
-        say "Sorry, there is no generator for #{options[:front_end]}!\n\n", :red
-        say "If you are a #{options[:front_end]} developer, please help us improve inertia_rails by contributing an installer.\n\n"
-        say "https://github.com/inertiajs/inertia-rails/\n\n"
-
-        return
-      end
+      exit! unless installable?
 
       install_base!
 
@@ -24,6 +18,21 @@ module InertiaRails
     end
 
     protected
+
+    def installable?
+      unless run("./bin/rails webpacker:verify_install")
+        say "Sorry, you need to have webpacker installed for inertia_rails default setup.", :red
+        return false
+      end
+
+      unless options[:front_end].in? FRONT_END_INSTALLERS
+        say "Sorry, there is no generator for #{options[:front_end]}!\n\n", :red
+        say "If you are a #{options[:front_end]} developer, please help us improve inertia_rails by contributing an installer.\n\n"
+        say "https://github.com/inertiajs/inertia-rails/\n\n"
+
+        return false
+      end
+    end
 
     def install_base!
       say "Adding inertia pack tag to application layout", :blue

--- a/lib/tasks/inertia_rails.rake
+++ b/lib/tasks/inertia_rails.rake
@@ -1,6 +1,14 @@
 namespace :inertia_rails do
-  desc "Installs inertia_rails packages and configurations for a React based app"
-  task :install => :environment do
-    system 'rails g inertia_rails:install'
+  namespace :install do
+    desc "Installs inertia_rails packages and configurations for a React based app"
+    task :react => :environment do
+      system 'rails g inertia_rails:install --front_end react'
+    end
+    task vue: :environment do
+      system 'rails g inertia_rails:install --front_end vue'
+    end
+    task svelte: :environment do
+      system 'rails g inertia_rails:install --front_end svelte'
+    end
   end
 end

--- a/lib/tasks/inertia_rails.rake
+++ b/lib/tasks/inertia_rails.rake
@@ -4,9 +4,11 @@ namespace :inertia_rails do
     task :react => :environment do
       system 'rails g inertia_rails:install --front_end react'
     end
+    desc "Installs inertia_rails packages and configurations for a Vue based app"
     task vue: :environment do
       system 'rails g inertia_rails:install --front_end vue'
     end
+    desc "Installs inertia_rails packages and configurations for a Svelte based app"
     task svelte: :environment do
       system 'rails g inertia_rails:install --front_end svelte'
     end

--- a/lib/tasks/inertia_rails.rake
+++ b/lib/tasks/inertia_rails.rake
@@ -1,0 +1,6 @@
+namespace :inertia_rails do
+  desc "Installs inertia_rails packages and configurations for a React based app"
+  task :install => :environment do
+    system 'rails g inertia_rails:install'
+  end
+end


### PR DESCRIPTION
Adds a generator for installing a few necessary files for a React based inertia_rails project:

* An `inertia.jsx` pack file with CSRF set up that renders an Inertia app, and adds it into `application.html.erb`
* A controller, route, and React component for a "hello world!" inertia-fied page
* Adds the appropriate inertiajs packages via Yarn
* Stubbed, non-functional rake tasks for Vue and Svelte installs (we use React internally so we haven't built out these installers yet)

The task is run via:

```
./bin/rails inertia_rails:install:react
./bin/rails inertia_rails:install:vue # doesn't do anything yet
./bin/rails inertia_rails:install:svelte # doesn't do anything yet
```
