### PR TITLE
Make middleware thread safe

### DIFF
--- a/lib/inertia_rails/middleware.rb
+++ b/lib/inertia_rails/middleware.rb
@@ -5,78 +5,91 @@ module InertiaRails
     end
 
     def call(env)
-      status, headers, body = @app.call(env)
-      request = ActionDispatch::Request.new(env)
-
-      ::InertiaRails.reset!
-
-      # Inertia errors are added to the session via redirect_to
-      request.session.delete(:inertia_errors) unless keep_inertia_errors?(status, env)
-
-      status = 303 if inertia_non_post_redirect?(status, env)
-
-      return stale_inertia_get?(env) ? force_refresh(request) : [status, headers, body]
+      InertiaRailsRequest.new(@app, env)
+                         .response
     end
 
-    private
+    class InertiaRailsRequest
+      def initialize(app, env)
+        @app = app
+        @env = env
+      end
 
-    def keep_inertia_errors?(status, env)
-      redirect_status?(status) || stale_inertia_request?(env)
-    end
+      def response
+        status, headers, body = @app.call(@env)
+        request = ActionDispatch::Request.new(@env)
 
-    def stale_inertia_request?(env)
-      inertia_request?(env) && version_stale?(env)
-    end
+        ::InertiaRails.reset!
 
-    def redirect_status?(status)
-      [301, 302].include? status
-    end
+        # Inertia errors are added to the session via redirect_to 
+        request.session.delete(:inertia_errors) unless keep_inertia_errors?(status)
 
-    def non_get_redirectable_method?(env)
-      ["PUT", "PATCH", "DELETE"].include? request_method(env)
-    end
+        status = 303 if inertia_non_post_redirect?(status)
 
-    def inertia_non_post_redirect?(status, env)
-      inertia_request?(env) && redirect_status?(status) && non_get_redirectable_method?(env)
-    end
+        stale_inertia_get? ? force_refresh(request) : [status, headers, body]
+      end
 
-    def stale_inertia_get?(env)
-      get?(env) && stale_inertia_request?(env)
-    end
+      private
 
-    def get?(env)
-      request_method(env) == "GET"
-    end
+      def keep_inertia_errors?(status)
+        redirect_status?(status) || stale_inertia_request?
+      end
 
-    def request_method(env)
-      env["REQUEST_METHOD"]
-    end
+      def stale_inertia_request?
+        inertia_request? && version_stale?
+      end
 
-    def inertia_version(env)
-      env["HTTP_X_INERTIA_VERSION"]
-    end
+      def redirect_status?(status)
+        [301, 302].include? status
+      end
 
-    def inertia_request?(env)
-      env["HTTP_X_INERTIA"].present?
-    end
+      def non_get_redirectable_method?
+        ['PUT', 'PATCH', 'DELETE'].include? request_method
+      end
 
-    def version_stale?(env)
-      sent_version(env) != saved_version
-    end
+      def inertia_non_post_redirect?(status)
+        inertia_request? && redirect_status?(status) && non_get_redirectable_method?
+      end
 
-    def sent_version(env)
-      return nil if inertia_version(env).nil?
+      def stale_inertia_get?
+        get? && stale_inertia_request?
+      end
 
-      InertiaRails.version.is_a?(Numeric) ? inertia_version(env).to_f : inertia_version(env)
-    end
+      def get?
+        request_method == 'GET'
+      end
 
-    def saved_version
-      InertiaRails.version.is_a?(Numeric) ? InertiaRails.version.to_f : InertiaRails.version
-    end
+      def request_method
+        @env['REQUEST_METHOD']
+      end
 
-    def force_refresh(request)
-      request.flash.keep
-      Rack::Response.new("", 409, { "X-Inertia-Location" => request.original_url }).finish
+      def inertia_version
+        @env['HTTP_X_INERTIA_VERSION']
+      end
+
+      def inertia_request?
+        @env['HTTP_X_INERTIA'].present?
+      end
+
+      def version_stale?
+        sent_version != saved_version
+      end
+
+      def sent_version
+        return nil if inertia_version.nil?
+
+        InertiaRails.version.is_a?(Numeric) ? inertia_version.to_f : inertia_version
+      end
+
+      def saved_version
+        InertiaRails.version.is_a?(Numeric) ? InertiaRails.version.to_f : InertiaRails.version
+      end
+
+      def force_refresh(request)
+        request.flash.keep
+        Rack::Response.new('', 409, {'X-Inertia-Location' => request.original_url}).finish
+      end
     end
   end
 end
+

--- a/spec/inertia/middleware_spec.rb
+++ b/spec/inertia/middleware_spec.rb
@@ -28,6 +28,24 @@ RSpec.describe InertiaRails::Middleware, type: :request do
 
       it { is_expected.to eq 303 }
     end
+
+    it 'is thread safe' do
+      delete_request_proc = -> { delete redirect_test_path, headers: { 'X-Inertia' => true } }
+      get_request_proc = -> { get empty_test_path }
+
+      statusses = []
+
+      threads = []
+
+      100.times do
+        threads << Thread.new { statusses << delete_request_proc.call }
+        threads << Thread.new { get_request_proc.call }
+      end
+
+      threads.each(&:join)
+
+      expect(statusses.uniq).to eq([303])
+    end
   end
 
   context 'a request not originating from inertia' do


### PR DESCRIPTION
Issue #58 happens when a delete request (or similar) and a get request are processed in different threads concurrently.

In the middleware @env isn't thread safe as it is an instance variable of the application (not scoped within the thread). That implicates that a new get request following a delete request on another thread would override @env during the delete request cycle thus not returning 303 but the Rails default 302.

I have two commits in this pr. The first one solves the problem by simply handing the env variable to every method depending on it. The second one uses a new class to be able to use the @env abstraction. In my opinion that approach is way cleaner and won't encourage other developers to reintroduce instance variables in the middleware itself.