### PR TITLE
make CSRF protection work out of the box (#71)

### DIFF
--- a/lib/inertia_rails.rb
+++ b/lib/inertia_rails.rb
@@ -1,6 +1,7 @@
 require 'inertia_rails/renderer'
 require 'inertia_rails/engine'
 
+require 'patches/action_controller'
 require 'patches/debug_exceptions'
 require 'patches/better_errors'
 require 'patches/request'

--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -9,6 +9,11 @@ module InertiaRails
         # :inertia_errors are deleted from the session by the middleware
         InertiaRails.share(errors: session[:inertia_errors]) if session[:inertia_errors].present?
       end
+
+      after_action do
+        # Axios by default looks for an XSRF-TOKEN cookie to use for POST requests
+        cookies['XSRF-TOKEN'] = form_authenticity_token unless request.inertia?
+      end
     end
 
     module ClassMethods

--- a/lib/patches/action_controller.rb
+++ b/lib/patches/action_controller.rb
@@ -1,0 +1,8 @@
+module ActionController
+  module RequestForgeryProtection
+    private
+    def request_authenticity_tokens
+      [form_authenticity_param, request.x_csrf_token, request.headers['X-XSRF-TOKEN']]
+    end
+  end
+end


### PR DESCRIPTION
This PR removes the need for the [manual steps](https://discord.com/channels/592327939920494592/759114256817455145/773925412626628618) to make CSRF protection work. It does this by storing the current form_authenticity_token in the `XSRF-TOKEN` cookie (which is picked up by Axios automatically) and adding the the `X-XSRF-TOKEN` header value (which is sent by Axios by default) in the list of possible authenticity tokens.