### PR TITLE
WIP: SSR integration

### DIFF
--- a/lib/inertia_rails.rb
+++ b/lib/inertia_rails.rb
@@ -15,9 +15,11 @@ ActionController::Renderers.add :inertia do |component, options|
     method(:render),
     props: options[:props],
     view_data: options[:view_data],
+    ssr: options[:ssr]
   ).render
 end
 
 module InertiaRails
   class Error < StandardError; end
+  mattr_accessor :ssr_enabled, :ssr_port, :ssr_host
 end

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -1,10 +1,11 @@
 require_relative "inertia_rails"
+require 'net/http'
 
 module InertiaRails
   class Renderer
     attr_reader :component, :view_data
 
-    def initialize(component, controller, request, response, render_method, props:, view_data:)
+    def initialize(component, controller, request, response, render_method, props:, view_data:, ssr: nil)
       @component = component
       @controller = controller
       @request = request
@@ -12,6 +13,7 @@ module InertiaRails
       @render_method = render_method
       @props = props || {}
       @view_data = view_data || {}
+      @ssr_template_option = ssr
     end
 
     def render
@@ -19,12 +21,42 @@ module InertiaRails
         @response.set_header('Vary', 'Accept')
         @response.set_header('X-Inertia', 'true')
         @render_method.call json: page, status: @response.status, content_type: Mime[:json]
+      elsif ssr? and check_ssr_running
+        begin
+          perform_ssr
+        rescue StandardError => e
+          Rails.logger.error "Error while performing SSR: #{e}, fallback to default handling"
+            @render_method.call template: 'inertia', layout: ::InertiaRails.layout, locals: (view_data).merge({page: page})
+        end
       else
         @render_method.call template: 'inertia', layout: ::InertiaRails.layout, locals: (view_data).merge({page: page})
       end
     end
 
     private
+
+    def ssr?
+      InertiaRails.ssr_enabled && @ssr_template_option != false
+    end
+
+    def perform_ssr
+      ssr_uri = URI("http://#{InertiaRails.ssr_host}:#{InertiaRails.ssr_port}/render")
+      ssr_response = Net::HTTP.post(ssr_uri, page.to_json, { "Content-Type" => "application/json" })
+      unless ssr_response.code == "200"
+        raise StandardError.new("Error while contacting ssr server: Status: #{ssr_response.code}\n#{ssr_response.body.read}")
+      end
+      body = JSON.parse(ssr_response.body)
+
+      @render_method.call html: body['body'].html_safe, layout: ::InertiaRails.layout, locals: (view_data).merge({page: page, ssr_headers: body['head'] || []})
+    end
+
+    def check_ssr_running
+      Socket.tcp(InertiaRails.ssr_host, InertiaRails.ssr_port, connect_timeout: 0.01).close
+      true
+    rescue StandardError
+      Rails.logger.warn "SSR server could not be reached: #{InertiaRails.ssr_host}:#{InertiaRails.ssr_port}!"
+      false
+    end
 
     def props
       _props = ::InertiaRails.shared_data(@controller).merge(@props).select do |key, prop|


### PR DESCRIPTION
Just want to let you know, I am working on a SSR integration.


How it works:  
It is based on the SSR guide recently released to Inertia backer's and Vite's SSR guide amalgamated into this prototype/ProofOfConcept. When rendering a template for the first time, it will check, if a SSR server is running and try to ``post /render`` to it with the ``page`` as a json payload. The SSR server is expected to respond with a JSON object of ``{ head: [], body: "" }``. The plugin then puts the ``body`` as the complete template, and supplies the ``head`` as instance variables for the application layout. If any error occurs alongside, the plugin will fallback to the default handling of rendering inertia template with div#app. 


### Configuration:

SSR is opt-in: 

```ruby
# config/initializers/inertia.rb
InertiaRails.ssr_enabled = true
InertiaRails.ssr_host = 'localhost'
InertiaRails.ssr_port = 23526
```

To add headers from rendered files (supplied by inertia-head), also add them to your application layout:

```erb
    <% if @ssr_headers %>
      <!-- SSR-headers -->
      <% @ssr_headers.each do |head| %>
        <%= raw head %>
      <% end %>
    <% end %>
 </head>
```

- Start the SSR server as well as the Rails Server., e.g. ``node server.js``.
- If SSR is not required/wished for a specific action, you can pass  ``render inertia: {..., ssr: false }``

## Development:
Missing:
- [ ] Tests.. hadn't even looked into the repo (happy if you give me any pointers which tests to add)
- [ ] Docs
- [ ] SSR script/guide/docs for the webpacker folks (maybe other people can join in here)

(How to make a SSR also depends a lot on your bundler, Webpack, Vite etc., we are using Vite at the moment)


<details>
<summary>Our Vite + Inertia + Vue SSR server:</summary>

```js
// server.js
const fs = require("fs")
const path = require("path")
const express = require("express")
const { createServer: createViteServer } = require("vite")

async function createServer() {
  const app = express()
  app.use(express.json())

  const vite = await createViteServer({
    server: {
      middlewareMode: "ssr",
      port: 23526,
      host: '0.0.0.0',
      hmr: false,
      // hmr: { port: 23526, protocol: "wss", host: "jobsdaheim.swi.pludoni.com" },
      https: false,
    },
  })
  app.use(vite.middlewares)

  app.post("/render", async (request, response, next) => {
    try {
      const render = await vite.ssrLoadModule("~/ssr")
      const out = await render.default(request.body)
      response.json(out)
    } catch (error) {
      // vite.ssrFixStacktrace(error)
      next(error)
    }
  })

  app.listen(23526)
}

createServer()
```

```typescript
# app/javascript/ssr.ts
import { renderToString } from "@vue/server-renderer"
import { createInertiaApp } from "@inertiajs/inertia-vue3"
import { createSSRApp, h } from "vue"

export default (jsonPage: any) => {
  return createInertiaApp({
    page: jsonPage,
    render: renderToString,
    resolve: (name) => import(`/pages/${name}.vue`),
    setup({ app, props, plugin }) {
      return createSSRApp({
        render: () => h(app, props),
      }).use(plugin)
    },
  })
}
```
</details>