### PR TITLE
Fix: Use action_controller_base hook in initializer

### DIFF
--- a/lib/inertia_rails/engine.rb
+++ b/lib/inertia_rails/engine.rb
@@ -8,7 +8,7 @@ module InertiaRails
     end
 
     initializer "inertia_rails.action_controller" do
-      ActiveSupport.on_load(:action_controller) do
+      ActiveSupport.on_load(:action_controller_base) do
         include ::InertiaRails::Controller
       end
     end


### PR DESCRIPTION
Using inertia-rails in a Rails project where an `ActionController::API` controllers exists will trigger `undefined method 'helper_method' for ActionController::API:Class` error.

`action_controller` is called if the controller is an instance of `ActionController::Base` or `ActionController::API`.  And `ActionController::API` don't have `helper_method` method.


ref: rails/rails#28402