### PR TITLE
NoMethodError: undefined method `helper' for ActionController::API:Class

### DIFF
--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -10,7 +10,9 @@ module InertiaRails
         # :inertia_errors are deleted from the session by the middleware
         InertiaRails.share(errors: session[:inertia_errors]) if session[:inertia_errors].present?
       end
-      helper ::InertiaRails::Helper
+      if respond_to? :helper
+        helper ::InertiaRails::Helper
+      end
     end
 
     module ClassMethods


### PR DESCRIPTION
On rails 7.0.1 I got error:
```
2022-06-07 23:17:03 +0300 Rack app ("GET /" - (127.0.0.1)): #<NoMethodError: undefined method `helper' for ActionController::API:Class

      helper ::InertiaRails::Helper
      ^^^^^^>
```      