### PR TITLE
Mimic Rails behavior for instance props and rendering

### DIFF
--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -22,6 +22,18 @@ module InertiaRails
       end
     end
 
+    def render_inertia(component = nil)
+      render(inertia: component)
+    end
+
+    def default_render
+      if InertiaRails.default_render?
+        render_inertia
+      else
+        super
+      end
+    end
+
     def redirect_to(options = {}, response_options = {})
       capture_inertia_errors(response_options)
       super(options, response_options)

--- a/lib/inertia_rails/inertia_rails.rb
+++ b/lib/inertia_rails/inertia_rails.rb
@@ -32,6 +32,10 @@ module InertiaRails
     Configuration.ssr_url
   end
 
+  def self.default_render?
+    Configuration.default_render
+  end 
+
   def self.html_headers
     self.threadsafe_html_headers || []
   end
@@ -66,6 +70,7 @@ module InertiaRails
     mattr_accessor(:version) { nil }
     mattr_accessor(:ssr_enabled) { false }
     mattr_accessor(:ssr_url) { 'http://localhost:13714' }
+    mattr_accessor(:default_render) { false }
 
     def self.evaluated_version
       self.version.respond_to?(:call) ? self.version.call : self.version

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -6,8 +6,8 @@ module InertiaRails
   class Renderer
     attr_reader :component, :view_data
 
-    def initialize(component, controller, request, response, render_method, props:, view_data:)
-      @component = component
+    def initialize(component = nil, controller, request, response, render_method, props:, view_data:)
+      @component = component || "#{controller.controller_path}/#{controller.action_name}"
       @controller = controller
       @request = request
       @response = response
@@ -38,7 +38,7 @@ module InertiaRails
     end
 
     def props
-      _props = ::InertiaRails.shared_data(@controller).merge(@props).select do |key, prop|
+      _props = ::InertiaRails.shared_data(@controller).merge(@controller.view_assigns).merge(@props).select do |key, prop|
         if rendering_partial_component?
           key.in? partial_keys
         else

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -38,7 +38,7 @@ module InertiaRails
     end
 
     def props
-      _props = ::InertiaRails.shared_data(@controller).merge(@controller.view_assigns).merge(@props).select do |key, prop|
+      _props = ::InertiaRails.shared_data(@controller).merge(controller_instance_variables).merge(@props).select do |key, prop|
         if rendering_partial_component?
           key.in? partial_keys
         else
@@ -56,6 +56,10 @@ module InertiaRails
         url: @request.original_fullpath,
         version: ::InertiaRails.version,
       }
+    end
+
+    def controller_instance_variables
+      @controller.view_assigns.except('rendered_format', 'marked_for_same_origin_verification')
     end
 
     def deep_transform_values(hash, proc)

--- a/spec/dummy/app/controllers/inertia_rails_mimic_controller.rb
+++ b/spec/dummy/app/controllers/inertia_rails_mimic_controller.rb
@@ -1,0 +1,28 @@
+class InertiaRailsMimicController < ApplicationController
+  before_action :enable_inertia_default, only: :default_render_test
+
+  def instance_props_test
+    @name = 'Brandon'
+    @sport = 'hockey'
+
+    render inertia: 'TestComponent'
+  end
+
+  def default_render_test
+    @name = 'Brian'
+  end
+
+  def default_component_test
+    render inertia: nil
+  end
+
+  def default_component_shortcut_test
+    render_inertia
+  end
+
+  def enable_inertia_default
+    InertiaRails.configure do |config|
+      config.default_render = true
+    end
+  end
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -26,5 +26,10 @@ Rails.application.routes.draw do
   get 'lazy_props' => 'inertia_render_test#lazy_props'
   get 'non_inertiafied' => 'inertia_test#non_inertiafied'
 
+  get 'instance_props_test' => 'inertia_rails_mimic#instance_props_test'
+  get 'default_render_test' => 'inertia_rails_mimic#default_render_test'
+  get 'default_component_test' => 'inertia_rails_mimic#default_component_test'
+  get 'default_component_shortcut_test' => 'inertia_rails_mimic#default_component_shortcut_test'
+
   inertia 'inertia_route' => 'TestComponent'
 end

--- a/spec/inertia/rails_mimic_spec.rb
+++ b/spec/inertia/rails_mimic_spec.rb
@@ -1,0 +1,36 @@
+require_relative '../../lib/inertia_rails/rspec'
+
+RSpec.describe 'rendering when mimicking rails behavior', type: :request, inertia: true do
+
+  context 'the props are provided by instance variables' do
+    it 'has the props' do
+      get instance_props_test_path
+
+      expect_inertia.to include_props({'name' => 'Brandon', 'sport' => 'hockey'})
+    end
+  end
+
+  context 'no component name is provided' do
+    it 'has the correct derived component name' do
+      get default_component_test_path
+
+      expect_inertia.to render_component('inertia_rails_mimic/default_component_test')
+    end
+
+    it 'works with a neat shortcut' do
+      get default_component_shortcut_test_path
+
+      expect_inertia.to render_component('inertia_rails_mimic/default_component_shortcut_test')
+    end
+  end
+
+  context 'no render is done at all and default_render is enabled' do
+    it 'renders via inertia' do
+      get default_render_test_path
+
+      expect_inertia.to render_component('inertia_rails_mimic/default_render_test')
+      expect_inertia.to include_props({'name' => 'Brian'})
+    end
+  end
+end
+

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -1,11 +1,13 @@
 RSpec.describe 'rendering inertia views', type: :request do
   subject { response.body }
 
+  let(:controller) { double('Controller', view_assigns: {})}
+
   context 'first load' do
-    let(:page) { InertiaRails::Renderer.new('TestComponent', '', request, response, '', props: nil, view_data: nil).send(:page) }
+    let(:page) { InertiaRails::Renderer.new('TestComponent', controller, request, response, '', props: nil, view_data: nil).send(:page) }
     
     context 'with props' do
-      let(:page) { InertiaRails::Renderer.new('TestComponent', '', request, response, '', props: {name: 'Brandon', sport: 'hockey'}, view_data: nil).send(:page) }
+      let(:page) { InertiaRails::Renderer.new('TestComponent', controller, request, response, '', props: {name: 'Brandon', sport: 'hockey'}, view_data: nil).send(:page) }
       before { get props_path }
 
       it { is_expected.to include inertia_div(page) }
@@ -37,7 +39,7 @@ RSpec.describe 'rendering inertia views', type: :request do
   end
 
   context 'subsequent requests' do
-    let(:page) { InertiaRails::Renderer.new('TestComponent', '', request, response, '', props: {name: 'Brandon', sport: 'hockey'}, view_data: nil).send(:page) }
+    let(:page) { InertiaRails::Renderer.new('TestComponent', controller, request, response, '', props: {name: 'Brandon', sport: 'hockey'}, view_data: nil).send(:page) }
     let(:headers) { {'X-Inertia' => true} }
 
     before { get props_path, headers: headers }
@@ -62,7 +64,7 @@ RSpec.describe 'rendering inertia views', type: :request do
 
   context 'partial rendering' do
     let (:page) {
-      InertiaRails::Renderer.new('TestComponent', '', request, response, '', props: { sport: 'hockey'}, view_data: nil).send(:page)
+      InertiaRails::Renderer.new('TestComponent', controller, request, response, '', props: { sport: 'hockey'}, view_data: nil).send(:page)
     }
     let(:headers) {{
       'X-Inertia' => true,
@@ -92,7 +94,7 @@ RSpec.describe 'rendering inertia views', type: :request do
   context 'lazy prop rendering' do
     context 'on first load' do
       let (:page) {
-        InertiaRails::Renderer.new('TestComponent', '', request, response, '', props: { name: 'Brian'}, view_data: nil).send(:page)
+        InertiaRails::Renderer.new('TestComponent', controller, request, response, '', props: { name: 'Brian'}, view_data: nil).send(:page)
       }
       before { get lazy_props_path }
 
@@ -101,7 +103,7 @@ RSpec.describe 'rendering inertia views', type: :request do
 
     context 'with a partial reload' do
       let (:page) {
-        InertiaRails::Renderer.new('TestComponent', '', request, response, '', props: { sport: 'basketball', level: 'worse than he believes', grit: 'intense'}, view_data: nil).send(:page)
+        InertiaRails::Renderer.new('TestComponent', controller, request, response, '', props: { sport: 'basketball', level: 'worse than he believes', grit: 'intense'}, view_data: nil).send(:page)
       }
       let(:headers) {{
         'X-Inertia' => true,


### PR DESCRIPTION
Thanks to an excellent suggestion by @buhrmi, this PR would bring Rails view rendering behavior to Inertia Rails. It includes the following three new features:

## Instance Variables as Props
All instance variables defined during your controller method will be available to your inertia components as props.

**New Behavior:**
```ruby
def index
   @users = User.all
   
   render inertia: 'MyComponent'
end
```
**Is the same as currently writing:**
```ruby
def index
   render inertia: 'MyComponent', props: {
      users: User.all,
   }
end
```

## Automatically Determine Component Name
If you don't provide a component name, inertia will use Rails template logic to determine what it should be

**New Behavior:**
```ruby
class UsersController < ApplicationController
   def index
      render inertia: nil # this syntax looks a little silly, so a new helper was added as shown below
      # OR
      render_inertia # this does the same thing as the render above, but looks a bit cleaner
   end
end
```
**is the same as currently writing:**
```ruby
class UsersController < ApplicationController
   def index
      render inertia: 'users/index'
   end
end
```

## Make Inertia the Default Rendering Option
If your app is nearly all inertia-based, you can have the inertia render process be the default instead of rails views. Since this behavior is a bit magical feeling it's opt-in, not the default.

**New Behavior:**
```ruby
InertiaRails.configure do |config|
   config.default_render = true
end

class UsersController < ApplicationController
   def index
      @users = User.all
   end
end
``` 
**is the same as currently writing:**
```ruby
class UsersController < ApplicationController
   def index
      render inertia: 'users/index', props: {
         users: User.all,
      }
   end
end
```