### PR TITLE
fix: avoid leaking shared state across requests on error conditions

### DIFF
--- a/lib/inertia_rails/middleware.rb
+++ b/lib/inertia_rails/middleware.rb
@@ -7,6 +7,8 @@ module InertiaRails
     def call(env)
       InertiaRailsRequest.new(@app, env)
                          .response
+    ensure
+      ::InertiaRails.reset!
     end
 
     class InertiaRailsRequest
@@ -18,8 +20,6 @@ module InertiaRails
       def response
         status, headers, body = @app.call(@env)
         request = ActionDispatch::Request.new(@env)
-
-        ::InertiaRails.reset!
 
         # Inertia errors are added to the session via redirect_to 
         request.session.delete(:inertia_errors) unless keep_inertia_errors?(status)

--- a/spec/dummy/app/controllers/inertia_multithreaded_share_controller.rb
+++ b/spec/dummy/app/controllers/inertia_multithreaded_share_controller.rb
@@ -6,4 +6,8 @@ class InertiaMultithreadedShareController < ApplicationController
     sleep 1
     render inertia: 'ShareTestComponent'
   end
+
+  def share_multithreaded_error
+    raise Exception
+  end
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   delete 'redirect_test' => 'inertia_test#redirect_test'
   get 'my_location' => 'inertia_test#my_location'
   get 'share_multithreaded' => 'inertia_multithreaded_share#share_multithreaded'
+  get 'share_multithreaded_error' => 'inertia_multithreaded_share#share_multithreaded_error'
   get 'redirect_with_inertia_errors' => 'inertia_test#redirect_with_inertia_errors'
   post 'redirect_with_inertia_errors' => 'inertia_test#redirect_with_inertia_errors'
   post 'redirect_back_with_inertia_errors' => 'inertia_test#redirect_back_with_inertia_errors'

--- a/spec/inertia/sharing_spec.rb
+++ b/spec/inertia/sharing_spec.rb
@@ -88,5 +88,15 @@ RSpec.describe 'using inertia share when rendering views', type: :request do
       thread1.join
       thread2.join
     end
+
+    it 'is expected not to leak shared data across requests' do
+      begin
+        get share_multithreaded_error_path, headers: {'X-Inertia' => true}
+      rescue Exception
+      end
+
+      expect(InertiaRails.shared_plain_data).to be_empty
+      expect(InertiaRails.shared_blocks).to be_empty
+    end
   end
 end


### PR DESCRIPTION
### Description 📖 

This pull request fixes a leak of shared data and blocks across requests, which poses both a security risk, and the capability of creating puzzling one-of-a-kind error conditions in production.

### The Fix 🔨 

Ensuring that `InertiaRails.reset!` is called in an `ensure` block in the middleware, so the shared variables are [always reset](https://github.com/ElMassimo/request_store_rails/blob/master/lib/request_store_rails/middleware.rb#L13-L21).

Added a test that failed before this fix, and passes with this fix.

### Background 📜 

While https://github.com/inertiajs/inertia-rails/pull/38 removed some of the race conditions, the implementation still suffers from the perils of shared global state, and some of the problems mentioned in https://github.com/inertiajs/inertia-rails/pull/17 persist.

When an unhandled error occurs, the middleware chain is halted, causing shared data and blocks to be __leaked across requests__.

After a fatal error, any subsequent request in the same thread will have `shared_data` and `shared_blocks` from the previous request, which is incorrect and dangerous (can cause requests to fail if blocks are executed in different controllers, and data to be leaked across requests).

### Future Work 🔮 

Shared global state should be avoided like the plague, and I say this [from experience](https://github.com/ElMassimo/request_store_rails) 😄 

I'd suggest bringing back @ledermann's refactor to avoid global variables, and I'm willing to update that PR if you are willing to merge it 😃 