### PR TITLE
include initial page data in server-rendered page

### DIFF
--- a/app/views/inertia.html.erb
+++ b/app/views/inertia.html.erb
@@ -1,1 +1,1 @@
-<div id="app" data-page="<%= page.to_json %>"></div>
+<div <% if ssr_html %> data-server-rendered="true" <% end %>id="app" data-page="<%= page.to_json %>"><%= ssr_html %></div>

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -22,8 +22,8 @@ module InertiaRails
         @response.set_header('X-Inertia', 'true')
         @render_method.call json: page, status: @response.status, content_type: Mime[:json]
       else
-        return render_ssr if ::InertiaRails.ssr_enabled? rescue nil
-        @render_method.call template: 'inertia', layout: ::InertiaRails.layout, locals: (view_data).merge({page: page})
+        ssr_html = render_ssr if ::InertiaRails.ssr_enabled? rescue nil
+        @render_method.call template: 'inertia', layout: ::InertiaRails.layout, locals: view_data.merge({ssr_html: ssr_html, page: page})
       end
     end
 
@@ -34,7 +34,7 @@ module InertiaRails
       res = JSON.parse(Net::HTTP.post(uri, page.to_json, 'Content-Type' => 'application/json').body)
       
       ::InertiaRails.html_headers = res['head']
-      @render_method.call html: res['body'].html_safe, layout: ::InertiaRails.layout, locals: (view_data).merge({page: page})
+      return res['body'].html_safe
     end
 
     def props

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'rendering inertia views', type: :request do
       before { get view_data_path }
 
       it { is_expected.to include inertia_div(page) }
-      it { is_expected.to include({name: 'Brian', sport: 'basketball'}.to_json) }
+      it { is_expected.to include({name: 'Brian', sport: 'basketball', ssr_html: nil}.to_json) }
     end
 
     context 'with no data' do

--- a/spec/inertia/rspec_helper_spec.rb
+++ b/spec/inertia/rspec_helper_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe InertiaRails::RSpec, type: :request do
       before { get view_data_path }
 
       it 'has view data' do
-        expect_inertia.to have_exact_view_data({name: 'Brian', sport: 'basketball'})
+        expect_inertia.to have_exact_view_data({name: 'Brian', sport: 'basketball', ssr_html: nil})
       end
 
       it 'includes view data' do


### PR DESCRIPTION
Currently, the Rails adapter throws away the initial page data in the server-side rendered HTML. This makes it impossible for the client to "take over" and hydrate the page. This PR keeps the initial data and also adds a `data-server-rendered="true"` attribute to it, bringing it in line with the other adatpers.