### PR TITLE
feat: support multiple inertia apps by allowing different layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,6 @@ InertiaRails.configure do |config|
   # set the current version for automatic asset refreshing. A string value should be used if any.
   config.version = nil
   
-  # set the layout you want inertia components to be rendered within. This layout must include any required inertia javascript.
-  config.layout = 'application'
-
   # ssr specific options
   config.ssr_enabled = false
   config.ssr_url = 'http://localhost:13714'

--- a/inertia_rails.gemspec
+++ b/inertia_rails.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "responders"
+  spec.add_development_dependency "debug"
 end

--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -40,6 +40,9 @@ module InertiaRails
 
     def inertia_layout
       layout = ::InertiaRails.layout
+
+      # When the global configuration is not set, let Rails decide which layout
+      # should be used based on the controller configuration.
       layout.nil? ? true : layout
     end
 

--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -38,6 +38,11 @@ module InertiaRails
 
     private
 
+    def inertia_layout
+      layout = ::InertiaRails.layout
+      layout.nil? ? true : layout
+    end
+
     def inertia_location(url)
       headers['X-Inertia-Location'] = url
       head :conflict

--- a/lib/inertia_rails/inertia_rails.rb
+++ b/lib/inertia_rails/inertia_rails.rb
@@ -62,7 +62,7 @@ module InertiaRails
   private
 
   module Configuration
-    mattr_accessor(:layout) { 'application' }
+    mattr_accessor(:layout) { nil }
     mattr_accessor(:version) { nil }
     mattr_accessor(:ssr_enabled) { false }
     mattr_accessor(:ssr_url) { 'http://localhost:13714' }

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -23,7 +23,7 @@ module InertiaRails
         @render_method.call json: page, status: @response.status, content_type: Mime[:json]
       else
         return render_ssr if ::InertiaRails.ssr_enabled? rescue nil
-        @render_method.call template: 'inertia', layout: ::InertiaRails.layout, locals: (view_data).merge({page: page})
+        @render_method.call template: 'inertia', layout: layout, locals: (view_data).merge({page: page})
       end
     end
 
@@ -34,7 +34,11 @@ module InertiaRails
       res = JSON.parse(Net::HTTP.post(uri, page.to_json, 'Content-Type' => 'application/json').body)
       
       ::InertiaRails.html_headers = res['head']
-      @render_method.call html: res['body'].html_safe, layout: ::InertiaRails.layout, locals: (view_data).merge({page: page})
+      @render_method.call html: res['body'].html_safe, layout: layout, locals: (view_data).merge({page: page})
+    end
+
+    def layout
+      @controller.send(:inertia_layout)
     end
 
     def props

--- a/spec/dummy/app/controllers/inertia_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_test_controller.rb
@@ -1,5 +1,11 @@
 class InertiaTestController < ApplicationController
+  layout 'conditional', only: [:with_different_layout]
+
   def empty_test
+    render inertia: 'EmptyTestComponent'
+  end
+
+  def with_different_layout
     render inertia: 'EmptyTestComponent'
   end
 

--- a/spec/dummy/app/views/layouts/conditional.html.erb
+++ b/spec/dummy/app/views/layouts/conditional.html.erb
@@ -1,0 +1,2 @@
+<h1>Conditional layout specified by controller</h1>
+<%= yield %>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   get 'share' => 'inertia_share_test#share'
   get 'share_with_inherited' => 'inertia_child_share_test#share_with_inherited'
   get 'empty_test' => 'inertia_test#empty_test'
+  get 'with_different_layout' => 'inertia_test#with_different_layout'
   get 'redirect_test' => 'inertia_test#redirect_test'
   get 'inertia_request_test' => 'inertia_test#inertia_request_test'
   get 'inertia_partial_request_test' => 'inertia_test#inertia_partial_request_test'

--- a/spec/inertia/configuration_spec.rb
+++ b/spec/inertia/configuration_spec.rb
@@ -98,6 +98,27 @@ RSpec.describe 'Inertia configuration', type: :request do
         it { is_expected.to render_template 'testing' }
         it { is_expected.not_to render_template 'application' }
       end
+
+      context 'opting out of a different layout for Inertia' do
+        before do
+          InertiaRails.configure {|c| c.layout = nil }
+        end
+
+        it 'uses default layout for controller' do
+          get empty_test_path
+          is_expected.to render_template 'inertia'
+          is_expected.to render_template 'application'
+          is_expected.not_to render_template 'testing'
+        end
+
+        it 'applies conditional layouts as needed' do
+          get with_different_layout_path
+          is_expected.to render_template 'inertia'
+          is_expected.to render_template 'conditional'
+          is_expected.not_to render_template 'application'
+          is_expected.not_to render_template 'testing'
+        end
+      end
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,6 +3,8 @@ ENV['RAILS_ENV'] ||= 'test'
 
 require File.expand_path('../dummy/config/environment', __FILE__)
 
+# Allow using `debugger` to debug failing tests.
+require 'debug'
 
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?


### PR DESCRIPTION
### Description 📖 

This pull request allows to leverage the default layout resolution in Rails.

### Background 📜 

When using Rails as the backend for different Inertia apps, having a global layout configuration does not allow each app to have a different layout (with different title and meta tags, for example).

By using the layout specified by the controller (which defaults to `application` in most apps), the user has more flexibility to choose which layout should be used.

---

For example, this pull request enables:

```ruby
class Admin::BaseController < ApplicationController
  layout "admin"
end
```

where the `admin` frontend app gets its own layout, with different scripts, meta tags, and title.

### Notes ✏️ 

- The previous mechanism to configure a layout is still supported:

  ```ruby
  InertiaRails.configure { |config| config.layout = 'other' }
  ```

- An internal `inertia_layout` controller instance method was added for the purpose of even more dynamic configurations, for users that need the flexibility. Now they can customize the behavior by defining a method in their controllers, without having to monkey-patch `InertiaRails`.

### Considerations about Backwards Compatibility

This shouldn't be considered a breaking change, as the default layout for most Rails apps is `application` (hence, the tests didn't need to be updated), and in other setups, a user would already be configuring `InertiaRails::Configuration#layout` explicitly, which will continue to work.