### PR TITLE
Fix rspec failure on X-Inertia requests

### DIFF
--- a/lib/inertia_rails/rspec.rb
+++ b/lib/inertia_rails/rspec.rb
@@ -25,9 +25,16 @@ module InertiaRails
       protected
     
       def set_values(params)
-        @view_data = params[:locals].except(:page)
-        @props = params[:locals][:page][:props]
-        @component = params[:locals][:page][:component]
+        if params[:locals].present?
+          @view_data = params[:locals].except(:page)
+          @props = params[:locals][:page][:props]
+          @component = params[:locals][:page][:component]
+        else
+          # Sequential Inertia request
+          @view_data = {}
+          @props = params[:json][:props]
+          @component = params[:json][:component]
+        end
       end
     end
 

--- a/spec/inertia/rspec_helper_spec.rb
+++ b/spec/inertia/rspec_helper_spec.rb
@@ -34,6 +34,22 @@ RSpec.describe InertiaRails::RSpec, type: :request do
       end
     end
 
+    context 'with props during sequential request' do
+      before { get props_path, headers: {'X-Inertia': true} }
+
+      it 'has props' do
+        expect_inertia.to have_exact_props({name: 'Brandon', sport: 'hockey'})
+      end
+
+      it 'includes props' do
+        expect_inertia.to include_props({sport: 'hockey'})
+      end
+
+      it 'can retrieve props' do
+        expect(inertia.props[:name]).to eq 'Brandon'
+      end
+    end
+
     context 'with view data' do
       before { get view_data_path }
 


### PR DESCRIPTION
As initial request and subsequent requests are handled with different renderers sometimes we may end up in situation where controller action may fail just in one of those cases:

https://github.com/inertiajs/inertia-rails/blob/master/lib/inertia_rails/renderer.rb#L19L28

This is exactly what happened on one of my work projects. Subsequent requests (with `X-Inertia` header were failing) but my rspec specs were all :green_circle: .

Naturally, I decided to add another spec that issues the request with `X-Inertia` header. It turned out that the rspec helper is not expecting that :sweat_smile: . This PR aims to resolve that and allow tests like the one below.

```ruby
it 'works on subsequential requests' do
  get homepage_path, headers: {'X-Inertia' => true}

  expect(inertia_props.keys).to include('records', 'pagination', 'filters')
end
```