### PR TITLE
add railties as the runtime dependency

### DIFF
--- a/inertia_rails.gemspec
+++ b/inertia_rails.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rails", '>= 5'
+  spec.add_runtime_dependency "railties", '>= 5'
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
This releases this gem from depending on the whole Rails suite.