### PR TITLE
Fix stale shared data in tests - call `::InertiaRails.reset!` before each rspec example

### DIFF
--- a/lib/inertia_rails/rspec.rb
+++ b/lib/inertia_rails/rspec.rb
@@ -65,6 +65,7 @@ RSpec.configure do |config|
   }
 
   config.before(:each, inertia: true) do
+    ::InertiaRails.reset!
     new_renderer = InertiaRails::Renderer.method(:new)
     allow(InertiaRails::Renderer).to receive(:new) do |component, controller, request, response, render, named_args|
       new_renderer.call(component, controller, request, response, inertia_wrap_render(render), **named_args)


### PR DESCRIPTION
## Notes

We're seeing an issue with `shared_data` making our specs non-deterministic, depending on the running order of our tests (i.e. where a particular controller spec passes individually but fails if it's run after another controller spec).

The example code below illustrates the problem we're seeing

```ruby
# groups_controller.rb
class GroupsController < ApplicationController
  inertia_share do
    { someGroupsControllerData: true }
  end

  def index
    render inertia: 'Groups/Index', props: { groups: [] }
  end
end

# people_controller.rb
class PeopleController < ApplicationController
  def show
    render inertia: 'People/Show', props: { some_people_data: {} }
  end
end

# people_controller_spec.rb
require 'rails_helper'
describe PeopleController, controller: true do
  describe '#show', inertia: true do
    it 'should not have data from a different controller' do
      expect(inertia.props.keys).to contain_exactly(:some_people_data)
    end
  end
end
```

When we run the `people_controller_spec.rb` by itself it all works fine.

However, if we run the test suite and the `people_controller_spec.rb` runs after the `groups_controller_spec.rb` then we get the following failure message, indicating that the `shared_data` is not being successfully cleared between specs:

> **Failure/Error: expect(inertia.props.keys).to contain_exactly(:some_people_data)**
> 
>    expected collection contained:  [:some_people_data]
>    actual collection contained:    [:some_people_data, :someGroupsControllerData]
>    the extra elements were:        [:someGroupsControllerData]

## Proposed solution in this PR

You might have preferred ways of resolving this issue but for the sake of suggesting a solution I can confirm that the 1-line change in this PR resolves the issue we're seeing by adding `::InertiaRails.reset!` within the `config.before(:each, inertia: true) do` block (that reset is called in the middleware layer but I'm guessing it's skipped when running in the test environment)

Definitely no dramas if you'd prefer to solve this another way though (i.e. no worries if you need to close this PR unmerged in favour of some other approach!)

Please let me know if it'd be helpful for me to try to add a failing spec to the `inertia_rails` test suite and I can have a go at making that happen based on the example above.

Cheers for your great work on this excellent library!