### PR TITLE
Set the correct `Vary` header

### DIFF
--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -19,7 +19,7 @@ module InertiaRails
 
     def render
       if @request.headers['X-Inertia']
-        @response.set_header('Vary', 'Accept')
+        @response.set_header('Vary', 'X-Inertia')
         @response.set_header('X-Inertia', 'true')
         @render_method.call json: page, status: @response.status, content_type: Mime[:json]
       else

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'rendering inertia views', type: :request do
 
     it 'has the proper headers' do
       expect(response.headers['X-Inertia']).to eq 'true'
-      expect(response.headers['Vary']).to eq 'Accept'
+      expect(response.headers['Vary']).to eq 'X-Inertia'
       expect(response.headers['Content-Type']).to eq 'application/json; charset=utf-8'
     end
 

--- a/spec/inertia/ssr_spec.rb
+++ b/spec/inertia/ssr_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'inertia ssr', type: :request do
       it 'allows inertia to take over when inertia headers are passed' do
         get props_path, headers: {'X-Inertia' => true, 'X-Inertia-Version' => '1.0'}
 
-        expect(response.headers['Vary']).to eq 'Accept'
+        expect(response.headers['Vary']).to eq 'X-Inertia'
         expect(response.headers['Content-Type']).to eq 'application/json; charset=utf-8'
       end
     end


### PR DESCRIPTION
~Following Inertia author on this one: https://github.com/inertiajs/inertia-laravel/pull/404, since he updated the `Vary` header to be `X-Inertia` instead of `Accept`.~

**The [protocol](https://inertiajs.com/the-protocol#inertia-responses) got updated and now `Vary` has to be `X-Inertia`.**