### PR TITLE
Align CSRF cookie provisioning with Laravel's precedents to eliminate ActionController::InvalidAuthenticityToken edge cases

### DIFF
--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -13,7 +13,7 @@ module InertiaRails
       helper ::InertiaRails::Helper
 
       after_action do
-        cookies['XSRF-TOKEN'] = form_authenticity_token unless request.inertia? || !protect_against_forgery?
+        cookies['XSRF-TOKEN'] = form_authenticity_token unless !protect_against_forgery?
       end
     end
 

--- a/spec/dummy/app/controllers/inertia_session_continuity_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_session_continuity_test_controller.rb
@@ -1,0 +1,15 @@
+class InertiaSessionContinuityTestController < ApplicationController
+  def initialize_session
+    render inertia: 'TestNewSessionComponent'
+  end
+
+  def submit_form_to_test_csrf
+    render inertia: 'TestComponent'
+  end
+
+  def clear_session
+    session.clear
+
+    return redirect_to initialize_session_path
+  end
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -41,4 +41,8 @@ Rails.application.routes.draw do
   get 'merge_instance_props' => 'inertia_merge_instance_props#merge_instance_props'
 
   get 'lamda_shared_props' => 'inertia_lambda_shared_props#lamda_shared_props'
+
+  get 'initialize_session' => 'inertia_session_continuity_test#initialize_session'
+  post 'submit_form_to_test_csrf' => 'inertia_session_continuity_test#submit_form_to_test_csrf'
+  delete 'clear_session' => 'inertia_session_continuity_test#clear_session'
 end

--- a/spec/inertia/request_spec.rb
+++ b/spec/inertia/request_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe 'Inertia::Request', type: :request do
 
       context 'it is an inertia call' do
         let(:headers){ { 'X-Inertia' => true } }
-        it { is_expected.not_to include('XSRF-TOKEN') }
+        it { is_expected.to include('XSRF-TOKEN') }
       end
     end
 


### PR DESCRIPTION
In June 2023, https://github.com/inertiajs/inertia-rails/pull/96 implemented the following strategy for `XSRF-TOKEN` cookies -- **issue a new cookie if**:
- The current endpoint is configured to protect against forgery (e.g. respect `skip_forgery_protection`).
- The request is a non-Inertia call (e.g. it's the first request, a standard "full-page browser request, with no special Inertia headers or data" [<sup>1</sup>](html-responses)).
  
## Issue  
  
This strategy assumes that there is no need to issue the `XSRF-TOKEN` cookie in response to subsequent Inertia requests made by the client; this is not necessarily the case, and can lead to client applications observing unexpected `ActionController::InvalidAuthenticityToken` errors as a result; a simplified example:

- **Login.** The user visits `/login`, a full-HTML, non-Inertia request.
  - `inertia-rails` issues an `XSRF-TOKEN` cookie.
- **Application Use.** The user authenticates and uses the application.
  - All of these requests are Inertia calls; e.g. they are made via XHR with the `X-Inertia` header and the `X-XSRF-TOKEN` set by Axios, all using the `XSRF-TOKEN` issued by `inertia-rails` in response to the very first request.
- **Logout.** The user logs out, triggering `DELETE /logout`.
  - Let's suppose the logout implementation includes [session.clear](https://github.com/rails/rails/blob/ae3c93df0cbec2cacff89785af047066faf3a833/actionpack/lib/action_dispatch/request/session.rb#L159:L163). In addition to anything else in the session, this also purges the CSRF token stored in the session that was issued during the very first non-Inertia request.
  - ⚠️ The backend replies to `DELETE /logout`, an Inertia request like all of the others that preceded it -- it does not issue a new `XSRF-TOKEN` cookie.
- **Reauthentication Attempt.** After logging out, the user later triggers a form submission to login again on the same page.
  - This, too, is an Inertia call. Because no new cookie was issued during logout, it still uses the same original `X-XSRF-TOKEN` that was issued during the user's very first request.
  - 💥 The login attempt throws an `ActionController::InvalidAuthenticityToken`. This will happen for any request eligible for CSRF protection until the user hard-reloads the page, triggering another initial non-Inertia request that will issue them a new cookie.

### Relevant Laravel CSRF Precedents

As it relates to CSRF protection, the interaction between `inertia-js` & `inertia-rails` differs from the precedent established by Laravel & `inertia-js` in one significant way: **they issue a new `XSRF-TOKEN` for every request,** preventing this kind of edge case:

> Laravel stores the current CSRF token in an encrypted XSRF-TOKEN cookie that is included **with each response generated by the framework**.
> https://laravel.com/docs/10.x/csrf#csrf-x-xsrf-token

> Implementation: https://github.com/laravel/framework/blob/e0be50a7b770c46b522377cb46318e06e312014e/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php#L41-L86

This PR proposes that `inertia-rails` follow Laravel's precedent, and issue an `XSRF-TOKEN` cookie on every request, regardless of whether or not the request is an Inertia call.

Thank you so much for your work on this fantastic gem!