### PR TITLE
feat: add `inertia_config` to enable controller-specific config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 
 # Appraisal
 gemfiles/*.gemfile.lock
+
+# Local files, such as .env.development.local
+*.local

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ inertia 'about' => 'AboutComponent'
 
 Enable SSR via the config settings for `ssr_enabled` and `ssr_url`.
 
-When using SSR, don't forget to add `<%= inertia_headers %>` to the `<head>` of your `application.html.erb`.
+When using SSR, don't forget to add `<%= inertia_ssr_head %>` to the `<head>` of your `application.html.erb`.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ end
 In order to use instance props, you must call `use_inertia_instance_props` on the controller (or a base controller it inherits from). If any props are provided manually, instance props
 are automatically disabled for that response. Instance props are only included if they are defined after the before filter is set from `use_inertia_instance_props`.
 
-Automatic component name is also opt in, you must set the `default_render` config value to `true`. Otherwise, you can simply `render inertia: true` for the same behavior explicitly. 
+Automatic component name is also opt in, you must set the [`default_render`](#default_render) config value to `true`. Otherwise, you can simply `render inertia: true` for the same behavior explicitly.
 
 ### Layout 
 
@@ -132,7 +132,7 @@ end
 }
 ```
 
-Deep merging can be configured using the `deep_merge_shared_data` configuration option.
+Deep merging can be configured using the [`deep_merge_shared_data`](#deep_merge_shared_data) configuration option.
 
 If deep merging is enabled, you can still opt-out within the action:
 
@@ -182,7 +182,7 @@ inertia 'about' => 'AboutComponent'
 
 ### SSR _(experimental)_
 
-Enable SSR via the configuration options for `ssr_enabled` and `ssr_url`.
+Enable SSR via the configuration options for [`ssr_enabled`](#ssr_enabled-experimental) and [`ssr_url`](#ssr_url-experimental).
 
 When using SSR, don't forget to add `<%= inertia_ssr_head %>` to the `<head>` of your layout (i.e. `application.html.erb`).
 

--- a/README.md
+++ b/README.md
@@ -7,14 +7,25 @@
 
 ### Backend
 
-Just add the inertia rails gem to your Gemfile
+Add the `inertia_rails` gem to your Gemfile.
+
 ```ruby
 gem 'inertia_rails'
 ```
 
+For more instructions, see [Server-side setup](https://inertia-rails.netlify.app/guide/server-side-setup.html).
+
 ### Frontend
 
-Rails 7 specific frontend docs coming soon. For now, check out the official Inertia docs at https://inertiajs.com/ or see an example using React/Vite [here](https://github.com/BrandonShar/inertia-rails-template)
+We are discussing on bringing official docs for Inertia Rails to this repo, as
+the [official docs](https://inertiajs.com/client-side-setup) are specific to Laravel.
+
+In the meantime, you can refer to the community-maintained [Client-side setup](https://inertia-rails.netlify.app/guide/client-side-setup.html).
+
+Examples:
+
+- [React/Vite](https://github.com/BrandonShar/inertia-rails-template)
+- [React/Vite + SSR](https://github.com/ElMassimo/inertia-rails-ssr-template)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ Automatic component name is also opt in, you must set the `default_render` confi
 
 ### Layout 
 
-Inertia layouts use the rails layout convention and can be set or changed in the same way. The original `layout` config option is still functional, but will likely be deprecated in the future in favor
-of using rails layouts.
+Inertia layouts use the rails layout convention and can be set or changed in the same way.
 
 ```ruby
 class EventsController < ApplicationController
@@ -133,20 +132,14 @@ end
 }
 ```
 
-Deep merging can be set as the project wide default via the InertiaRails configuration:
+Deep merging can be configured using the `deep_merge_shared_data` configuration option.
 
-```ruby
-# config/initializers/some_initializer.rb
-InertiaRails.configure do |config|
-  config.deep_merge_shared_data = true
-end
-
-```
-
-If deep merging is enabled by default, it's possible to opt out within the action:
+If deep merging is enabled, you can still opt-out within the action:
 
 ```ruby
 class CrazyScorersController < ApplicationController
+  inertia_config(deep_merge_shared_data: true)
+
   inertia_share do
     {
       basketball_data: {
@@ -163,7 +156,7 @@ class CrazyScorersController < ApplicationController
   end
 end
 
-# Even if deep merging is set by default, since the renderer has `deep_merge: false`, it will send a shallow merge to the frontend:
+# `deep_merge: false` overrides the default:
 {
   basketball_data: {
     points: 100,
@@ -187,33 +180,84 @@ If you don't need a controller to handle a static component, you can route direc
 inertia 'about' => 'AboutComponent'
 ```
 
-### SSR
+### SSR _(experimental)_
 
-Enable SSR via the config settings for `ssr_enabled` and `ssr_url`.
+Enable SSR via the configuration options for `ssr_enabled` and `ssr_url`.
 
-When using SSR, don't forget to add `<%= inertia_ssr_head %>` to the `<head>` of your `application.html.erb`.
+When using SSR, don't forget to add `<%= inertia_ssr_head %>` to the `<head>` of your layout (i.e. `application.html.erb`).
 
-## Configuration
+## Configuration ⚙️
 
-Inertia Rails has a few different configuration options that can be set anywhere, but the most common location is from within an initializer.
+Inertia Rails can be configured globally or in a specific controller (and subclasses).
 
-The default config is shown below
+### Global Configuration
+
+If using global configuration, we recommend you place the code inside an initializer:
+
 ```ruby
-InertiaRails.configure do |config|
-  
-  # set the current version for automatic asset refreshing. A string value should be used if any.
-  config.version = nil
-  # enable default inertia rendering (warning! this will override rails default rendering behavior)
-  config.default_render = true
-  
-  # ssr specific options
-  config.ssr_enabled = false
-  config.ssr_url = 'http://localhost:13714'
+# config/initializers/inertia.rb
 
-  config.deep_merge_shared_data = false
-  
+InertiaRails.configure do |config|
+  # Example: force a full-reload if the deployed assets change.
+  config.version = ViteRuby.digest
 end
 ```
+
+The default configuration can be found [here](https://github.com/inertiajs/inertia-rails/blob/master/lib/inertia_rails/configuration.rb#L5-L22).
+
+### Local Configuration
+
+Use `inertia_config` in your controllers to override global settings:
+
+```ruby
+class EventsController < ApplicationController
+  inertia_config(
+    version: "events-#{InertiaRails.configuration.version}",
+    ssr_enabled: -> { action_name == "index" },
+  )
+end
+```
+
+### Configuration Options
+
+#### `version` _(recommended)_
+
+  This allows Inertia to detect if the app running in the client is oudated,
+  forcing a full page visit instead of an XHR visit on the next request.
+
+  See [assets versioning](https://inertiajs.com/asset-versioning).
+
+  __Default__: `nil`
+
+#### `deep_merge_shared_data`
+
+  When enabled, props will be deep merged with shared data, combining hashes
+  with the same keys instead of replacing them.
+
+  __Default__: `false`
+
+#### `default_render`
+
+  Overrides Rails default rendering behavior to render using Inertia by default.
+
+  __Default__: `false`
+
+#### `ssr_enabled` _(experimental)_
+
+  Whether to use a JavaScript server to pre-render your JavaScript pages,
+  allowing your visitors to receive fully rendered HTML when they first visit
+  your application.
+
+  Requires a JS server to be available at `ssr_url`. [_Example_](https://github.com/ElMassimo/inertia-rails-ssr-template)
+
+  __Default__: `false`
+
+#### `ssr_url` _(experimental)_
+
+  The URL of the JS server that will pre-render the app using the specified
+  component and props.
+
+  __Default__: `"http://localhost:13714"`
 
 ## Testing
 

--- a/bin/console
+++ b/bin/console
@@ -1,14 +1,13 @@
 #!/usr/bin/env ruby
 
+require "pathname"
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
+  Pathname.new(__FILE__).realpath)
+
+require "rubygems"
 require "bundler/setup"
-require "inertia_rails/rails"
-
-# You can add fixtures and/or initialization code here to make experimenting
-# with your gem easier. You can also use a different console, if you like.
-
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
+require "rails/all"
+require "inertia_rails"
 
 require "irb"
 IRB.start(__FILE__)

--- a/lib/inertia_rails.rb
+++ b/lib/inertia_rails.rb
@@ -21,4 +21,8 @@ end
 
 module InertiaRails
   class Error < StandardError; end
+
+  def self.deprecator # :nodoc:
+    @deprecator ||= ActiveSupport::Deprecation.new
+  end
 end

--- a/lib/inertia_rails/configuration.rb
+++ b/lib/inertia_rails/configuration.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module InertiaRails
+  class Configuration
+    DEFAULTS = {
+      default_render: false,
+      layout: nil,
+      deep_merge_shared_data: false,
+      merge_props_with: ->(shared_data, props) { shared_data.merge(props) },
+      ssr_enabled: false,
+      ssr_url: 'http://localhost:13714',
+      version: nil,
+    }.freeze
+
+    OPTION_NAMES = DEFAULTS.keys.freeze
+
+    protected attr_reader :options
+
+    def initialize(**attrs)
+      @options = attrs.extract!(*OPTION_NAMES)
+
+      unless attrs.empty?
+        raise ArgumentError, "Unknown options for #{self.class}: #{attrs.keys}"
+      end
+    end
+
+    def to_h
+      @options.to_h
+    end
+
+    def merge(config)
+      Configuration.new(**@options.merge(config.options))
+    end
+
+    OPTION_NAMES.each do |option|
+      define_method(option) {
+        value = @options[option]
+        value.respond_to?(:call) ? value.call : value
+      }
+      define_method("#{option}=") { |value|
+        @options[option] = value
+      }
+    end
+
+    def self.default
+      new(**DEFAULTS)
+    end
+  end
+end

--- a/lib/inertia_rails/configuration.rb
+++ b/lib/inertia_rails/configuration.rb
@@ -37,10 +37,6 @@ module InertiaRails
       super
     end
 
-    def to_h
-      @options.to_h
-    end
-
     def merge!(config)
       @options.merge!(config.options)
       self

--- a/lib/inertia_rails/configuration.rb
+++ b/lib/inertia_rails/configuration.rb
@@ -3,14 +3,21 @@
 module InertiaRails
   class Configuration
     DEFAULTS = {
+      # Whether to combine hashes with the same keys instead of replacing them.
+      deep_merge_shared_data: false,
+
+      # Overrides Rails default rendering behavior to render using Inertia by default.
       default_render: false,
 
-      # Let Rails decide which layout should be used based on the controller configuration.
+      # DEPRECATED: Let Rails decide which layout should be used based on the
+      # controller configuration.
       layout: true,
 
-      deep_merge_shared_data: false,
+      # SSR options.
       ssr_enabled: false,
       ssr_url: 'http://localhost:13714',
+
+      # Used to detect version drift between server and client.
       version: nil,
     }.freeze
 

--- a/lib/inertia_rails/configuration.rb
+++ b/lib/inertia_rails/configuration.rb
@@ -32,8 +32,18 @@ module InertiaRails
       Configuration.new(**@options, controller: controller)
     end
 
+    def freeze
+      @options.freeze
+      super
+    end
+
     def to_h
       @options.to_h
+    end
+
+    def merge!(config)
+      @options.merge!(config.options)
+      self
     end
 
     def merge(config)

--- a/lib/inertia_rails/configuration.rb
+++ b/lib/inertia_rails/configuration.rb
@@ -4,9 +4,11 @@ module InertiaRails
   class Configuration
     DEFAULTS = {
       default_render: false,
-      layout: nil,
+
+      # Let Rails decide which layout should be used based on the controller configuration.
+      layout: true,
+
       deep_merge_shared_data: false,
-      merge_props_with: ->(shared_data, props) { shared_data.merge(props) },
       ssr_enabled: false,
       ssr_url: 'http://localhost:13714',
       version: nil,

--- a/lib/inertia_rails/configuration.rb
+++ b/lib/inertia_rails/configuration.rb
@@ -53,6 +53,12 @@ module InertiaRails
       Configuration.new(**@options.merge(config.options))
     end
 
+    # Internal: Finalizes the configuration for a specific controller.
+    def with_defaults(config)
+      @options = config.options.merge(@options)
+      freeze
+    end
+
     OPTION_NAMES.each do |option|
       define_method(option) {
         evaluate_option @options[option]

--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -23,11 +23,26 @@ module InertiaRails
         end
       end
 
+      def inertia_config(**attrs)
+        config = InertiaRails::Configuration.new(**attrs)
+
+        if @inertia_configuration
+          @inertia_configuration.merge!(config)
+        else
+          @inertia_configuration = config
+        end
+      end
+
       def use_inertia_instance_props
         before_action do
           @_inertia_instance_props = true
           @_inertia_skip_props = view_assigns.keys + ['_inertia_skip_props']
         end
+      end
+
+      def _inertia_configuration
+        config = superclass.try(:_inertia_configuration) || ::InertiaRails.configuration
+        @inertia_configuration ? config.merge(@inertia_configuration) : config
       end
     end
 
@@ -61,7 +76,7 @@ module InertiaRails
     end
 
     def inertia_configuration
-      ::InertiaRails.configuration
+      self.class._inertia_configuration.bind_controller(self)
     end
 
     def inertia_shared_data

--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -62,6 +62,10 @@ module InertiaRails
 
     private
 
+    def inertia_configuration
+      ::InertiaRails.configuration
+    end
+
     def inertia_layout
       layout = ::InertiaRails.layout
 

--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -40,12 +40,20 @@ module InertiaRails
       def _inertia_configuration
         @_inertia_configuration ||= begin
           config = superclass.try(:_inertia_configuration) || ::InertiaRails.configuration
-          @inertia_config ? config.merge(@inertia_config).freeze : config
+          @inertia_config ? config.merge(@inertia_config.freeze).freeze : config
         end
       end
 
       def _inertia_shared_data
-        @_inertia_shared_data ||= [*superclass.try(:_inertia_shared_data), *@inertia_share].freeze
+        @_inertia_shared_data ||= begin
+          shared_data = superclass.try(:_inertia_shared_data)
+
+          if @inertia_share && shared_data.present?
+            shared_data + @inertia_share.freeze
+          else
+            @inertia_share || shared_data || []
+          end.freeze
+        end
       end
     end
 

--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -13,7 +13,7 @@ module InertiaRails
       helper ::InertiaRails::Helper
 
       after_action do
-        cookies['XSRF-TOKEN'] = form_authenticity_token unless !protect_against_forgery?
+        cookies['XSRF-TOKEN'] = form_authenticity_token if protect_against_forgery?
       end
     end
 

--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -40,7 +40,7 @@ module InertiaRails
       def _inertia_configuration
         @_inertia_configuration ||= begin
           config = superclass.try(:_inertia_configuration) || ::InertiaRails.configuration
-          @inertia_config ? config.merge(@inertia_config.freeze).freeze : config
+          @inertia_config&.with_defaults(config) || config
         end
       end
 

--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -34,7 +34,7 @@ module InertiaRails
     end
 
     def default_render
-      if InertiaRails.default_render?
+      if inertia_configuration.default_render
         render(inertia: true)
       else
         super
@@ -64,14 +64,6 @@ module InertiaRails
 
     def inertia_configuration
       ::InertiaRails.configuration
-    end
-
-    def inertia_layout
-      layout = ::InertiaRails.layout
-
-      # When the global configuration is not set, let Rails decide which layout
-      # should be used based on the controller configuration.
-      layout.nil? ? true : layout
     end
 
     def inertia_location(url)

--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -53,15 +53,19 @@ module InertiaRails
       )
     end
 
+    private
+
     def inertia_view_assigns
       return {} unless @_inertia_instance_props
       view_assigns.except(*@_inertia_skip_props)
     end
 
-    private
-
     def inertia_configuration
       ::InertiaRails.configuration
+    end
+
+    def inertia_shared_data
+      ::InertiaRails.shared_data(self)
     end
 
     def inertia_location(url)

--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -1,5 +1,4 @@
 require_relative "inertia_rails"
-require_relative "helper"
 
 module InertiaRails
   module Controller
@@ -10,7 +9,6 @@ module InertiaRails
         # :inertia_errors are deleted from the session by the middleware
         InertiaRails.share(errors: session[:inertia_errors]) if session[:inertia_errors].present?
       end
-      helper ::InertiaRails::Helper
 
       after_action do
         cookies['XSRF-TOKEN'] = form_authenticity_token if protect_against_forgery?

--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -1,10 +1,13 @@
 require_relative "inertia_rails"
+require_relative "helper"
 
 module InertiaRails
   module Controller
     extend ActiveSupport::Concern
 
     included do
+      helper ::InertiaRails::Helper
+
       after_action do
         cookies['XSRF-TOKEN'] = form_authenticity_token if protect_against_forgery?
       end

--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -15,18 +15,18 @@ module InertiaRails
 
     module ClassMethods
       def inertia_share(**attrs, &block)
-        @inertia_shared_data ||= []
-        @inertia_shared_data << attrs unless attrs.empty?
-        @inertia_shared_data << block if block
+        @inertia_share ||= []
+        @inertia_share << attrs.freeze unless attrs.empty?
+        @inertia_share << block if block
       end
 
       def inertia_config(**attrs)
         config = InertiaRails::Configuration.new(**attrs)
 
-        if @inertia_configuration
-          @inertia_configuration.merge!(config)
+        if @inertia_config
+          @inertia_config.merge!(config)
         else
-          @inertia_configuration = config
+          @inertia_config = config
         end
       end
 
@@ -38,12 +38,14 @@ module InertiaRails
       end
 
       def _inertia_configuration
-        config = superclass.try(:_inertia_configuration) || ::InertiaRails.configuration
-        @inertia_configuration ? config.merge(@inertia_configuration) : config
+        @_inertia_configuration ||= begin
+          config = superclass.try(:_inertia_configuration) || ::InertiaRails.configuration
+          @inertia_config ? config.merge(@inertia_config).freeze : config
+        end
       end
 
       def _inertia_shared_data
-        [*superclass.try(:_inertia_shared_data), *@inertia_shared_data]
+        @_inertia_shared_data ||= [*superclass.try(:_inertia_shared_data), *@inertia_share].freeze
       end
     end
 

--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -14,7 +14,7 @@ module InertiaRails
     end
 
     module ClassMethods
-      def inertia_share(**attrs, &block)
+      def inertia_share(attrs = {}, &block)
         @inertia_share ||= []
         @inertia_share << attrs.freeze unless attrs.empty?
         @inertia_share << block if block

--- a/lib/inertia_rails/helper.rb
+++ b/lib/inertia_rails/helper.rb
@@ -1,0 +1,14 @@
+require_relative 'inertia_rails'
+
+module InertiaRails::Helper
+  def inertia_ssr_head
+    controller.instance_variable_get("@_inertia_ssr_head")
+  end
+
+  def inertia_headers
+    InertiaRails.deprecator.warn(
+      "`inertia_headers` is deprecated and will be removed in InertiaRails 4.0, use `inertia_ssr_head` instead."
+    )
+    inertia_ssr_head
+  end
+end

--- a/lib/inertia_rails/helper.rb
+++ b/lib/inertia_rails/helper.rb
@@ -1,7 +1,0 @@
-require_relative 'inertia_rails'
-
-module InertiaRails::Helper
-  def inertia_headers
-    ::InertiaRails.html_headers.join.html_safe
-  end
-end

--- a/lib/inertia_rails/inertia_rails.rb
+++ b/lib/inertia_rails/inertia_rails.rb
@@ -1,14 +1,21 @@
 # Needed for `thread_mattr_accessor`
 require 'active_support/core_ext/module/attribute_accessors_per_thread'
 require 'inertia_rails/lazy'
+require 'inertia_rails/configuration'
 
 module InertiaRails
   thread_mattr_accessor :threadsafe_shared_plain_data
   thread_mattr_accessor :threadsafe_shared_blocks
   thread_mattr_accessor :threadsafe_html_headers
 
+  CONFIGURATION = Configuration.default
+
   def self.configure
-    yield(Configuration)
+    yield(CONFIGURATION)
+  end
+
+  def self.configuration
+    CONFIGURATION
   end
 
   # "Getters"
@@ -18,23 +25,23 @@ module InertiaRails
   end
 
   def self.version
-    Configuration.evaluated_version
+    configuration.version
   end
 
   def self.layout
-    Configuration.layout
+    configuration.layout
   end
 
   def self.ssr_enabled?
-    Configuration.ssr_enabled
+    configuration.ssr_enabled
   end
 
   def self.ssr_url
-    Configuration.ssr_url
+    configuration.ssr_url
   end
 
   def self.default_render?
-    Configuration.default_render
+    configuration.default_render
   end 
 
   def self.html_headers
@@ -42,7 +49,7 @@ module InertiaRails
   end
 
   def self.deep_merge_shared_data?
-    Configuration.deep_merge_shared_data
+    configuration.deep_merge_shared_data
   end
 
   # "Setters"
@@ -69,19 +76,6 @@ module InertiaRails
   end
 
   private
-
-  module Configuration
-    mattr_accessor(:layout) { nil }
-    mattr_accessor(:version) { nil }
-    mattr_accessor(:ssr_enabled) { false }
-    mattr_accessor(:ssr_url) { 'http://localhost:13714' }
-    mattr_accessor(:default_render) { false }
-    mattr_accessor(:deep_merge_shared_data) { false }
-
-    def self.evaluated_version
-      self.version.respond_to?(:call) ? self.version.call : self.version
-    end
-  end
 
   # Getters and setters to provide default values for the threadsafe attributes
   def self.shared_plain_data

--- a/lib/inertia_rails/inertia_rails.rb
+++ b/lib/inertia_rails/inertia_rails.rb
@@ -4,9 +4,6 @@ require 'inertia_rails/lazy'
 require 'inertia_rails/configuration'
 
 module InertiaRails
-  thread_mattr_accessor :threadsafe_shared_plain_data
-  thread_mattr_accessor :threadsafe_shared_blocks
-
   CONFIGURATION = Configuration.default
 
   def self.configure
@@ -17,50 +14,10 @@ module InertiaRails
     CONFIGURATION
   end
 
-  # "Getters"
-  def self.shared_data(controller)
-    shared_plain_data.
-      merge!(evaluated_blocks(controller, shared_blocks))
-  end
-
-  # "Setters"
-  def self.share(**args)
-    self.shared_plain_data = self.shared_plain_data.merge(args)
-  end
-
-  def self.share_block(block)
-    self.shared_blocks = self.shared_blocks + [block]
-  end
-
   def self.reset!
-    self.shared_plain_data = {}
-    self.shared_blocks = []
   end
 
   def self.lazy(value = nil, &block)
     InertiaRails::Lazy.new(value, &block)
-  end
-
-  private
-
-  # Getters and setters to provide default values for the threadsafe attributes
-  def self.shared_plain_data
-    self.threadsafe_shared_plain_data || {}
-  end
-
-  def self.shared_plain_data=(val)
-    self.threadsafe_shared_plain_data = val
-  end
-
-  def self.shared_blocks
-    self.threadsafe_shared_blocks || []
-  end
-
-  def self.shared_blocks=(val)
-    self.threadsafe_shared_blocks = val
-  end
-
-  def self.evaluated_blocks(controller,  blocks)
-    blocks.flat_map { |block| controller.instance_exec(&block) }.reduce(&:merge) || {}
   end
 end

--- a/lib/inertia_rails/inertia_rails.rb
+++ b/lib/inertia_rails/inertia_rails.rb
@@ -24,32 +24,8 @@ module InertiaRails
       merge!(evaluated_blocks(controller, shared_blocks))
   end
 
-  def self.version
-    configuration.version
-  end
-
-  def self.layout
-    configuration.layout
-  end
-
-  def self.ssr_enabled?
-    configuration.ssr_enabled
-  end
-
-  def self.ssr_url
-    configuration.ssr_url
-  end
-
-  def self.default_render?
-    configuration.default_render
-  end 
-
   def self.html_headers
     self.threadsafe_html_headers || []
-  end
-
-  def self.deep_merge_shared_data?
-    configuration.deep_merge_shared_data
   end
 
   # "Setters"

--- a/lib/inertia_rails/inertia_rails.rb
+++ b/lib/inertia_rails/inertia_rails.rb
@@ -6,7 +6,6 @@ require 'inertia_rails/configuration'
 module InertiaRails
   thread_mattr_accessor :threadsafe_shared_plain_data
   thread_mattr_accessor :threadsafe_shared_blocks
-  thread_mattr_accessor :threadsafe_html_headers
 
   CONFIGURATION = Configuration.default
 
@@ -24,10 +23,6 @@ module InertiaRails
       merge!(evaluated_blocks(controller, shared_blocks))
   end
 
-  def self.html_headers
-    self.threadsafe_html_headers || []
-  end
-
   # "Setters"
   def self.share(**args)
     self.shared_plain_data = self.shared_plain_data.merge(args)
@@ -37,14 +32,9 @@ module InertiaRails
     self.shared_blocks = self.shared_blocks + [block]
   end
 
-  def self.html_headers=(headers)
-    self.threadsafe_html_headers = headers
-  end
-
   def self.reset!
     self.shared_plain_data = {}
     self.shared_blocks = []
-    self.html_headers = []
   end
 
   def self.lazy(value = nil, &block)

--- a/lib/inertia_rails/inertia_rails.rb
+++ b/lib/inertia_rails/inertia_rails.rb
@@ -14,9 +14,6 @@ module InertiaRails
     CONFIGURATION
   end
 
-  def self.reset!
-  end
-
   def self.lazy(value = nil, &block)
     InertiaRails::Lazy.new(value, &block)
   end

--- a/lib/inertia_rails/middleware.rb
+++ b/lib/inertia_rails/middleware.rb
@@ -6,8 +6,6 @@ module InertiaRails
 
     def call(env)
       InertiaRailsRequest.new(@app, env).response
-    ensure
-      ::InertiaRails.reset!
     end
 
     class InertiaRailsRequest

--- a/lib/inertia_rails/middleware.rb
+++ b/lib/inertia_rails/middleware.rb
@@ -78,7 +78,7 @@ module InertiaRails
       end
 
       def server_version
-        controller.send(:inertia_configuration).version
+        controller&.send(:inertia_configuration)&.version
       end
 
       def coerce_version(version)

--- a/lib/inertia_rails/middleware.rb
+++ b/lib/inertia_rails/middleware.rb
@@ -5,8 +5,7 @@ module InertiaRails
     end
 
     def call(env)
-      InertiaRailsRequest.new(@app, env)
-                         .response
+      InertiaRailsRequest.new(@app, env).response
     ensure
       ::InertiaRails.reset!
     end
@@ -60,11 +59,15 @@ module InertiaRails
         request_method == 'GET'
       end
 
+      def controller
+        @env["action_controller.instance"]
+      end
+
       def request_method
         @env['REQUEST_METHOD']
       end
 
-      def inertia_version
+      def client_version
         @env['HTTP_X_INERTIA_VERSION']
       end
 
@@ -73,17 +76,15 @@ module InertiaRails
       end
 
       def version_stale?
-        sent_version != saved_version
+        coerce_version(client_version) != coerce_version(server_version)
       end
 
-      def sent_version
-        return nil if inertia_version.nil?
-
-        InertiaRails.version.is_a?(Numeric) ? inertia_version.to_f : inertia_version
+      def server_version
+        controller.send(:inertia_configuration).version
       end
 
-      def saved_version
-        InertiaRails.version.is_a?(Numeric) ? InertiaRails.version.to_f : InertiaRails.version
+      def coerce_version(version)
+        server_version.is_a?(Numeric) ? version.to_f : version
       end
 
       def force_refresh(request)

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -46,7 +46,8 @@ module InertiaRails
     end
 
     def layout
-      configuration.layout
+      layout = configuration.layout
+      layout.nil? ? true : layout
     end
 
     def shared_data

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -34,9 +34,9 @@ module InertiaRails
     def render_ssr
       uri = URI("#{configuration.ssr_url}/render")
       res = JSON.parse(Net::HTTP.post(uri, page.to_json, 'Content-Type' => 'application/json').body)
-      
-      ::InertiaRails.html_headers = res['head']
-      @render_method.call html: res['body'].html_safe, layout: layout, locals: (view_data).merge({page: page})
+
+      locals = view_data.merge(page: page, inertia_ssr_head: res['head'].join.html_safe)
+      @render_method.call html: res['body'].html_safe, layout: layout, locals: locals
     end
 
     def layout

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -41,8 +41,8 @@ module InertiaRails
       uri = URI("#{configuration.ssr_url}/render")
       res = JSON.parse(Net::HTTP.post(uri, page.to_json, 'Content-Type' => 'application/json').body)
 
-      locals = view_data.merge(page: page, inertia_ssr_head: res['head'].join.html_safe)
-      @render_method.call html: res['body'].html_safe, layout: layout, locals: locals
+      controller.instance_variable_set("@_inertia_ssr_head", res['head'].join.html_safe)
+      @render_method.call html: res['body'].html_safe, layout: layout, locals: view_data.merge(page: page)
     end
 
     def layout

--- a/lib/inertia_rails/rspec.rb
+++ b/lib/inertia_rails/rspec.rb
@@ -65,7 +65,6 @@ RSpec.configure do |config|
   }
 
   config.before(:each, inertia: true) do
-    ::InertiaRails.reset!
     new_renderer = InertiaRails::Renderer.method(:new)
     allow(InertiaRails::Renderer).to receive(:new) do |component, controller, request, response, render, named_args|
       new_renderer.call(component, controller, request, response, inertia_wrap_render(render), **named_args)

--- a/spec/dummy/app/controllers/inertia_conditional_sharing_controller.rb
+++ b/spec/dummy/app/controllers/inertia_conditional_sharing_controller.rb
@@ -1,6 +1,9 @@
 class InertiaConditionalSharingController < ApplicationController
-  before_action :conditionally_share_props, only: [:show]
   inertia_share normal_shared_prop: 1
+
+  inertia_share do
+    {conditionally_shared_show_prop: 1} if action_name == "show"
+  end
 
   def index
     render inertia: 'EmptyTestComponent', props: {
@@ -12,11 +15,5 @@ class InertiaConditionalSharingController < ApplicationController
     render inertia: 'EmptyTestComponent', props: {
       show_only_prop: 1,
     }
-  end
-
-  protected
-
-  def conditionally_share_props
-    self.class.inertia_share conditionally_shared_show_prop: 1
   end
 end

--- a/spec/dummy/app/controllers/inertia_config_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_config_test_controller.rb
@@ -1,6 +1,5 @@
 class InertiaConfigTestController < ApplicationController
   inertia_config(
-    ssr_enabled: true,
     deep_merge_shared_data: true,
     ssr_enabled: true,
     ssr_url: "http://localhost:7777",

--- a/spec/dummy/app/controllers/inertia_config_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_config_test_controller.rb
@@ -4,7 +4,7 @@ class InertiaConfigTestController < ApplicationController
     ssr_enabled: true,
     ssr_url: "http://localhost:7777",
     layout: "test",
-    version: "2.0",
+    version: "1.0",
   )
 
   # Test that modules included in the same class can also call it.
@@ -13,6 +13,6 @@ class InertiaConfigTestController < ApplicationController
   )
 
   def configuration
-    render json: inertia_configuration.to_h
+    render json: inertia_configuration.send(:options)
   end
 end

--- a/spec/dummy/app/controllers/inertia_config_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_config_test_controller.rb
@@ -1,0 +1,14 @@
+class InertiaConfigTestController < ApplicationController
+  inertia_config(
+    ssr_enabled: true,
+    deep_merge_shared_data: true,
+    ssr_enabled: true,
+    ssr_url: "http://localhost:7777",
+    layout: "test",
+    version: "2.0",
+  )
+
+  def configuration
+    render json: inertia_configuration.to_h
+  end
+end

--- a/spec/dummy/app/controllers/inertia_config_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_config_test_controller.rb
@@ -7,6 +7,11 @@ class InertiaConfigTestController < ApplicationController
     version: "2.0",
   )
 
+  # Test that modules included in the same class can also call it.
+  inertia_config(
+    version: "2.0",
+  )
+
   def configuration
     render json: inertia_configuration.to_h
   end

--- a/spec/dummy/app/controllers/inertia_rails_mimic_controller.rb
+++ b/spec/dummy/app/controllers/inertia_rails_mimic_controller.rb
@@ -1,5 +1,7 @@
 class InertiaRailsMimicController < ApplicationController
-  before_action :enable_inertia_default, only: :default_render_test
+  inertia_config(
+    default_render: -> { action_name == "default_render_test" },
+  )
   use_inertia_instance_props
 
   def instance_props_test
@@ -23,11 +25,5 @@ class InertiaRailsMimicController < ApplicationController
 
   def default_component_test
     render inertia: true
-  end
-
-  def enable_inertia_default
-    InertiaRails.configure do |config|
-      config.default_render = true
-    end
   end
 end

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -1,3 +1,3 @@
-<%= inertia_headers %>
+<%= local_assigns[:inertia_ssr_head] %>
 <%= yield %>
-<%= local_assigns.except(:page).to_json.html_safe %>
+<%= local_assigns.except(:page, :inertia_ssr_head).to_json.html_safe %>

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -1,3 +1,3 @@
-<%= local_assigns[:inertia_ssr_head] %>
+<%= inertia_ssr_head %>
 <%= yield %>
 <%= local_assigns.except(:page, :inertia_ssr_head).to_json.html_safe %>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   mount InertiaRails::Engine => "/inertia-rails"
 
+  get 'configuration' => 'inertia_config_test#configuration'
   get 'props' => 'inertia_render_test#props'
   get 'view_data' => 'inertia_render_test#view_data'
   get 'component' => 'inertia_render_test#component'

--- a/spec/inertia/conditional_sharing_spec.rb
+++ b/spec/inertia/conditional_sharing_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "conditionally shared data in a controller", type: :request do
-  context "when there is a before_action inside a inertia_share" do
-    it "does leak data between requests" do
+  context "when there is conditional data inside inertia_share" do
+    it "does not leak data between requests" do
       get conditional_share_index_path, headers: {'X-Inertia' => true}
       expect(JSON.parse(response.body)['props'].deep_symbolize_keys).to eq({
                                                                              index_only_prop: 1,
@@ -22,7 +22,6 @@ RSpec.describe "conditionally shared data in a controller", type: :request do
       expect(JSON.parse(response.body)['props'].deep_symbolize_keys).to eq({
                                                                              index_only_prop: 1,
                                                                              normal_shared_prop: 1,
-                                                                             conditionally_shared_show_prop: 1,
                                                                            })
     end
   end

--- a/spec/inertia/configuration_spec.rb
+++ b/spec/inertia/configuration_spec.rb
@@ -1,6 +1,23 @@
 RSpec.describe 'Inertia configuration', type: :request do
   after { reset_config! }
 
+  describe "InertiaRails::Configuration" do
+    it "does not allow to modify options after frozen" do
+      config = InertiaRails::Configuration.default
+      config.ssr_enabled = true
+      expect(config.ssr_enabled).to eq true
+
+      config.freeze
+      expect { config.ssr_enabled = false }.to raise_error(FrozenError)
+      expect { config.merge!(InertiaRails::Configuration.default) }.to raise_error(FrozenError)
+
+      expect {
+        merged_config = config.merge(InertiaRails::Configuration.default)
+        expect(merged_config.ssr_enabled).to eq false
+      }.not_to raise_error
+    end
+  end
+
   describe 'inertia_config' do
     it 'overrides the global values' do
       get configuration_path

--- a/spec/inertia/configuration_spec.rb
+++ b/spec/inertia/configuration_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe 'Inertia configuration', type: :request do
 
       context 'opting out of a different layout for Inertia' do
         before do
-          InertiaRails.configure {|c| c.layout = nil }
+          InertiaRails.configure {|c| c.layout = true }
         end
 
         it 'uses default layout for controller' do

--- a/spec/inertia/configuration_spec.rb
+++ b/spec/inertia/configuration_spec.rb
@@ -1,6 +1,21 @@
 RSpec.describe 'Inertia configuration', type: :request do
   after { reset_config! }
 
+  describe 'inertia_config' do
+    it 'overrides the global values' do
+      get configuration_path
+
+      expect(response.parsed_body.symbolize_keys).to eq(
+        deep_merge_shared_data: true,
+        default_render: false,
+        layout: "test",
+        ssr_enabled: true,
+        ssr_url: "http://localhost:7777",
+        version: "2.0",
+      )
+    end
+  end
+
   describe '.version' do
     subject { JSON.parse(response.body)['version'] }
 

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'rendering inertia views', type: :request do
   subject { response.body }
 
-  let(:controller) { ApplicationController.new }
+  let(:controller) { ApplicationController.new.tap { |controller| controller.set_request!(request) } }
 
   context 'first load' do
     let(:page) { InertiaRails::Renderer.new('TestComponent', controller, request, response, '').send(:page) }

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -1,7 +1,14 @@
 RSpec.describe 'rendering inertia views', type: :request do
   subject { response.body }
 
-  let(:controller) { double('Controller', inertia_view_assigns: {}, inertia_configuration: InertiaRails.configuration)}
+  let(:controller) {
+    instance_double(
+      InertiaRails::Controller,
+      inertia_view_assigns: {},
+      inertia_configuration: InertiaRails.configuration,
+      inertia_shared_data: {},
+    )
+  }
 
   context 'first load' do
     let(:page) { InertiaRails::Renderer.new('TestComponent', controller, request, response, '').send(:page) }

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'rendering inertia views', type: :request do
   subject { response.body }
 
-  let(:controller) { double('Controller', inertia_view_assigns: {})}
+  let(:controller) { double('Controller', inertia_view_assigns: {}, inertia_configuration: InertiaRails.configuration)}
 
   context 'first load' do
     let(:page) { InertiaRails::Renderer.new('TestComponent', controller, request, response, '').send(:page) }

--- a/spec/inertia/sharing_spec.rb
+++ b/spec/inertia/sharing_spec.rb
@@ -54,52 +54,6 @@ RSpec.describe 'using inertia share when rendering views', type: :request do
     it { is_expected.to eq props.merge({ errors: errors }) }
   end
 
-  context 'multithreaded intertia share' do
-    let(:props) { { name: 'Michael', has_goat_status: true } }
-    it 'is expected to render props even when another thread shares Inertia data' do
-      start_thread1 = false
-      start_thread2 = false
-
-      thread1 = Thread.new do
-        sleep 0.1 until start_thread1
-
-        get share_multithreaded_path, headers: {'X-Inertia' => true}
-        expect(subject).to eq props
-      end
-
-      thread2 = Thread.new do
-        sleep 0.1 until start_thread2
-
-        # Would prefer to make this a second get request, but RSpec will overwrite
-        # the @response variable if another request is made in the second thread.
-        # This simulates the relevant effects of another call to a different
-        # controller with different values for inertia_share
-        InertiaRails.reset!
-        InertiaRails.share(name: 'Brian', has_goat_status: false)
-      end
-
-      # Thread 1 starts. The controller method runs inertia_share, then sleeps.
-      # Thread 2 then modifies the shared inertia data before Thread 1 stops sleeping
-      start_thread1 = true
-      sleep 0.5
-      start_thread2 = true
-
-      # Make sure that both threads finish before the block returns
-      thread1.join
-      thread2.join
-    end
-
-    it 'is expected not to leak shared data across requests' do
-      begin
-        get share_multithreaded_error_path, headers: {'X-Inertia' => true}
-      rescue Exception
-      end
-
-      expect(InertiaRails.shared_plain_data).to be_empty
-      expect(InertiaRails.shared_blocks).to be_empty
-    end
-  end
-
   describe 'deep or shallow merging shared data' do
     context 'with default settings (shallow merge)' do
       describe 'shallow merging by default' do

--- a/spec/inertia/ssr_spec.rb
+++ b/spec/inertia/ssr_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe 'inertia ssr', type: :request do
   context 'ssr is enabled' do
     before do
-      InertiaRails.reset!
       InertiaRails.configure do |config|
         config.ssr_enabled = true
         config.ssr_url = 'ssr-url'


### PR DESCRIPTION
### Description 📖 

This pull request is a complete refactor of the implementation in order to introduce controller-specific configuration.

### `inertia_config`

A new way for controllers to override the global configuration, and provide dynamic values, such as:

```ruby
class PostsController < ApplicationController
  inertia_config(
    ssr_enabled: -> { action_name == "index" },
  )
end
```

Just like `inertia_share`, configuration is inheritable, and subclasses can override values.

In addition, all configuration options can now be procs (before only `version` supported this).

### Performance 🚀 

The implementation of `inertia_share` no longer relies on `before_action`, improving performance when calculating shared data at runtime, and reducing object allocations.

As an additional benefit, we no longer run this code unnecessarily for non-Inertia requests.

### Notes ✏️ 

Each commit is a gradual refactoring, and can be read in isolation (and passes all tests). I'd still suggest using _Squash and Merge_.

We also `freeze` config and shared data to prevent any mutations, ensuring it's safe for multiple threads to access the configuration from the controller class.