### PR TITLE
Set `Vary` header to `X-Inertia` on HTML responses

### DIFF
--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -16,8 +16,8 @@ module InertiaRails
     end
 
     def render
+      @response.set_header('Vary', 'X-Inertia')
       if @request.headers['X-Inertia']
-        @response.set_header('Vary', 'X-Inertia')
         @response.set_header('X-Inertia', 'true')
         @render_method.call json: page, status: @response.status, content_type: Mime[:json]
       else

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -31,6 +31,14 @@ RSpec.describe 'rendering inertia views', type: :request do
       expect(response.status).to eq 200
     end
 
+    it 'has the proper headers' do
+      get component_path
+
+      expect(response.headers['X-Inertia']).to be_nil
+      expect(response.headers['Vary']).to eq 'X-Inertia'
+      expect(response.headers['Content-Type']).to eq 'text/html; charset=utf-8'
+    end
+
     context 'via an inertia route' do
       before { get inertia_route_path }
 


### PR DESCRIPTION
This PR Fixes #124 by setting the `Vary` header to `X-Inertia` on all Inertia responses.

This change brings Rails adapter in line with the Laravel adapter:
https://github.com/inertiajs/inertia-laravel/blob/ddf47e999dcdabd2f370e5b9772a7449f4a81729/src/Middleware.php#L87