### PR TITLE
Inertia.js v2.0 compatibility

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,8 +19,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.1', '3.2', '3.3']
-        rails: ['6.1', '7.0', '7.1', '7.2']
+        ruby: ['3.0', '3.1', '3.2', '3.3']
+        rails: ['6.1', '7.0', '7.1', '7.2', '8.0']
+      exclude:
+        - ruby: '3.0'
+          rails: '8.0'
+        - ruby: '3.1'
+          rails: '8.0'
+        - ruby: '3.0'
+          rails: '7.2'
+        - ruby: '3.1'
+          rails: '7.2'
 
     runs-on: ubuntu-latest
     name: Test against Ruby ${{ matrix.ruby }} / Rails ${{ matrix.rails }}

--- a/README.md
+++ b/README.md
@@ -188,15 +188,12 @@ end
 }
 ```
 
-### Lazy Props
+### Optional Props
 
-On the front end, Inertia supports the concept of "partial reloads" where only the props requested are returned by the server. Sometimes, you may want to use this flow to avoid processing a particularly slow prop on the intial load. In this case, you can use Lazy props. Lazy props aren't evaluated unless they're specifically requested by name in a partial reload.
+On the frontend, Inertia supports the concept of "partial reloads" where only the props requested are returned by the server. Sometimes, you may want to use this flow to avoid processing a particularly slow prop on the initial load. In this case, you can use Optional props. Optional props aren't evaluated unless they're specifically requested by name in a partial reload.
 
 ```ruby
-  inertia_share some_data: InertiaRails.lazy(lambda { some_very_slow_method })
-
-  # Using a Ruby block syntax
-  inertia_share some_data: InertiaRails.lazy { some_very_slow_method }
+  inertia_share some_data: InertiaRails.optional { some_very_slow_method }
 ```
 
 ### Routing
@@ -266,6 +263,14 @@ end
 #### `default_render`
 
   Overrides Rails default rendering behavior to render using Inertia by default.
+
+  __Default__: `false`
+
+#### `encrypt_history`
+
+  When enabled, you instruct Inertia to encrypt your app's history, it uses
+  the browser's built-in [`crypto` api](https://developer.mozilla.org/en-US/docs/Web/API/Crypto)
+  to encrypt the current page's data before pushing it to the history state.
 
   __Default__: `false`
 

--- a/lib/inertia_rails.rb
+++ b/lib/inertia_rails.rb
@@ -16,6 +16,8 @@ ActionController::Renderers.add :inertia do |component, options|
     props: options[:props],
     view_data: options[:view_data],
     deep_merge: options[:deep_merge],
+    encrypt_history: options[:encrypt_history],
+    clear_history: options[:clear_history],
   ).render
 end
 

--- a/lib/inertia_rails/configuration.rb
+++ b/lib/inertia_rails/configuration.rb
@@ -16,6 +16,9 @@ module InertiaRails
       # controller configuration.
       layout: true,
 
+      # Whether to encrypt the history state in the client.
+      encrypt_history: false,
+
       # SSR options.
       ssr_enabled: false,
       ssr_url: 'http://localhost:13714',

--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -123,7 +123,7 @@ module InertiaRails
     end
 
     def redirect_to(options = {}, response_options = {})
-      capture_inertia_errors(response_options)
+      capture_inertia_session_options(response_options)
       super
     end
 
@@ -155,10 +155,11 @@ module InertiaRails
       head :conflict
     end
 
-    def capture_inertia_errors(options)
-      if (inertia_errors = options.dig(:inertia, :errors))
-        session[:inertia_errors] = inertia_errors.to_hash
-      end
+    def capture_inertia_session_options(options)
+      return unless (inertia = options[:inertia])
+
+      session[:inertia_errors] = inertia[:errors].to_hash if inertia[:errors]
+      session[:inertia_clear_history] = inertia[:clear_history] if inertia[:clear_history]
     end
   end
 end

--- a/lib/inertia_rails/defer_prop.rb
+++ b/lib/inertia_rails/defer_prop.rb
@@ -1,0 +1,12 @@
+module InertiaRails
+  class DeferProp < IgnoreOnFirstLoadProp
+    DEFAULT_GROUP = "default".freeze
+
+    attr_reader :group
+
+    def initialize(group: nil, &block)
+      @group = group || DEFAULT_GROUP
+      @block = block
+    end
+  end
+end

--- a/lib/inertia_rails/defer_prop.rb
+++ b/lib/inertia_rails/defer_prop.rb
@@ -1,12 +1,19 @@
+# frozen_string_literal: true
+
 module InertiaRails
   class DeferProp < IgnoreOnFirstLoadProp
-    DEFAULT_GROUP = "default".freeze
+    DEFAULT_GROUP = "default"
 
     attr_reader :group
 
-    def initialize(group: nil, &block)
+    def initialize(group: nil, merge: nil, &block)
       @group = group || DEFAULT_GROUP
+      @merge = merge
       @block = block
+    end
+
+    def merge?
+      @merge
     end
   end
 end

--- a/lib/inertia_rails/ignore_on_first_load_prop.rb
+++ b/lib/inertia_rails/ignore_on_first_load_prop.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module InertiaRails
+  class IgnoreOnFirstLoadProp < BaseProp
+  end
+end

--- a/lib/inertia_rails/inertia_rails.rb
+++ b/lib/inertia_rails/inertia_rails.rb
@@ -1,6 +1,8 @@
 require 'inertia_rails/base_prop'
+require 'inertia_rails/ignore_on_first_load_prop'
 require 'inertia_rails/always_prop'
 require 'inertia_rails/lazy_prop'
+require 'inertia_rails/defer_prop'
 require 'inertia_rails/configuration'
 
 module InertiaRails
@@ -21,6 +23,10 @@ module InertiaRails
 
     def always(&block)
       AlwaysProp.new(&block)
+    end
+
+    def defer(group: nil, &block)
+      DeferProp.new(group:, &block)
     end
   end
 end

--- a/lib/inertia_rails/inertia_rails.rb
+++ b/lib/inertia_rails/inertia_rails.rb
@@ -2,6 +2,7 @@ require 'inertia_rails/base_prop'
 require 'inertia_rails/ignore_on_first_load_prop'
 require 'inertia_rails/always_prop'
 require 'inertia_rails/lazy_prop'
+require 'inertia_rails/optional_prop'
 require 'inertia_rails/defer_prop'
 require 'inertia_rails/merge_prop'
 require 'inertia_rails/configuration'
@@ -20,6 +21,10 @@ module InertiaRails
 
     def lazy(value = nil, &block)
       LazyProp.new(value, &block)
+    end
+
+    def optional(&block)
+      OptionalProp.new(&block)
     end
 
     def always(&block)

--- a/lib/inertia_rails/inertia_rails.rb
+++ b/lib/inertia_rails/inertia_rails.rb
@@ -3,6 +3,7 @@ require 'inertia_rails/ignore_on_first_load_prop'
 require 'inertia_rails/always_prop'
 require 'inertia_rails/lazy_prop'
 require 'inertia_rails/defer_prop'
+require 'inertia_rails/merge_prop'
 require 'inertia_rails/configuration'
 
 module InertiaRails
@@ -25,8 +26,12 @@ module InertiaRails
       AlwaysProp.new(&block)
     end
 
-    def defer(group: nil, &block)
-      DeferProp.new(group:, &block)
+    def merge(&block)
+      MergeProp.new(&block)
+    end
+
+    def defer(group: nil, merge: nil, &block)
+      DeferProp.new(group: group, merge: merge, &block)
     end
   end
 end

--- a/lib/inertia_rails/lazy_prop.rb
+++ b/lib/inertia_rails/lazy_prop.rb
@@ -5,6 +5,10 @@ module InertiaRails
     def initialize(value = nil, &block)
       raise ArgumentError, 'You must provide either a value or a block, not both' if value && block
 
+      InertiaRails.deprecator.warn(
+        "`lazy` is deprecated and will be removed in InertiaRails 4.0, use `optional` instead."
+      )
+
       @value = value
       @block = block
     end

--- a/lib/inertia_rails/lazy_prop.rb
+++ b/lib/inertia_rails/lazy_prop.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module InertiaRails
-  class LazyProp < BaseProp
+  class LazyProp < IgnoreOnFirstLoadProp
     def initialize(value = nil, &block)
       raise ArgumentError, 'You must provide either a value or a block, not both' if value && block
 

--- a/lib/inertia_rails/merge_prop.rb
+++ b/lib/inertia_rails/merge_prop.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module InertiaRails
+  class MergeProp < BaseProp
+    def initialize(*)
+      super
+      @merge = true
+    end
+
+    def merge?
+      @merge
+    end
+  end
+end

--- a/lib/inertia_rails/middleware.rb
+++ b/lib/inertia_rails/middleware.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module InertiaRails
   class Middleware
     def initialize(app)
@@ -20,7 +22,10 @@ module InertiaRails
         request = ActionDispatch::Request.new(@env)
 
         # Inertia errors are added to the session via redirect_to
-        request.session.delete(:inertia_errors) unless keep_inertia_errors?(status)
+        unless keep_inertia_session_options?(status)
+          request.session.delete(:inertia_errors)
+          request.session.delete(:inertia_clear_history)
+        end
 
         status = 303 if inertia_non_post_redirect?(status)
 
@@ -29,7 +34,7 @@ module InertiaRails
 
       private
 
-      def keep_inertia_errors?(status)
+      def keep_inertia_session_options?(status)
         redirect_status?(status) || stale_inertia_request?
       end
 

--- a/lib/inertia_rails/optional_prop.rb
+++ b/lib/inertia_rails/optional_prop.rb
@@ -1,0 +1,4 @@
+module InertiaRails
+  class OptionalProp < IgnoreOnFirstLoadProp
+  end
+end

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -12,9 +12,11 @@ module InertiaRails
       :controller,
       :props,
       :view_data,
+      :encrypt_history,
+      :clear_history
     )
 
-    def initialize(component, controller, request, response, render_method, props: nil, view_data: nil, deep_merge: nil)
+    def initialize(component, controller, request, response, render_method, props: nil, view_data: nil, deep_merge: nil, encrypt_history: nil, clear_history: nil)
       @controller = controller
       @configuration = controller.__send__(:inertia_configuration)
       @component = resolve_component(component)
@@ -24,6 +26,8 @@ module InertiaRails
       @props = props || controller.__send__(:inertia_view_assigns)
       @view_data = view_data || {}
       @deep_merge = !deep_merge.nil? ? deep_merge : configuration.deep_merge_shared_data
+      @encrypt_history = !encrypt_history.nil? ? encrypt_history : configuration.encrypt_history
+      @clear_history = clear_history || controller.session[:inertia_clear_history] || false
     end
 
     def render
@@ -102,6 +106,8 @@ module InertiaRails
         props: computed_props,
         url: @request.original_fullpath,
         version: configuration.version,
+        encryptHistory: encrypt_history,
+        clearHistory: clear_history,
       }
 
       deferred_props = deferred_props_keys

--- a/spec/dummy/app/controllers/inertia_config_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_config_test_controller.rb
@@ -5,6 +5,7 @@ class InertiaConfigTestController < ApplicationController
     ssr_url: "http://localhost:7777",
     layout: "test",
     version: "1.0",
+    encrypt_history: false,
   )
 
   # Test that modules included in the same class can also call it.

--- a/spec/dummy/app/controllers/inertia_encrypt_history_controller.rb
+++ b/spec/dummy/app/controllers/inertia_encrypt_history_controller.rb
@@ -1,0 +1,25 @@
+class InertiaEncryptHistoryController < ApplicationController
+  inertia_config(
+    encrypt_history: -> { action_name != "default_config" }
+  )
+
+  def default_config
+    render inertia: 'TestComponent'
+  end
+
+  def encrypt_history
+    render inertia: 'TestComponent'
+  end
+
+  def override_config
+    render inertia: 'TestComponent', encrypt_history: false
+  end
+
+  def clear_history
+    render inertia: 'TestComponent', clear_history: true
+  end
+
+  def clear_history_after_redirect
+    redirect_to :empty_test, inertia: {clear_history: true}
+  end
+end

--- a/spec/dummy/app/controllers/inertia_render_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_render_test_controller.rb
@@ -63,6 +63,15 @@ class InertiaRenderTestController < ApplicationController
     }
   end
 
+  def merge_props
+    render inertia: 'TestComponent', props: {
+      merge: InertiaRails.merge { 'merge prop' },
+      regular: 'regular prop',
+      deferred_merge: InertiaRails.defer(merge: true) { 'deferred and merge prop'},
+      deferred: InertiaRails.defer { 'deferred' },
+    }
+  end
+
   def deferred_props
     render inertia: 'TestComponent', props: {
       name: 'Brian',

--- a/spec/dummy/app/controllers/inertia_render_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_render_test_controller.rb
@@ -10,10 +10,10 @@ class InertiaRenderTestController < ApplicationController
   def except_props
     render inertia: 'TestComponent', props: {
       flat: 'flat param',
-      lazy: InertiaRails.lazy('lazy param'),
-      nested_lazy: InertiaRails.lazy do
+      optional: InertiaRails.optional { 'optional param' },
+      nested_optional: InertiaRails.optional do
         {
-          first: 'first nested lazy param',
+          first: 'first nested optional param',
         }
       end,
       nested: {
@@ -52,14 +52,22 @@ class InertiaRenderTestController < ApplicationController
     }
   end
 
+  def optional_props
+    render inertia: 'TestComponent', props: {
+      regular: 1,
+      optional: InertiaRails.optional { 1 },
+      another_optional: InertiaRails.optional { 1 },
+    }
+  end
+
   def always_props
     render inertia: 'TestComponent', props: {
       always: InertiaRails.always { 'always prop' },
       regular: 'regular prop',
-      lazy: InertiaRails.lazy do
-        'lazy prop'
+      optional: InertiaRails.optional do
+        'optional prop'
       end,
-      another_lazy: InertiaRails.lazy(->{ 'another lazy prop' })
+      another_optional: InertiaRails.optional { 'another optional prop' }
     }
   end
 

--- a/spec/dummy/app/controllers/inertia_render_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_render_test_controller.rb
@@ -36,7 +36,7 @@ class InertiaRenderTestController < ApplicationController
   end
 
   def vary_header
-    response.headers["Vary"] = 'Accept-Language'
+    response.headers['Vary'] = 'Accept-Language'
 
     render inertia: 'TestComponent'
   end

--- a/spec/dummy/app/controllers/inertia_render_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_render_test_controller.rb
@@ -62,4 +62,15 @@ class InertiaRenderTestController < ApplicationController
       another_lazy: InertiaRails.lazy(->{ 'another lazy prop' })
     }
   end
+
+  def deferred_props
+    render inertia: 'TestComponent', props: {
+      name: 'Brian',
+      sport: InertiaRails.defer(group: 'other') { 'basketball' },
+      level: InertiaRails.defer do
+        'worse than he believes'
+      end,
+      grit: InertiaRails.defer { 'intense' }
+    }
+  end
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -59,4 +59,10 @@ Rails.application.routes.draw do
   get 'conditional_share_show' => 'inertia_conditional_sharing#show'
   get 'conditional_share_edit' => 'inertia_conditional_sharing#edit'
   get 'conditional_share_show_with_a_problem' => 'inertia_conditional_sharing#show_with_a_problem'
+
+  get 'encrypt_history_default_config' => 'inertia_encrypt_history#default_config'
+  get 'encrypt_history_encrypt_history' => 'inertia_encrypt_history#encrypt_history'
+  get 'encrypt_history_override_config' => 'inertia_encrypt_history#override_config'
+  get 'encrypt_history_clear_history' => 'inertia_encrypt_history#clear_history'
+  post 'encrypt_history_clear_history_after_redirect' => 'inertia_encrypt_history#clear_history_after_redirect'
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
   get 'error_500' => 'inertia_test#error_500'
   get 'content_type_test' => 'inertia_test#content_type_test'
   get 'lazy_props' => 'inertia_render_test#lazy_props'
+  get 'optional_props' => 'inertia_render_test#optional_props'
   get 'always_props' => 'inertia_render_test#always_props'
   get 'except_props' => 'inertia_render_test#except_props'
   get 'merge_props' => 'inertia_render_test#merge_props'

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
   get 'lazy_props' => 'inertia_render_test#lazy_props'
   get 'always_props' => 'inertia_render_test#always_props'
   get 'except_props' => 'inertia_render_test#except_props'
+  get 'merge_props' => 'inertia_render_test#merge_props'
   get 'deferred_props' => 'inertia_render_test#deferred_props'
   get 'non_inertiafied' => 'inertia_test#non_inertiafied'
 

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
   get 'lazy_props' => 'inertia_render_test#lazy_props'
   get 'always_props' => 'inertia_render_test#always_props'
   get 'except_props' => 'inertia_render_test#except_props'
+  get 'deferred_props' => 'inertia_render_test#deferred_props'
   get 'non_inertiafied' => 'inertia_test#non_inertiafied'
 
   get 'instance_props_test' => 'inertia_rails_mimic#instance_props_test'

--- a/spec/inertia/configuration_spec.rb
+++ b/spec/inertia/configuration_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe 'Inertia configuration', type: :request do
         ssr_enabled: true,
         ssr_url: "http://localhost:7777",
         version: "2.0",
+        encrypt_history: false,
       )
     end
   end

--- a/spec/inertia/encrypt_history_spec.rb
+++ b/spec/inertia/encrypt_history_spec.rb
@@ -1,0 +1,54 @@
+RSpec.describe 'Inertia encrypt history', type: :request do
+  let(:headers) { {'X-Inertia' => true} }
+
+  context 'with default config' do
+    it 'returns encryptHistory false' do
+      get encrypt_history_default_config_path, headers: headers
+
+      expect(response.parsed_body['encryptHistory']).to eq(false)
+      expect(response.parsed_body['clearHistory']).to eq(false)
+    end
+  end
+
+  context 'with encrypt history config' do
+    it 'returns encryptHistory true' do
+      get encrypt_history_encrypt_history_path, headers: headers
+
+      expect(response.parsed_body['encryptHistory']).to eq(true)
+      expect(response.parsed_body['clearHistory']).to eq(false)
+    end
+  end
+
+  context 'with override config' do
+
+    it 'returns encryptHistory false' do
+      get encrypt_history_override_config_path, headers: headers
+
+      expect(response.parsed_body['encryptHistory']).to eq(false)
+      expect(response.parsed_body['clearHistory']).to eq(false)
+    end
+  end
+
+  context 'with clear history' do
+    it 'returns clearHistory true' do
+      get encrypt_history_clear_history_path, headers: headers
+
+      expect(response.parsed_body['clearHistory']).to eq(true)
+    end
+  end
+
+  context 'with clear history on redirect' do
+    it 'returns clearHistory true after the redirect' do
+      post encrypt_history_clear_history_after_redirect_path, headers: headers
+
+      expect(response.headers['Location']).to eq(empty_test_url)
+      expect(session[:inertia_clear_history]).to eq(true)
+
+      follow_redirect!
+      expect(response.body).to include('&quot;clearHistory&quot;:true')
+
+      get empty_test_path, headers: headers
+      expect(response.parsed_body['clearHistory']).to eq(false)
+    end
+  end
+end

--- a/spec/inertia/lazy_prop_spec.rb
+++ b/spec/inertia/lazy_prop_spec.rb
@@ -1,6 +1,18 @@
 RSpec.describe InertiaRails::LazyProp do
   it_behaves_like 'base prop'
 
+  let(:deprecator) do
+    double(warn: nil).tap do |deprecator|
+      allow(InertiaRails).to receive(:deprecator).and_return(deprecator)
+    end
+  end
+
+  it "is deprecated" do
+    expect(deprecator).to receive(:warn).with("`lazy` is deprecated and will be removed in InertiaRails 4.0, use `optional` instead.")
+
+    described_class.new('value')
+  end
+
   describe '#call' do
     subject(:call) { prop.call(controller) }
     let(:prop) { described_class.new('value') }

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -263,8 +263,8 @@ RSpec.describe 'rendering inertia views', type: :request do
 
     before { get always_props_path, headers: headers }
 
-    it "returns non-optional props on first load" do
-      expect(response.parsed_body["props"]).to eq({"always" => 'always prop', "regular" => 'regular prop' })
+    it 'returns non-optional props on first load' do
+      expect(response.parsed_body['props']).to eq({'always' => 'always prop', 'regular' => 'regular prop' })
     end
 
     context 'with a partial reload' do
@@ -274,8 +274,8 @@ RSpec.describe 'rendering inertia views', type: :request do
         'X-Inertia-Partial-Component' => 'TestComponent',
       }}
 
-      it "returns listed and always props" do
-        expect(response.parsed_body["props"]).to eq({"always" => 'always prop', "optional" => 'optional prop' })
+      it 'returns listed and always props' do
+        expect(response.parsed_body['props']).to eq({'always' => 'always prop', 'optional' => 'optional prop' })
       end
     end
   end
@@ -323,26 +323,24 @@ RSpec.describe 'rendering inertia views', type: :request do
 
   context 'deferred prop rendering' do
     context 'on first load' do
-      let (:page) {
-        InertiaRails::Renderer.new('TestComponent', controller, request, response, '', props: { name: 'Brian', sport: 'basketball', level: 'worse than he believes', grit: 'intense' }).send(:page)
-      }
       let(:headers) { { 'X-Inertia' => true } }
+
       before { get deferred_props_path, headers: headers }
 
-      it "does not include defer props inside props in first load" do
-        expect(JSON.parse(response.body)["props"]).to eq({ "name" => 'Brian' })
+      it 'does not include defer props inside props in first load' do
+        expect(response.parsed_body['props']).to eq({ 'name' => 'Brian' })
       end
 
-      it "returns deferredProps" do
-        expect(JSON.parse(response.body)["deferredProps"]).to eq(
-          "default" => ["level", "grit"],
-          "other" => ["sport"]
+      it 'returns deferredProps' do
+        expect(response.parsed_body['deferredProps']).to eq(
+          'default' => ['level', 'grit'],
+          'other' => ['sport']
         )
       end
     end
 
     context 'with a partial reload' do
-      let (:page) {
+      let(:page) {
         InertiaRails::Renderer.new('TestComponent', controller, request, response, '', props: { sport: 'basketball', level: 'worse than he believes', grit: 'intense' }).send(:page)
       }
       let(:headers) { {
@@ -357,8 +355,8 @@ RSpec.describe 'rendering inertia views', type: :request do
       it { is_expected.to include('intense') }
       it { is_expected.to include('worse') }
       it { is_expected.not_to include('basketball') }
-      it "does not deferredProps key in json" do
-        expect(JSON.parse(response.body)["deferredProps"]).to eq(nil)
+      it 'does not deferredProps key in json' do
+        expect(response.parsed_body['deferredProps']).to eq(nil)
       end
     end
   end

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -253,6 +253,48 @@ RSpec.describe 'rendering inertia views', type: :request do
       end
     end
   end
+
+  context 'deferred prop rendering' do
+    context 'on first load' do
+      let (:page) {
+        InertiaRails::Renderer.new('TestComponent', controller, request, response, '', props: { name: 'Brian', sport: 'basketball', level: 'worse than he believes', grit: 'intense' }).send(:page)
+      }
+      let(:headers) { { 'X-Inertia' => true } }
+      before { get deferred_props_path, headers: headers }
+
+      it "does not include defer props inside props in first load" do
+        expect(JSON.parse(response.body)["props"]).to eq({ "name" => 'Brian' })
+      end
+
+      it "returns deferredProps" do
+        expect(JSON.parse(response.body)["deferredProps"]).to eq(
+          "default" => ["level", "grit"],
+          "other" => ["sport"]
+        )
+      end
+    end
+
+    context 'with a partial reload' do
+      let (:page) {
+        InertiaRails::Renderer.new('TestComponent', controller, request, response, '', props: { sport: 'basketball', level: 'worse than he believes', grit: 'intense' }).send(:page)
+      }
+      let(:headers) { {
+        'X-Inertia' => true,
+        'X-Inertia-Partial-Data' => 'level,grit', # Simulate default group
+        'X-Inertia-Partial-Component' => 'TestComponent',
+      } }
+
+      before { get deferred_props_path, headers: headers }
+
+      it { is_expected.to eq page.to_json }
+      it { is_expected.to include('intense') }
+      it { is_expected.to include('worse') }
+      it { is_expected.not_to include('basketball') }
+      it "does not deferredProps key in json" do
+        expect(JSON.parse(response.body)["deferredProps"]).to eq(nil)
+      end
+    end
+  end
 end
 
 def inertia_div(page)

--- a/spec/inertia/ssr_spec.rb
+++ b/spec/inertia/ssr_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe 'inertia ssr', type: :request do
             props: {name: 'Brandon', sport: 'hockey'},
             url: props_path,
             version: '1.0',
+            encryptHistory: false,
+            clearHistory: false,
           }.to_json,
           'Content-Type' => 'application/json'
         )
@@ -58,6 +60,8 @@ RSpec.describe 'inertia ssr', type: :request do
             props: {name: 'Brandon', sport: 'hockey'},
             url: props_path,
             version: '1.0',
+            encryptHistory: false,
+            clearHistory: false,
           }.to_json,
           'Content-Type' => 'application/json'
         )
@@ -67,7 +71,7 @@ RSpec.describe 'inertia ssr', type: :request do
       it 'renders inertia without ssr as a fallback' do
         get props_path
 
-        expect(response.body).to include '<div id="app" data-page="{&quot;component&quot;:&quot;TestComponent&quot;,&quot;props&quot;:{&quot;name&quot;:&quot;Brandon&quot;,&quot;sport&quot;:&quot;hockey&quot;},&quot;url&quot;:&quot;/props&quot;,&quot;version&quot;:&quot;1.0&quot;}"></div>'
+        expect(response.body).to include '<div id="app" data-page="{&quot;component&quot;:&quot;TestComponent&quot;,&quot;props&quot;:{&quot;name&quot;:&quot;Brandon&quot;,&quot;sport&quot;:&quot;hockey&quot;},&quot;url&quot;:&quot;/props&quot;,&quot;version&quot;:&quot;1.0&quot;,&quot;encryptHistory&quot;:false,&quot;clearHistory&quot;:false}"></div>'
       end
     end
   end


### PR DESCRIPTION
This PR based on work from #121 and #130 and aims to add full Inertia.js v2.0 compatibility (because I want to have a branch to play with the beta 😂).

It includes:

- Encrypt History configuration – based on #121
- `DeferredProp` – from #130
- `OptionalProp` - replacement for deprecated `LazyProp`
- `MergeProp`

Updated documentation: #148

Closes #129
Closes #131