### PR TITLE
Update `README` to address Lazy block syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ On the front end, Inertia supports the concept of "partial reloads" where only t
 
 ```ruby
   inertia_share some_data: InertiaRails.lazy(lambda { some_very_slow_method })
+
+  # Using a Ruby block syntax
+  inertia_share some_data: InertiaRails.lazy { some_very_slow_method }
 ```
 
 ### Routing


### PR DESCRIPTION
👋 Hey all, wanted to make an addition to the documentation for `lazy`. This is often a point of discussion in code review for inertia related PRs since it's not immediately clear in documentation that `lazy` supports a block syntax. Given this is another idiomatic way to pass proc-like behavior in Ruby we feel it should be documented as well.

References to where the block is provided to the Lazy object:

- https://github.com/inertiajs/inertia-rails/blob/6e0fc5a92cafd5e821e6918168260d0e2fbce539/lib/inertia_rails/inertia_rails.rb#L34-L36
- https://github.com/inertiajs/inertia-rails/blob/6e0fc5a92cafd5e821e6918168260d0e2fbce539/lib/inertia_rails/lazy.rb#L24