### PR TITLE
Always return vary header

### DIFF
--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -16,7 +16,7 @@ module InertiaRails
     end
 
     def render
-      @response.set_header('Vary', 'X-Inertia')
+      @response.set_header('Vary', [@request.headers['Vary'], 'X-Inertia'].compact.join(', '))
       if @request.headers['X-Inertia']
         @response.set_header('X-Inertia', 'true')
         @render_method.call json: page, status: @response.status, content_type: Mime[:json]

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -16,8 +16,8 @@ module InertiaRails
     end
 
     def render
+      @response.set_header('Vary', 'X-Inertia')
       if @request.headers['X-Inertia']
-        @response.set_header('Vary', 'X-Inertia')
         @response.set_header('X-Inertia', 'true')
         @render_method.call json: page, status: @response.status, content_type: Mime[:json]
       else

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'rendering inertia views', type: :request do
 
   context 'first load' do
     let(:page) { InertiaRails::Renderer.new('TestComponent', controller, request, response, '').send(:page) }
-    
+
     context 'with props' do
       let(:page) { InertiaRails::Renderer.new('TestComponent', controller, request, response, '', props: {name: 'Brandon', sport: 'hockey'}).send(:page) }
       before { get props_path }
@@ -31,12 +31,26 @@ RSpec.describe 'rendering inertia views', type: :request do
       expect(response.status).to eq 200
     end
 
-    it 'has the proper headers' do
-      get component_path
+    describe 'headers' do
+      context 'when no other Vary header is present' do
+        it 'has the proper headers' do
+          get component_path
 
-      expect(response.headers['X-Inertia']).to be_nil
-      expect(response.headers['Vary']).to eq 'X-Inertia'
-      expect(response.headers['Content-Type']).to eq 'text/html; charset=utf-8'
+          expect(response.headers['X-Inertia']).to be_nil
+          expect(response.headers['Vary']).to eq 'X-Inertia'
+          expect(response.headers['Content-Type']).to eq 'text/html; charset=utf-8'
+        end
+      end
+
+      context 'when another Vary header is present' do
+        it 'has the proper headers' do
+          get component_path, headers: {'Vary' => 'Accept'}
+
+          expect(response.headers['X-Inertia']).to be_nil
+          expect(response.headers['Vary']).to eq 'Accept, X-Inertia'
+          expect(response.headers['Content-Type']).to eq 'text/html; charset=utf-8'
+        end
+      end
     end
 
     context 'via an inertia route' do

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -31,6 +31,14 @@ RSpec.describe 'rendering inertia views', type: :request do
       expect(response.status).to eq 200
     end
 
+    it 'has the proper headers' do
+      get component_path
+
+      expect(response.headers['X-Inertia']).to be_nil
+      expect(response.headers['Vary']).to eq 'X-Inertia'
+      expect(response.headers['Content-Type']).to eq 'text/html; charset=utf-8'
+    end
+
     context 'via an inertia route' do
       before { get inertia_route_path }
 


### PR DESCRIPTION
Adding a commit on top of #128 to append the header instead of overwriting it.

Resolves #124 .