### PR TITLE
Vary Header should not be controlled by the client

### DIFF
--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -16,7 +16,11 @@ module InertiaRails
     end
 
     def render
-      @response.set_header('Vary', [@request.headers['Vary'], 'X-Inertia'].compact.join(', '))
+      if @response.headers["Vary"].blank?
+        @response.headers["Vary"] = 'X-Inertia'
+      else
+        @response.headers["Vary"] = "#{@response.headers["Vary"]}, X-Inertia"
+      end
       if @request.headers['X-Inertia']
         @response.set_header('X-Inertia', 'true')
         @render_method.call json: page, status: @response.status, content_type: Mime[:json]

--- a/spec/dummy/app/controllers/inertia_render_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_render_test_controller.rb
@@ -18,6 +18,12 @@ class InertiaRenderTestController < ApplicationController
     render inertia: 'TestComponent'
   end
 
+  def vary_header
+    response.headers["Vary"] = 'Accept-Language'
+
+    render inertia: 'TestComponent'
+  end
+
   def lazy_props
     render inertia: 'TestComponent', props: {
       name: 'Brian',

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   get 'props' => 'inertia_render_test#props'
   get 'view_data' => 'inertia_render_test#view_data'
   get 'component' => 'inertia_render_test#component'
+  get 'vary_header' => 'inertia_render_test#vary_header'
   get 'share' => 'inertia_share_test#share'
   get 'share_with_inherited' => 'inertia_child_share_test#share_with_inherited'
   get 'empty_test' => 'inertia_test#empty_test'

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -44,10 +44,10 @@ RSpec.describe 'rendering inertia views', type: :request do
 
       context 'when another Vary header is present' do
         it 'has the proper headers' do
-          get component_path, headers: {'Vary' => 'Accept'}
+          get vary_header_path
 
           expect(response.headers['X-Inertia']).to be_nil
-          expect(response.headers['Vary']).to eq 'Accept, X-Inertia'
+          expect(response.headers['Vary']).to eq 'Accept-Language, X-Inertia'
           expect(response.headers['Content-Type']).to eq 'text/html; charset=utf-8'
         end
       end


### PR DESCRIPTION
The Vary header is a way for servers to control caching mechanisms, and it is purely a server-side mechanism. The client does not control or affect the Vary header. Issue #136 introduced logic that does not conform to this: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-semantics-19#section-12.5.5

There are several approaches we can take with the Vary header:
1. Apply the original Laravel plugin logic: force the `Vary: X-Inertia` header.
2. Set the `Vary` header if it wasn't set before, which is the default logic used in Rails: https://github.com/rails/rails/blob/b8720e7cb8c9894d142b8576c21065c92cd1907a/actionpack/lib/action_controller/metal/rendering.rb#L220-L224
3. Append `X-Inertia` if the `Vary` header was set previously, or set the `Vary: X-Inertia` header if it was not.

I believe the third option makes the most sense: it allows users to add other headers, like `Accept-Language`, to the `Vary` list, but it also prevents them from omitting `X-Inertia`.