### PR TITLE
Add specs from config refactor

### DIFF
--- a/inertia_rails.gemspec
+++ b/inertia_rails.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.name          = "inertia_rails"
   spec.version       = InertiaRails::VERSION
   spec.authors       = ["Brian Knoles", "Brandon Shar", "Eugene Granovsky"]
-  spec.email         = ["brain@bellawatt.com", "brandon@bellawatt.com", "eugene@bellawatt.com"]
+  spec.email         = ["brian@bellawatt.com", "brandon@bellawatt.com", "eugene@bellawatt.com"]
 
   spec.summary       = %q{Inertia adapter for Rails}
   spec.homepage      = "https://github.com/inertiajs/inertia-rails"

--- a/spec/dummy/app/controllers/inertia_conditional_sharing_controller.rb
+++ b/spec/dummy/app/controllers/inertia_conditional_sharing_controller.rb
@@ -1,4 +1,6 @@
 class InertiaConditionalSharingController < ApplicationController
+  before_action :conditionally_share_a_prop, only: :show_with_a_problem
+
   inertia_share normal_shared_prop: 1
 
   inertia_share do
@@ -15,5 +17,17 @@ class InertiaConditionalSharingController < ApplicationController
     render inertia: 'EmptyTestComponent', props: {
       show_only_prop: 1,
     }
+  end
+
+  def show_with_a_problem
+    render inertia: 'EmptyTestComponent', props: {
+      show_only_prop: 1,
+    }
+  end
+
+  protected
+
+  def conditionally_share_a_prop
+    self.class.inertia_share incorrectly_conditionally_shared_prop: 1
   end
 end

--- a/spec/dummy/app/controllers/inertia_share_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_share_test_controller.rb
@@ -1,6 +1,7 @@
 class InertiaShareTestController < ApplicationController
   inertia_share name: 'Brandon'
   inertia_share sport: -> { 'hockey' }
+  inertia_share({a_hash: 'also works'})
   inertia_share do
     {
       position: 'center',

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = :none
+  config.action_dispatch.show_exceptions = false
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -50,4 +50,5 @@ Rails.application.routes.draw do
 
   get 'conditional_share_index' => 'inertia_conditional_sharing#index'
   get 'conditional_share_show' => 'inertia_conditional_sharing#show'
+  get 'conditional_share_show_with_a_problem' => 'inertia_conditional_sharing#show_with_a_problem'
 end

--- a/spec/inertia/conditional_sharing_spec.rb
+++ b/spec/inertia/conditional_sharing_spec.rb
@@ -19,10 +19,8 @@ RSpec.describe "conditionally shared data in a controller", type: :request do
 
   context "when there is conditional data shared via before_action" do
     it "raises an error because it is frozen" do
-      # Rails < 7.1 won't raise the error unless we load the controller before the request we actually want to test.
-      #
-      # This can be removed when we drop support for Rails < 7.1.
-      get conditional_share_show_path, headers: {'X-Inertia' => true}
+      # InertiaSharedData isn't frozen until after the first time it's accessed.
+      InertiaConditionalSharingController.send(:_inertia_shared_data)
 
       expect {
         get conditional_share_show_with_a_problem_path, headers: {'X-Inertia' => true}

--- a/spec/inertia/conditional_sharing_spec.rb
+++ b/spec/inertia/conditional_sharing_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe "conditionally shared data in a controller", type: :request do
 
   context "when there is conditional data shared via before_action" do
     it "raises an error because it is frozen" do
+      # Rails < 7.1 won't raise the error unless we load the controller before the request we actually want to test.
+      #
+      # This can be removed when we drop support for Rails < 7.1.
+      get conditional_share_show_path, headers: {'X-Inertia' => true}
+
       expect {
         get conditional_share_show_with_a_problem_path, headers: {'X-Inertia' => true}
       }.to raise_error(FrozenError)

--- a/spec/inertia/conditional_sharing_spec.rb
+++ b/spec/inertia/conditional_sharing_spec.rb
@@ -1,28 +1,27 @@
+# Specs as documentation. Per-action shared data isn't explicity supported,
+# but it can be done by referencing the action name in an inertia_share block.
 RSpec.describe "conditionally shared data in a controller", type: :request do
-  context "when there is conditional data inside inertia_share" do
-    it "does not leak data between requests" do
-      get conditional_share_index_path, headers: {'X-Inertia' => true}
-      expect(JSON.parse(response.body)['props'].deep_symbolize_keys).to eq({
-                                                                             index_only_prop: 1,
-                                                                             normal_shared_prop: 1,
-                                                                           })
-
-      # NOTE: we actually have to run the show action twice since the new implementation
-      # sets up a before_action within a before_action to share the data.
-      # In effect, that means that the shared data isn't rendered until the second time the action is run.
-      get conditional_share_show_path, headers: {'X-Inertia' => true}
+  context "when there is data inside inertia_share only applicable to a single action" do
+    it "does not leak the data between requests" do
       get conditional_share_show_path, headers: {'X-Inertia' => true}
       expect(JSON.parse(response.body)['props'].deep_symbolize_keys).to eq({
-                                                                             normal_shared_prop: 1,
-                                                                             show_only_prop: 1,
-                                                                             conditionally_shared_show_prop: 1,
-                                                                           })
+        normal_shared_prop: 1,
+        show_only_prop: 1,
+        conditionally_shared_show_prop: 1,
+      })
 
       get conditional_share_index_path, headers: {'X-Inertia' => true}
-      expect(JSON.parse(response.body)['props'].deep_symbolize_keys).to eq({
-                                                                             index_only_prop: 1,
-                                                                             normal_shared_prop: 1,
-                                                                           })
+      expect(JSON.parse(response.body)['props'].deep_symbolize_keys).not_to include({
+        conditionally_shared_show_prop: 1,
+      })
+    end
+  end
+
+  context "when there is conditional data shared via before_action" do
+    it "raises an error because it is frozen" do
+      expect {
+        get conditional_share_show_with_a_problem_path, headers: {'X-Inertia' => true}
+      }.to raise_error(FrozenError)
     end
   end
 end

--- a/spec/inertia/request_spec.rb
+++ b/spec/inertia/request_spec.rb
@@ -154,4 +154,12 @@ RSpec.describe 'Inertia::Request', type: :request do
       end
     end
   end
+
+  describe 'a non existent route' do
+    it 'raises a 404 exception' do
+      expect {
+        get '/non_existent_route', headers: { 'X-Inertia' => true }
+      }.to raise_error(ActionController::RoutingError,  /No route matches/)
+    end
+  end
 end

--- a/spec/inertia/sharing_spec.rb
+++ b/spec/inertia/sharing_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'using inertia share when rendering views', type: :request do
   subject { JSON.parse(response.body)['props'].deep_symbolize_keys }
 
   context 'using inertia share' do
-    let(:props) { {name: 'Brandon', sport: 'hockey', position: 'center', number: 29} }
+    let(:props) { {name: 'Brandon', sport: 'hockey', position: 'center', number: 29, a_hash: 'also works'} }
     before { get share_path, headers: {'X-Inertia' => true} }
 
     it { is_expected.to eq props }
@@ -18,7 +18,7 @@ RSpec.describe 'using inertia share when rendering views', type: :request do
   end
 
   context 'using inertia share in subsequent requests' do
-    let(:props) { {name: 'Brandon', sport: 'hockey', position: 'center', number: 29} }
+    let(:props) { {name: 'Brandon', sport: 'hockey', position: 'center', number: 29, a_hash: 'also works'} }
 
     before do
       get share_path, headers: {'X-Inertia' => true}
@@ -29,7 +29,7 @@ RSpec.describe 'using inertia share when rendering views', type: :request do
   end
 
   context 'using inertia share with inheritance' do
-    let(:props) { {name: 'No Longer Brandon', sport: 'hockey', position: 'center', number: 29} }
+    let(:props) { {name: 'No Longer Brandon', sport: 'hockey', position: 'center', number: 29, a_hash: 'also works'} }
 
     before do
       get share_with_inherited_path, headers: {'X-Inertia' => true}
@@ -39,7 +39,7 @@ RSpec.describe 'using inertia share when rendering views', type: :request do
   end
 
   context 'with errors' do
-    let(:props) { {name: 'Brandon', sport: 'hockey', position: 'center', number: 29} }
+    let(:props) { {name: 'Brandon', sport: 'hockey', position: 'center', number: 29, a_hash: 'also works'} }
     let(:errors) { 'rearview mirror is present' }
     before {
       allow_any_instance_of(ActionDispatch::Request).to receive(:session) {


### PR DESCRIPTION
The back and forth on #121 revealed a couple places where we lacked test coverage. I created them locally as I reviewed. 

This PR adds them in so Future Us have them available.