### PR TITLE
Ensure the Props Being Passed Have Been Turned Into a Hash

### DIFF
--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -75,7 +75,8 @@ module InertiaRails
       deep_transform_values(
         _props,
         lambda do |prop|
-          prop.respond_to?(:call) ? controller.instance_exec(&prop) : prop
+          result = prop.respond_to?(:call) ? @controller.instance_exec(&prop) : prop
+          result.respond_to?(:to_hash) ? result.to_hash : result
         end
       )
     end


### PR DESCRIPTION
We encountered a case where we would pass active model errors to the response. This allows objects such as ActiveModel::Errors which can be happily serialized to a hash to be passed directly into the props without calling `to_hash` all of the time.

If the serializer your rails app is using is not :json or :marshal, such as :message_pack, you will encounter an error when passing in an ActiveModel::Errors object since they don't respond to to_msgpack. This also fixes this case by converting the instance to a hash and then allowing our serializer to work successfully without going back to :marshal or :json.