### PR TITLE
Call to_hash On inertia_errors for Session Serialization

### DIFF
--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -109,7 +109,7 @@ module InertiaRails
 
     def capture_inertia_errors(options)
       if (inertia_errors = options.dig(:inertia, :errors))
-        session[:inertia_errors] = inertia_errors
+        session[:inertia_errors] = inertia_errors.to_hash
       end
     end
   end

--- a/spec/dummy/app/controllers/inertia_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_test_controller.rb
@@ -1,3 +1,7 @@
+class MyError
+  def to_hash() { uh: 'oh' } end
+end
+
 class InertiaTestController < ApplicationController
   layout 'conditional', only: [:with_different_layout]
 
@@ -41,6 +45,10 @@ class InertiaTestController < ApplicationController
 
   def redirect_with_inertia_errors
     redirect_to empty_test_path, inertia: { errors: { uh: 'oh' } }
+  end
+
+  def redirect_with_inertia_error_object
+    redirect_to empty_test_path, inertia: { errors: MyError.new }
   end
 
   def redirect_back_with_inertia_errors

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
   get 'share_multithreaded_error' => 'inertia_multithreaded_share#share_multithreaded_error'
   get 'redirect_with_inertia_errors' => 'inertia_test#redirect_with_inertia_errors'
   post 'redirect_with_inertia_errors' => 'inertia_test#redirect_with_inertia_errors'
+  post 'redirect_with_inertia_error_object' => 'inertia_test#redirect_with_inertia_error_object'
   post 'redirect_back_with_inertia_errors' => 'inertia_test#redirect_back_with_inertia_errors'
   get 'error_404' => 'inertia_test#error_404'
   get 'error_500' => 'inertia_test#error_500'

--- a/spec/inertia/response_spec.rb
+++ b/spec/inertia/response_spec.rb
@@ -27,6 +27,15 @@ RSpec.describe 'InertiaRails::Response', type: :request do
           expect(response.headers['Location']).to eq(empty_test_url)
           expect(session[:inertia_errors]).to include({ uh: 'oh' })
         end
+
+        it 'serializes :inertia_errors to the session' do
+          post redirect_with_inertia_error_object_path,
+            headers: { 'X-Inertia' => true }
+
+          expect(response.status).to eq 302
+          expect(response.headers['Location']).to eq(empty_test_url)
+          expect(session[:inertia_errors]).to include({ uh: 'oh' })
+        end
       end
     end
   end


### PR DESCRIPTION
As one can see in the screenshot below, if `ActiveModel::Errors` is passed as the error object, it will be stored in the session. If your `cookie_serializer` is `:json`, `:marshal`, or `:hybrid` this will work fine. However, Rails now uses `:message_pack` and `ActiveModel::Errors` does not respond to `to_msgpack`. This ensures that errors being passed are turned into a hash.

<img width="991" alt="Screenshot 2024-10-25 at 2 40 59 PM" src="https://github.com/user-attachments/assets/242add98-9620-4281-bb8c-4d622a0e89a9">
