### PR TITLE
Allow Default Rendering Behavior to be Customized

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ are automatically disabled for that response. Instance props are only included i
 
 Automatic component name is also opt in, you must set the [`default_render`](#default_render) config value to `true`. Otherwise, you can simply `render inertia: true` for the same behavior explicitly.
 
+If the default component naming doesn't match your convention, you can define a method to resolve it however you like via the `component_path_resolver` config value. The value of this should be callable and will receive the path and action and should return a string component path.
+
+```ruby
+inertia_config(
+  component_path_resolver: ->(path, action) do
+    "Storefront/#{path.camelize}/#{action.camelize}"
+  end
+)
+
+```
+
+
+
 ### Layout 
 
 Inertia layouts use the rails layout convention and can be set or changed in the same way.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ are automatically disabled for that response. Instance props are only included i
 
 Automatic component name is also opt in, you must set the [`default_render`](#default_render) config value to `true`. Otherwise, you can simply `render inertia: true` for the same behavior explicitly.
 
+If the automatic component name doesn't match your convention, you can define a method to transform it. This method is called `inertia_render_transformer` and it will receive your path and action and should return a string component path.
+
+```ruby
+def inertia_render_transformer(path, action)
+   "#{path.camelize}/#{action.camelize}"
+end
+```
+
 ### Layout 
 
 Inertia layouts use the rails layout convention and can be set or changed in the same way.

--- a/README.md
+++ b/README.md
@@ -77,14 +77,6 @@ are automatically disabled for that response. Instance props are only included i
 
 Automatic component name is also opt in, you must set the [`default_render`](#default_render) config value to `true`. Otherwise, you can simply `render inertia: true` for the same behavior explicitly.
 
-If the automatic component name doesn't match your convention, you can define a method to transform it. This method is called `inertia_render_transformer` and it will receive your path and action and should return a string component path.
-
-```ruby
-def inertia_render_transformer(path, action)
-   "#{path.camelize}/#{action.camelize}"
-end
-```
-
 ### Layout 
 
 Inertia layouts use the rails layout convention and can be set or changed in the same way.

--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ are automatically disabled for that response. Instance props are only included i
 
 Automatic component name is also opt in, you must set the [`default_render`](#default_render) config value to `true`. Otherwise, you can simply `render inertia: true` for the same behavior explicitly.
 
-If the default component naming doesn't match your convention, you can define a method to resolve it however you like via the `component_path_resolver` config value. The value of this should be callable and will receive the path and action and should return a string component path.
+If the default component path doesn't match your convention, you can define a method to resolve it however you like via the `component_path_resolver` config value. The value of this should be callable and will receive the path and action and should return a string component path.
 
 ```ruby
 inertia_config(
-  component_path_resolver: ->(path, action) do
+  component_path_resolver: ->(path:, action:) do
     "Storefront/#{path.camelize}/#{action.camelize}"
   end
 )

--- a/lib/inertia_rails/configuration.rb
+++ b/lib/inertia_rails/configuration.rb
@@ -10,7 +10,7 @@ module InertiaRails
       default_render: false,
 
       # Allows the user to hook into the default rendering behavior and change it to fit their needs
-      component_path_resolver: ->(path, action) { "#{path}/#{action}" },
+      component_path_resolver: ->(path:, action:) { "#{path}/#{action}" },
 
       # DEPRECATED: Let Rails decide which layout should be used based on the
       # controller configuration.
@@ -62,8 +62,8 @@ module InertiaRails
       freeze
     end
 
-    def component_path_resolver(path, action)
-      @options[:component_path_resolver].call(path, action)
+    def component_path_resolver(path:, action:)
+      @options[:component_path_resolver].call(path:, action:)
     end
 
     OPTION_NAMES.each do |option|

--- a/lib/inertia_rails/configuration.rb
+++ b/lib/inertia_rails/configuration.rb
@@ -9,9 +9,6 @@ module InertiaRails
       # Overrides Rails default rendering behavior to render using Inertia by default.
       default_render: false,
 
-      # Allows the user to hook into the default rendering behavior and change it to fit their needs
-      render_transformer: ->(path, action) { "#{path}/#{action}" },
-
       # DEPRECATED: Let Rails decide which layout should be used based on the
       # controller configuration.
       layout: true,
@@ -62,14 +59,10 @@ module InertiaRails
       freeze
     end
 
-    def render_transformer(path, action)
-      @options[:render_transformer].call(path, action)
-    end
-
     OPTION_NAMES.each do |option|
       define_method(option) {
         evaluate_option @options[option]
-      } unless method_defined?(option)
+      }
       define_method("#{option}=") { |value|
         @options[option] = value
       }

--- a/lib/inertia_rails/configuration.rb
+++ b/lib/inertia_rails/configuration.rb
@@ -10,7 +10,7 @@ module InertiaRails
       default_render: false,
 
       # Allows the user to hook into the default rendering behavior and change it to fit their needs
-      render_transformer: ->(path, action) { "#{path}/#{action}" },
+      component_path_resolver: ->(path, action) { "#{path}/#{action}" },
 
       # DEPRECATED: Let Rails decide which layout should be used based on the
       # controller configuration.
@@ -62,8 +62,8 @@ module InertiaRails
       freeze
     end
 
-    def render_transformer(path, action)
-      @options[:render_transformer].call(path, action)
+    def component_path_resolver(path, action)
+      @options[:component_path_resolver].call(path, action)
     end
 
     OPTION_NAMES.each do |option|

--- a/lib/inertia_rails/configuration.rb
+++ b/lib/inertia_rails/configuration.rb
@@ -9,6 +9,9 @@ module InertiaRails
       # Overrides Rails default rendering behavior to render using Inertia by default.
       default_render: false,
 
+      # Allows the user to hook into the default rendering behavior and change it to fit their needs
+      render_transformer: ->(path, action) { "#{path}/#{action}" },
+
       # DEPRECATED: Let Rails decide which layout should be used based on the
       # controller configuration.
       layout: true,
@@ -59,10 +62,14 @@ module InertiaRails
       freeze
     end
 
+    def render_transformer(path, action)
+      @options[:render_transformer].call(path, action)
+    end
+
     OPTION_NAMES.each do |option|
       define_method(option) {
         evaluate_option @options[option]
-      }
+      } unless method_defined?(option)
       define_method("#{option}=") { |value|
         @options[option] = value
       }

--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -65,6 +65,10 @@ module InertiaRails
       end
     end
 
+    def inertia_render_transformer(path, action)
+      "#{path}/#{action}"
+    end
+
     def redirect_to(options = {}, response_options = {})
       capture_inertia_errors(response_options)
       super(options, response_options)

--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -65,10 +65,6 @@ module InertiaRails
       end
     end
 
-    def inertia_render_transformer(path, action)
-      "#{path}/#{action}"
-    end
-
     def redirect_to(options = {}, response_options = {})
       capture_inertia_errors(response_options)
       super(options, response_options)

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -110,7 +110,7 @@ module InertiaRails
     def resolve_component(component)
       return component unless component.is_a? TrueClass
 
-      configuration.render_transformer(controller.controller_path, controller.action_name)
+      configuration.component_path_resolver(controller.controller_path, controller.action_name)
     end
   end
 end

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -13,9 +13,9 @@ module InertiaRails
     )
 
     def initialize(component, controller, request, response, render_method, props: nil, view_data: nil, deep_merge: nil)
-      @component = component.is_a?(TrueClass) ? "#{controller.controller_path}/#{controller.action_name}" : component
       @controller = controller
       @configuration = controller.__send__(:inertia_configuration)
+      @component = resolve_component(component)
       @request = request
       @response = response
       @render_method = render_method
@@ -105,6 +105,12 @@ module InertiaRails
 
     def rendering_partial_component?
       @request.inertia_partial? && @request.headers['X-Inertia-Partial-Component'] == component
+    end
+
+    def resolve_component(component)
+      return component unless component.is_a? TrueClass
+
+      configuration.render_transformer(controller.controller_path, controller.action_name)
     end
   end
 end

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -110,7 +110,7 @@ module InertiaRails
     def resolve_component(component)
       return component unless component.is_a? TrueClass
 
-      configuration.render_transformer(controller.controller_path, controller.action_name)
+      controller.inertia_render_transformer(controller.controller_path, controller.action_name)
     end
   end
 end

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -110,7 +110,7 @@ module InertiaRails
     def resolve_component(component)
       return component unless component.is_a? TrueClass
 
-      controller.inertia_render_transformer(controller.controller_path, controller.action_name)
+      configuration.render_transformer(controller.controller_path, controller.action_name)
     end
   end
 end

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -110,7 +110,7 @@ module InertiaRails
     def resolve_component(component)
       return component unless component.is_a? TrueClass
 
-      configuration.component_path_resolver(controller.controller_path, controller.action_name)
+      configuration.component_path_resolver(path: controller.controller_path, action: controller.action_name)
     end
   end
 end

--- a/spec/dummy/app/controllers/transformed_inertia_rails_mimic_controller.rb
+++ b/spec/dummy/app/controllers/transformed_inertia_rails_mimic_controller.rb
@@ -1,0 +1,11 @@
+class TransformedInertiaRailsMimicController < ApplicationController
+  inertia_config(
+    default_render: true,
+    render_transformer: ->(path, action) do
+      "#{path.camelize}/#{action.camelize}"
+    end
+  )
+
+  def render_test
+  end
+end

--- a/spec/dummy/app/controllers/transformed_inertia_rails_mimic_controller.rb
+++ b/spec/dummy/app/controllers/transformed_inertia_rails_mimic_controller.rb
@@ -1,7 +1,7 @@
 class TransformedInertiaRailsMimicController < ApplicationController
   inertia_config(
     default_render: true,
-    render_transformer: ->(path, action) do
+    component_path_resolver: ->(path, action) do
       "#{path.camelize}/#{action.camelize}"
     end
   )

--- a/spec/dummy/app/controllers/transformed_inertia_rails_mimic_controller.rb
+++ b/spec/dummy/app/controllers/transformed_inertia_rails_mimic_controller.rb
@@ -1,11 +1,12 @@
 class TransformedInertiaRailsMimicController < ApplicationController
   inertia_config(
     default_render: true,
-    render_transformer: ->(path, action) do
-      "#{path.camelize}/#{action.camelize}"
-    end
   )
 
   def render_test
+  end
+
+  def inertia_render_transformer(path, action)
+    "#{path.camelize}/#{action.camelize}"
   end
 end

--- a/spec/dummy/app/controllers/transformed_inertia_rails_mimic_controller.rb
+++ b/spec/dummy/app/controllers/transformed_inertia_rails_mimic_controller.rb
@@ -1,12 +1,11 @@
 class TransformedInertiaRailsMimicController < ApplicationController
   inertia_config(
     default_render: true,
+    render_transformer: ->(path, action) do
+      "#{path.camelize}/#{action.camelize}"
+    end
   )
 
   def render_test
-  end
-
-  def inertia_render_transformer(path, action)
-    "#{path.camelize}/#{action.camelize}"
   end
 end

--- a/spec/dummy/app/controllers/transformed_inertia_rails_mimic_controller.rb
+++ b/spec/dummy/app/controllers/transformed_inertia_rails_mimic_controller.rb
@@ -1,7 +1,7 @@
 class TransformedInertiaRailsMimicController < ApplicationController
   inertia_config(
     default_render: true,
-    component_path_resolver: ->(path, action) do
+    component_path_resolver: ->(path:, action:) do
       "#{path.camelize}/#{action.camelize}"
     end
   )

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
 
   get 'instance_props_test' => 'inertia_rails_mimic#instance_props_test'
   get 'default_render_test' => 'inertia_rails_mimic#default_render_test'
+  get 'transformed_default_render_test' => 'transformed_inertia_rails_mimic#render_test'
   get 'default_component_test' => 'inertia_rails_mimic#default_component_test'
   get 'provided_props_test' => 'inertia_rails_mimic#provided_props_test'
 

--- a/spec/inertia/configuration_spec.rb
+++ b/spec/inertia/configuration_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Inertia configuration', type: :request do
     it 'overrides the global values' do
       get configuration_path
 
-      expect(response.parsed_body.symbolize_keys).to eq(
+      expect(response.parsed_body.symbolize_keys).to include(
         deep_merge_shared_data: true,
         default_render: false,
         layout: "test",

--- a/spec/inertia/rails_mimic_spec.rb
+++ b/spec/inertia/rails_mimic_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe 'rendering when mimicking rails behavior', type: :request, inerti
       expect_inertia.to render_component('inertia_rails_mimic/default_render_test')
       expect_inertia.to include_props({'name' => 'Brian'})
     end
+
+    context 'a rendering transformation is provided' do
+      it 'renders based on the transformation' do
+        get transformed_default_render_test_path
+
+        expect_inertia.to render_component('TransformedInertiaRailsMimic/RenderTest')
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Issues #107 and #122 both revolve around our "convention over configuration" not being quite the right convention. Because the convention in question is largely dictated by folder structure and component naming, I think it makes sense for us to be flexible here and allow our default renderer to be transformed.

This PR introduces a new configuration option called `component_path_resolver` that allows users to configure how inertia's default component renderer resolves the component path. For example:

```ruby
inertia_config(
   component_path_resolver: -> (path, action) do
      "Storefront/#{path.camelize}/#{action.camelize}"
   end
)
```

For a controller called `MarketplaceController` with a route called `buy_item`, this would render a component path like `Storefront/Marketplace/BuyItem` instead of our current default behavior of a path like `marketplace/buy_item`
