### PR TITLE
Add Rails 7.2 to the CI matrix

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['3.1', '3.2', '3.3']
-        rails: ['6.1', '7.0', '7.1']
+        rails: ['6.1', '7.0', '7.1', '7.2']
 
     runs-on: ubuntu-latest
     name: Test against Ruby ${{ matrix.ruby }} / Rails ${{ matrix.rails }}

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in inertia-rails.gemspec
 gemspec
 
-version = ENV["RAILS_VERSION"] || "7.1"
+version = ENV["RAILS_VERSION"] || "7.2"
 gem "rails", "~> #{version}.0"

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = Rails.version < '7.1' ? false : :none
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false


### PR DESCRIPTION
This PR adds Rails 7.2 to the CI matrix, makes it the default Rails version for the local development and also updates the test environment since Rails 7.2 dropped support for the outdated `config.action_dispatch.show_exceptions` boolean config values.