### PR TITLE
Respect `raise_on_open_redirects` Rails 7.0+ config

### DIFF
--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -67,16 +67,17 @@ module InertiaRails
 
     def redirect_to(options = {}, response_options = {})
       capture_inertia_errors(response_options)
-      super(options, response_options)
+      super
     end
 
-    def redirect_back(fallback_location:, allow_other_host: true, **options)
+    def redirect_back(**options)
       capture_inertia_errors(options)
-      super(
-        fallback_location: fallback_location,
-        allow_other_host: allow_other_host,
-        **options,
-      )
+      super
+    end
+
+    def redirect_back_or_to(_fallback_location, **options)
+      capture_inertia_errors(options)
+      super
     end
 
     private

--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -70,16 +70,6 @@ module InertiaRails
       super
     end
 
-    def redirect_back(**options)
-      capture_inertia_errors(options)
-      super
-    end
-
-    def redirect_back_or_to(_fallback_location, **options)
-      capture_inertia_errors(options)
-      super
-    end
-
     private
 
     def inertia_view_assigns

--- a/spec/dummy/app/controllers/inertia_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_test_controller.rb
@@ -50,6 +50,13 @@ class InertiaTestController < ApplicationController
     )
   end
 
+  def redirect_back_or_to_with_inertia_errors
+    redirect_back_or_to(
+      empty_test_path,
+      inertia: { errors: { go: 'back!' } }
+    )
+  end
+
   def error_404
     render inertia: 'ErrorComponent', status: 404
   end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
   get 'redirect_with_inertia_errors' => 'inertia_test#redirect_with_inertia_errors'
   post 'redirect_with_inertia_errors' => 'inertia_test#redirect_with_inertia_errors'
   post 'redirect_back_with_inertia_errors' => 'inertia_test#redirect_back_with_inertia_errors'
+  post 'redirect_back_or_to_with_inertia_errors' => 'inertia_test#redirect_back_or_to_with_inertia_errors'
   get 'error_404' => 'inertia_test#error_404'
   get 'error_500' => 'inertia_test#error_500'
   get 'content_type_test' => 'inertia_test#content_type_test'

--- a/spec/inertia/response_spec.rb
+++ b/spec/inertia/response_spec.rb
@@ -39,11 +39,32 @@ RSpec.describe 'InertiaRails::Response', type: :request do
             redirect_back_with_inertia_errors_path,
             headers: {
               'X-Inertia' => true,
-              'HTTP_REFERER' => "http://example.com/current-path"
+              'HTTP_REFERER' => "http://www.example.com/current-path"
             }
           )
           expect(response.status).to eq 302
-          expect(response.headers['Location']).to eq('http://example.com/current-path')
+          expect(response.headers['Location']).to eq('http://www.example.com/current-path')
+          expect(session[:inertia_errors]).to include({ go: 'back!' })
+        end
+      end
+    end
+  end
+
+  describe 'redirect_back_or_to' do
+    context 'with an [:inertia][:errors] option' do
+      context 'with a post request' do
+        it 'adds :inertia_errors to the session' do
+          skip("Requires Rails 7.0 or higher") if Rails.version < '7'
+
+          post(
+            redirect_back_or_to_with_inertia_errors_path,
+            headers: {
+              'X-Inertia' => true,
+              'HTTP_REFERER' => "http://www.example.com/current-path"
+            }
+          )
+          expect(response.status).to eq 302
+          expect(response.headers['Location']).to eq('http://www.example.com/current-path')
           expect(session[:inertia_errors]).to include({ go: 'back!' })
         end
       end


### PR DESCRIPTION
This PR simplifies our redirect patching and makes `redirect_back_or_to` and `redirect_back` respect `raise_on_open_redirects` config which is set to `true` by default starting Rails 7.0
