### PR TITLE
Cleanup gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,11 @@ gemspec
 
 version = ENV["RAILS_VERSION"] || "7.2"
 gem "rails", "~> #{version}.0"
+
+gem "bundler", "~> 2.0"
+gem "rake", "~> 13.0"
+gem "rspec-rails", "~> 6.0"
+gem "rails-controller-testing"
+gem "sqlite3"
+gem "responders"
+gem "debug"

--- a/inertia_rails.gemspec
+++ b/inertia_rails.gemspec
@@ -1,6 +1,6 @@
-lib = File.expand_path("lib", __dir__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "inertia_rails/version"
+# frozen_string_literal: true
+
+require_relative "lib/inertia_rails/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "inertia_rails"
@@ -8,30 +8,22 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Brian Knoles", "Brandon Shar", "Eugene Granovsky"]
   spec.email         = ["brian@bellawatt.com", "brandon@bellawatt.com", "eugene@bellawatt.com"]
 
-  spec.summary       = %q{Inertia adapter for Rails}
+  spec.summary       = "Inertia.js adapter for Rails"
+  spec.description   = "Quickly build modern single-page React, Vue and Svelte apps using classic server-side routing and controllers."
   spec.homepage      = "https://github.com/inertiajs/inertia-rails"
   spec.license       = "MIT"
 
-  spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = spec.homepage
-  spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/master/CHANGELOG.md"
+  spec.metadata = {
+    "bug_tracker_uri" => "#{spec.homepage}/issues",
+    "changelog_uri" => "#{spec.homepage}/blob/master/CHANGELOG.md",
+    "documentation_uri" => "#{spec.homepage}/blob/master/README.md",
+    "homepage_uri" => spec.homepage,
+    "source_code_uri" => spec.homepage,
+    "rubygems_mfa_required" => "true"
+  }
 
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.files = Dir["{app,lib}/**/*", "CHANGELOG.md", "LICENSE.txt", "README.md"]
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "railties", '>= 5'
-
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rspec-rails", "~> 4.0"
-  spec.add_development_dependency "rails-controller-testing"
-  spec.add_development_dependency "sqlite3"
-  spec.add_development_dependency "responders"
-  spec.add_development_dependency "debug"
+  spec.add_runtime_dependency "railties", '>= 6'
 end


### PR DESCRIPTION
This PR cleans up the gemspec:
- removes `.github/` and `/bin` dirs from the release gem
![CleanShot 2024-10-31 at 11 05 05@2x](https://github.com/user-attachments/assets/b6e55f52-0ca2-49e0-a75b-0b2e6eb00f78)
- **opts-in for MFA** https://guides.rubygems.org/mfa-requirement-opt-in/
- adds more metadata
- cleans up gemspec from dev dependencies and moves them to the Gemfile (makes more sense to me to have everything in one place, and we use Gemfile for rails gem matrix setup)