### PR TITLE
Use cleanUrls for docs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -11,6 +11,8 @@ export default defineConfig({
   title,
   description,
 
+  cleanUrls: true,
+
   markdown: {
     config(md) {
       md.use(tabsMarkdownPlugin)
@@ -33,6 +35,7 @@ export default defineConfig({
     ['meta', { property: 'og:image', content: image }],
     ['meta', { property: 'og:description', content: description }],
   ],
+
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
     nav: [

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2624,9 +2624,9 @@
       }
     },
     "node_modules/vitepress": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.4.2.tgz",
-      "integrity": "sha512-10v92Lqx0N4r7YC3cQLBvu+gRS2rHviE7vgdKiwlupUGfSWkyiQDqYccxM5iPStDGSi1Brnec1lf+lmhaQcZXw==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.4.3.tgz",
+      "integrity": "sha512-956c2K2Mr0ubY9bTc2lCJD3g0mgo0mARB1iJC/BqUt4s0AM8Wl60wSU4zbFnzV7X2miFK1XJDKzGZnuEN90umw==",
       "dev": true,
       "dependencies": {
         "@docsearch/css": "^3.6.2",


### PR DESCRIPTION
This PR turns on clean URL generation (without `.html`). It also upgrades vitepress from `v1.4.2` to `v1.4.3`.

See https://vitepress.dev/guide/routing#generating-clean-url