### PR TITLE
Add support for `always` and `except`

### DIFF
--- a/docs/guide/partial-reloads.md
+++ b/docs/guide/partial-reloads.md
@@ -46,9 +46,6 @@ router.visit(url, {
 
 ## Except certain props
 
-> [!WARNING]
-> The `except` option is not yet supported by the Inertia Rails.
-
 :::tabs key:frameworks
 == Vue
 
@@ -236,6 +233,11 @@ class UsersController < ApplicationController
       # OPTIONALLY included on partial reloads
       # ONLY evaluated when needed
       users: InertiaRails.lazy { User.all },
+
+      # ALWAYS included on standard visits
+      # ALWAYS included on partial reloads
+      # ALWAYS evaluated
+      users: InertiaRails.always(User.all),
     }
   end
 end

--- a/docs/guide/partial-reloads.md
+++ b/docs/guide/partial-reloads.md
@@ -201,13 +201,7 @@ On the inverse, you can use the `InertiaRails.always` method to specify that a p
 class UsersController < ApplicationController
   def index
     render inertia: 'Users/Index', props: {
-      users: InertiaRails.always(User.all),
-
-      # Also works with block:
-      # users: InertiaRails.always { User.all },
-
-      # Also works with a lambda:
-      # users: InertiaRails.always(-> { User.all }),
+      users: InertiaRails.always { User.all },
     }
   end
 end

--- a/lib/inertia_rails/always_prop.rb
+++ b/lib/inertia_rails/always_prop.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module InertiaRails
+  class AlwaysProp < BaseProp
+  end
+end

--- a/lib/inertia_rails/base_prop.rb
+++ b/lib/inertia_rails/base_prop.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 module InertiaRails
-  class Lazy
+  # Base class for all props.
+  class BaseProp
     def initialize(value = nil, &block)
       raise ArgumentError, 'You must provide either a value or a block, not both' if value && block
 

--- a/lib/inertia_rails/base_prop.rb
+++ b/lib/inertia_rails/base_prop.rb
@@ -3,19 +3,12 @@
 module InertiaRails
   # Base class for all props.
   class BaseProp
-    def initialize(value = nil, &block)
-      raise ArgumentError, 'You must provide either a value or a block, not both' if value && block
-
-      @value = value
+    def initialize(&block)
       @block = block
     end
 
     def call(controller)
-      value.respond_to?(:call) ? controller.instance_exec(&value) : value
-    end
-
-    def value
-      @value.nil? ? @block : @value
+      controller.instance_exec(&@block)
     end
   end
 end

--- a/lib/inertia_rails/inertia_rails.rb
+++ b/lib/inertia_rails/inertia_rails.rb
@@ -1,5 +1,3 @@
-# Needed for `thread_mattr_accessor`
-require 'active_support/core_ext/module/attribute_accessors_per_thread'
 require 'inertia_rails/lazy'
 require 'inertia_rails/configuration'
 

--- a/lib/inertia_rails/inertia_rails.rb
+++ b/lib/inertia_rails/inertia_rails.rb
@@ -1,18 +1,26 @@
-require 'inertia_rails/lazy'
+require 'inertia_rails/base_prop'
+require 'inertia_rails/always_prop'
+require 'inertia_rails/lazy_prop'
 require 'inertia_rails/configuration'
 
 module InertiaRails
-  CONFIGURATION = Configuration.default
+  class << self
+    CONFIGURATION = Configuration.default
 
-  def self.configure
-    yield(CONFIGURATION)
-  end
+    def configure
+      yield(CONFIGURATION)
+    end
 
-  def self.configuration
-    CONFIGURATION
-  end
+    def configuration
+      CONFIGURATION
+    end
 
-  def self.lazy(value = nil, &block)
-    InertiaRails::Lazy.new(value, &block)
+    def lazy(value = nil, &block)
+      LazyProp.new(value, &block)
+    end
+
+    def always(value = nil, &block)
+      AlwaysProp.new(value, &block)
+    end
   end
 end

--- a/lib/inertia_rails/inertia_rails.rb
+++ b/lib/inertia_rails/inertia_rails.rb
@@ -19,8 +19,8 @@ module InertiaRails
       LazyProp.new(value, &block)
     end
 
-    def always(value = nil, &block)
-      AlwaysProp.new(value, &block)
+    def always(&block)
+      AlwaysProp.new(&block)
     end
   end
 end

--- a/lib/inertia_rails/lazy.rb
+++ b/lib/inertia_rails/lazy.rb
@@ -1,28 +1,20 @@
+# frozen_string_literal: true
+
 module InertiaRails
   class Lazy
     def initialize(value = nil, &block)
+      raise ArgumentError, 'You must provide either a value or a block, not both' if value && block
+
       @value = value
       @block = block
     end
 
-    def call
-      to_proc.call
+    def call(controller)
+      value.respond_to?(:call) ? controller.instance_exec(&value) : value
     end
 
-    def to_proc
-      # This is called by controller.instance_exec, which changes self to the
-      # controller instance. That makes the instance variables unavailable to the
-      # proc via closure. Copying the instance variables to local variables before
-      # the proc is returned keeps them in scope for the returned proc.
-      value = @value
-      block = @block
-      if value.respond_to?(:call)
-        value
-      elsif value
-        Proc.new { value }
-      else
-        block
-      end
+    def value
+      @value.nil? ? @block : @value
     end
   end
 end

--- a/lib/inertia_rails/lazy_prop.rb
+++ b/lib/inertia_rails/lazy_prop.rb
@@ -2,5 +2,19 @@
 
 module InertiaRails
   class LazyProp < BaseProp
+    def initialize(value = nil, &block)
+      raise ArgumentError, 'You must provide either a value or a block, not both' if value && block
+
+      @value = value
+      @block = block
+    end
+
+    def call(controller)
+      value.respond_to?(:call) ? controller.instance_exec(&value) : value
+    end
+
+    def value
+      @value.nil? ? @block : @value
+    end
   end
 end

--- a/lib/inertia_rails/lazy_prop.rb
+++ b/lib/inertia_rails/lazy_prop.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module InertiaRails
+  class LazyProp < BaseProp
+  end
+end

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -76,12 +76,16 @@ module InertiaRails
         end
       end
 
-      deep_transform_values(
-        _props,
-        lambda do |prop|
-          prop.respond_to?(:call) ? controller.instance_exec(&prop) : prop
+      deep_transform_values _props do |prop|
+        case prop
+        when Lazy
+          prop.call(controller)
+        when Proc
+          controller.instance_exec(&prop)
+        else
+          prop
         end
-      )
+      end
     end
 
     def page
@@ -93,10 +97,10 @@ module InertiaRails
       }
     end
 
-    def deep_transform_values(hash, proc)
-      return proc.call(hash) unless hash.is_a? Hash
+    def deep_transform_values(hash, &block)
+      return block.call(hash) unless hash.is_a? Hash
 
-      hash.transform_values {|value| deep_transform_values(value, proc)}
+      hash.transform_values {|value| deep_transform_values(value, &block)}
     end
 
     def partial_keys

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -76,7 +76,7 @@ module InertiaRails
     def computed_props
       _props = merge_props(shared_data, props).select do |key, prop|
         if rendering_partial_component?
-          key.in?(partial_keys) || prop.is_a?(AlwaysProp)
+          partial_keys.none? || key.in?(partial_keys) || prop.is_a?(AlwaysProp)
         else
           !prop.is_a?(LazyProp)
         end
@@ -130,7 +130,7 @@ module InertiaRails
     end
 
     def rendering_partial_component?
-      @request.inertia_partial? && @request.headers['X-Inertia-Partial-Component'] == component
+      @request.headers['X-Inertia-Partial-Component'] == component
     end
 
     def resolve_component(component)

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'net/http'
 require 'json'
 require_relative "inertia_rails"
@@ -70,15 +72,15 @@ module InertiaRails
     def computed_props
       _props = merge_props(shared_data, props).select do |key, prop|
         if rendering_partial_component?
-          key.in? partial_keys
+          key.in?(partial_keys) || prop.is_a?(AlwaysProp)
         else
-          !prop.is_a?(InertiaRails::Lazy)
+          !prop.is_a?(LazyProp)
         end
       end
 
       deep_transform_values _props do |prop|
         case prop
-        when Lazy
+        when BaseProp
           prop.call(controller)
         when Proc
           controller.instance_exec(&prop)

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -78,6 +78,8 @@ module InertiaRails
         end
       end
 
+      drop_partial_except_keys(_props) if rendering_partial_component?
+
       deep_transform_values _props do |prop|
         case prop
         when BaseProp
@@ -105,8 +107,22 @@ module InertiaRails
       hash.transform_values {|value| deep_transform_values(value, &block)}
     end
 
+    def drop_partial_except_keys(hash)
+      partial_except_keys.each do |key|
+        parts = key.to_s.split('.').map(&:to_sym)
+        *initial_keys, last_key = parts
+        current = initial_keys.any? ? hash.dig(*initial_keys) : hash
+
+        current.delete(last_key) if current.is_a?(Hash) && !current[last_key].is_a?(AlwaysProp)
+      end
+    end
+
     def partial_keys
       (@request.headers['X-Inertia-Partial-Data'] || '').split(',').compact.map(&:to_sym)
+    end
+
+    def partial_except_keys
+      (@request.headers['X-Inertia-Partial-Except'] || '').split(',').filter_map(&:to_sym)
     end
 
     def rendering_partial_component?

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -66,7 +66,11 @@ module InertiaRails
     # Functionally, this permits using either string or symbol keys in the controller. Since the results
     # is cast to json, we should treat string/symbol keys as identical.
     def merge_props(shared_data, props)
-      shared_data.deep_symbolize_keys.send(@deep_merge ? :deep_merge : :merge, props.deep_symbolize_keys)
+      if @deep_merge
+        shared_data.deep_symbolize_keys.deep_merge!(props.deep_symbolize_keys)
+      else
+        shared_data.symbolize_keys.merge(props.symbolize_keys)
+      end
     end
 
     def computed_props

--- a/lib/patches/request.rb
+++ b/lib/patches/request.rb
@@ -4,6 +4,6 @@ ActionDispatch::Request.class_eval do
   end
 
   def inertia_partial?
-    key? 'HTTP_X_INERTIA_PARTIAL_DATA'
+    key?('HTTP_X_INERTIA_PARTIAL_COMPONENT')
   end
 end

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -1,2 +1,5 @@
 class ApplicationController < ActionController::Base
+  def controller_method
+    'controller_method value'
+  end
 end

--- a/spec/dummy/app/controllers/inertia_render_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_render_test_controller.rb
@@ -7,6 +7,23 @@ class InertiaRenderTestController < ApplicationController
     }
   end
 
+  def except_props
+    render inertia: 'TestComponent', props: {
+      flat: 'flat param',
+      lazy: InertiaRails.lazy('lazy param'),
+      nested_lazy: InertiaRails.lazy do
+        {
+          first: 'first nested lazy param',
+        }
+      end,
+      nested: {
+        first: 'first nested param',
+        second: 'second nested param'
+      },
+      always: InertiaRails.always('always prop')
+    }
+  end
+
   def view_data
     render inertia: 'TestComponent', view_data: {
       name: 'Brian',
@@ -32,6 +49,17 @@ class InertiaRenderTestController < ApplicationController
         'worse than he believes'
       end,
       grit: InertiaRails.lazy(->{ 'intense' })
+    }
+  end
+
+  def always_props
+    render inertia: 'TestComponent', props: {
+      always: InertiaRails.always('always prop'),
+      regular: 'regular prop',
+      lazy: InertiaRails.lazy do
+        'lazy prop'
+      end,
+      another_lazy: InertiaRails.lazy(->{ 'another lazy prop' })
     }
   end
 end

--- a/spec/dummy/app/controllers/inertia_render_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_render_test_controller.rb
@@ -20,7 +20,7 @@ class InertiaRenderTestController < ApplicationController
         first: 'first nested param',
         second: 'second nested param'
       },
-      always: InertiaRails.always('always prop')
+      always: InertiaRails.always { 'always prop' }
     }
   end
 
@@ -54,7 +54,7 @@ class InertiaRenderTestController < ApplicationController
 
   def always_props
     render inertia: 'TestComponent', props: {
-      always: InertiaRails.always('always prop'),
+      always: InertiaRails.always { 'always prop' },
       regular: 'regular prop',
       lazy: InertiaRails.lazy do
         'lazy prop'

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -30,6 +30,8 @@ Rails.application.routes.draw do
   get 'error_500' => 'inertia_test#error_500'
   get 'content_type_test' => 'inertia_test#content_type_test'
   get 'lazy_props' => 'inertia_render_test#lazy_props'
+  get 'always_props' => 'inertia_render_test#always_props'
+  get 'except_props' => 'inertia_render_test#except_props'
   get 'non_inertiafied' => 'inertia_test#non_inertiafied'
 
   get 'instance_props_test' => 'inertia_rails_mimic#instance_props_test'

--- a/spec/inertia/always_prop_spec.rb
+++ b/spec/inertia/always_prop_spec.rb
@@ -1,0 +1,3 @@
+RSpec.describe InertiaRails::AlwaysProp do
+  it_behaves_like 'base prop'
+end

--- a/spec/inertia/base_prop_spec.rb
+++ b/spec/inertia/base_prop_spec.rb
@@ -1,0 +1,3 @@
+RSpec.describe InertiaRails::BaseProp do
+  it_behaves_like 'base prop'
+end

--- a/spec/inertia/lazy_prop_spec.rb
+++ b/spec/inertia/lazy_prop_spec.rb
@@ -1,0 +1,3 @@
+RSpec.describe InertiaRails::LazyProp do
+  it_behaves_like 'base prop'
+end

--- a/spec/inertia/lazy_prop_spec.rb
+++ b/spec/inertia/lazy_prop_spec.rb
@@ -1,3 +1,35 @@
 RSpec.describe InertiaRails::LazyProp do
   it_behaves_like 'base prop'
+
+  describe '#call' do
+    subject(:call) { prop.call(controller) }
+    let(:prop) { described_class.new('value') }
+    let(:controller) { ApplicationController.new }
+
+    it { is_expected.to eq('value') }
+
+    context 'with false as value' do
+      let(:prop) { described_class.new(false) }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context 'with nil as value' do
+      let(:prop) { described_class.new(nil) }
+
+      it { is_expected.to eq(nil) }
+    end
+
+    context 'with a callable value' do
+      let(:prop) { described_class.new(-> { 'callable' }) }
+
+      it { is_expected.to eq('callable') }
+
+      context 'with dependency on the context of a controller' do
+        let(:prop) { described_class.new(-> { controller_method }) }
+
+        it { is_expected.to eq('controller_method value') }
+      end
+    end
+  end
 end

--- a/spec/inertia/lazy_spec.rb
+++ b/spec/inertia/lazy_spec.rb
@@ -1,20 +1,44 @@
 RSpec.describe InertiaRails::Lazy do
   describe '#call' do
-    context 'with a value' do
-      it 'returns the value' do
-        expect(InertiaRails::Lazy.new('thing').call).to eq('thing')
-      end
-    end
+    subject(:call) { prop.call(controller) }
+    let(:prop) { described_class.new('value') }
+    let(:controller) { ApplicationController.new }
+
+    it { is_expected.to eq('value') }
 
     context 'with a callable value' do
-      it 'returns the result of the callable value' do
-        expect(InertiaRails::Lazy.new(->{ 'thing' }).call).to eq('thing')
+      let(:prop) { described_class.new(-> { 'callable' }) }
+
+      it { is_expected.to eq('callable') }
+
+      context "with false as value" do
+        let(:prop) { described_class.new(false) }
+
+        it { is_expected.to eq(false) }
+      end
+
+      context "with nil as value" do
+        let(:prop) { described_class.new(nil) }
+
+        it { is_expected.to eq(nil) }
+      end
+
+      context "with dependency on the context of a controller" do
+        let(:prop) { described_class.new(-> { controller_method }) }
+
+        it { is_expected.to eq('controller_method value') }
       end
     end
 
     context 'with a block' do
-      it 'returns the result of the block' do
-        expect(InertiaRails::Lazy.new{'thing'}.call).to eq('thing')
+      let(:prop) { described_class.new { 'block' } }
+
+      it { is_expected.to eq('block') }
+
+      context "with dependency on the context of a controller" do
+        let(:prop) { described_class.new { controller_method } }
+
+        it { is_expected.to eq('controller_method value') }
       end
     end
   end

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -132,6 +132,23 @@ RSpec.describe 'rendering inertia views', type: :request do
       )
     end
 
+    context 'when except without X-Inertia-Partial-Data' do
+      let(:headers) {{
+        'X-Inertia' => true,
+        'X-Inertia-Partial-Except' => 'nested',
+        'X-Inertia-Partial-Component' => 'TestComponent',
+      }}
+
+      it 'returns all regular and partial props except excepted' do
+        expect(response.parsed_body['props']).to eq(
+          'flat' => 'flat param',
+          'lazy' => 'lazy param',
+          'always' => 'always prop',
+          'nested_lazy' => { 'first' => 'first nested lazy param' },
+        )
+      end
+    end
+
     context 'when except always prop' do
       let(:headers) {{
         'X-Inertia' => true,

--- a/spec/inertia/request_spec.rb
+++ b/spec/inertia/request_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Inertia::Request', type: :request do
     before { get inertia_partial_request_test_path, headers: headers }
 
     context 'it is a partial inertia call' do
-      let(:headers) { { 'X-Inertia' => true, 'X-Inertia-Partial-Data' => 'foo,bar,baz' } }
+      let(:headers) { { 'X-Inertia' => true, 'X-Inertia-Partial-Component' => 'Component', 'X-Inertia-Partial-Data' => 'foo,bar,baz' } }
 
       it { is_expected.to eq 202 }
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,9 +10,8 @@ require 'debug'
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 # Require the spec/support directory and its subdirectories.
-Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir[Pathname.new(__dir__).join('support', '**', '*.rb')].each { |f| require f }
 
-require_relative './support/helper_module'
 # Add additional requires below this line. Rails is not loaded until this point!
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -1,45 +1,15 @@
 RSpec.shared_examples 'base prop' do
   describe '#call' do
     subject(:call) { prop.call(controller) }
-    let(:prop) { described_class.new('value') }
+    let(:prop) { described_class.new { 'block' } }
     let(:controller) { ApplicationController.new }
 
-    it { is_expected.to eq('value') }
+    it { is_expected.to eq('block') }
 
-    context 'with false as value' do
-      let(:prop) { described_class.new(false) }
+    context 'with dependency on the context of a controller' do
+      let(:prop) { described_class.new { controller_method } }
 
-      it { is_expected.to eq(false) }
-    end
-
-    context 'with nil as value' do
-      let(:prop) { described_class.new(nil) }
-
-      it { is_expected.to eq(nil) }
-    end
-
-    context 'with a callable value' do
-      let(:prop) { described_class.new(-> { 'callable' }) }
-
-      it { is_expected.to eq('callable') }
-
-      context 'with dependency on the context of a controller' do
-        let(:prop) { described_class.new(-> { controller_method }) }
-
-        it { is_expected.to eq('controller_method value') }
-      end
-    end
-
-    context 'with a block' do
-      let(:prop) { described_class.new { 'block' } }
-
-      it { is_expected.to eq('block') }
-
-      context 'with dependency on the context of a controller' do
-        let(:prop) { described_class.new { controller_method } }
-
-        it { is_expected.to eq('controller_method value') }
-      end
+      it { is_expected.to eq('controller_method value') }
     end
   end
 end

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -1,4 +1,4 @@
-RSpec.describe InertiaRails::Lazy do
+RSpec.shared_examples 'base prop' do
   describe '#call' do
     subject(:call) { prop.call(controller) }
     let(:prop) { described_class.new('value') }
@@ -6,24 +6,24 @@ RSpec.describe InertiaRails::Lazy do
 
     it { is_expected.to eq('value') }
 
+    context 'with false as value' do
+      let(:prop) { described_class.new(false) }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context 'with nil as value' do
+      let(:prop) { described_class.new(nil) }
+
+      it { is_expected.to eq(nil) }
+    end
+
     context 'with a callable value' do
       let(:prop) { described_class.new(-> { 'callable' }) }
 
       it { is_expected.to eq('callable') }
 
-      context "with false as value" do
-        let(:prop) { described_class.new(false) }
-
-        it { is_expected.to eq(false) }
-      end
-
-      context "with nil as value" do
-        let(:prop) { described_class.new(nil) }
-
-        it { is_expected.to eq(nil) }
-      end
-
-      context "with dependency on the context of a controller" do
+      context 'with dependency on the context of a controller' do
         let(:prop) { described_class.new(-> { controller_method }) }
 
         it { is_expected.to eq('controller_method value') }
@@ -35,7 +35,7 @@ RSpec.describe InertiaRails::Lazy do
 
       it { is_expected.to eq('block') }
 
-      context "with dependency on the context of a controller" do
+      context 'with dependency on the context of a controller' do
         let(:prop) { described_class.new { controller_method } }
 
         it { is_expected.to eq('controller_method value') }


### PR DESCRIPTION
This PR "upstreams" some features from #132 which are related to Inertia.js 1.x, it includes:

- New `InertiaRails.always` prop from inertia.js 1.3: https://inertiajs.com/partial-reloads#lazy-data-evaluation
- Support for the `except` option from inertia.js 1.3: https://inertiajs.com/partial-reloads#except-certain-props
- Lazy props bug fix: this PR also fixes `InertiaRails.lazy(false)` and `InertiaRails.lazy(nil)` raising errors
- Simplification for lazy props: we don't wrap simple values into procs anymore
- Performance fix for merging props: we don't symbolyze keys deeply anymore when deep merge config is turned off
- `request.inertia_partial?` update: with introduction of the `X-Inertia-Partial-Except` header, `X-Inertia-Partial-Data` is now can be omitted when `router.visit(path, {except: 'foo'})` is called.

PR is intended to be reviewed commit by commit.