### PR TITLE
Partial reload guard rails

### DIFF
--- a/lib/inertia_rails.rb
+++ b/lib/inertia_rails.rb
@@ -25,4 +25,10 @@ module InertiaRails
   def self.deprecator # :nodoc:
     @deprecator ||= ActiveSupport::Deprecation.new
   end
+
+  def self.warn(message)
+    full_message = "[InertiaRails]: WARNING! #{message}"
+    Kernel.warn full_message if Rails.env.development? || Rails.env.test?
+    Rails.logger.warn full_message
+  end
 end

--- a/lib/inertia_rails.rb
+++ b/lib/inertia_rails.rb
@@ -21,6 +21,7 @@ end
 
 module InertiaRails
   class Error < StandardError; end
+  class UnoptimizedPartialReloadError < StandardError; end
 
   def self.deprecator # :nodoc:
     @deprecator ||= ActiveSupport::Deprecation.new

--- a/lib/inertia_rails/configuration.rb
+++ b/lib/inertia_rails/configuration.rb
@@ -22,6 +22,8 @@ module InertiaRails
 
       # Used to detect version drift between server and client.
       version: nil,
+
+      raise_on_unoptimized_partial_reloads: false,
     }.freeze
 
     OPTION_NAMES = DEFAULTS.keys.freeze

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -135,7 +135,11 @@ module InertiaRails
 
         warning_message = "The #{props} #{verb} being computed even though your partial reload did not request #{pronoun}. You might want to wrap these in a callable like a lambda ->{} or InertiaRails::Lazy()."
 
-        InertiaRails.warn warning_message
+        if configuration.raise_on_unoptimized_partial_reloads
+          raise InertiaRails::UnoptimizedPartialReloadError, warning_message
+        else
+          InertiaRails.warn warning_message
+        end
       end
     end
   end

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -68,6 +68,14 @@ module InertiaRails
     end
 
     def computed_props
+      unrequested_value_props = props.select do |key, prop|
+        !prop.respond_to?(:call) && !key.in?(partial_keys)
+      end
+
+      if rendering_partial_component? && unrequested_value_props.present?
+        InertiaRails.warn "The #{unrequested_value_props.keys.map{|k| ":#{k}"}.join(', ')} #{unrequested_value_props.length > 1 ? "props are" : "prop is"} being computed even though your partial reload did not request #{unrequested_value_props.length > 1 ? "them because they are defined as values" : "it because it is defined as a value"}. You might want to wrap these in a callable like a proc or InertiaRails::Lazy()."
+      end
+
       _props = merge_props(shared_data, props).select do |key, prop|
         if rendering_partial_component?
           key.in? partial_keys

--- a/spec/dummy/app/controllers/concerns/searchable.rb
+++ b/spec/dummy/app/controllers/concerns/searchable.rb
@@ -1,0 +1,13 @@
+module Searchable
+  extend ActiveSupport::Concern
+
+  included do
+    inertia_config(raise_on_unoptimized_partial_reloads: true)
+
+    inertia_share do
+      {
+        search: { query: '', results: [] }
+      }
+    end
+  end
+end

--- a/spec/dummy/app/controllers/inertia_has_searchable_controller.rb
+++ b/spec/dummy/app/controllers/inertia_has_searchable_controller.rb
@@ -1,0 +1,9 @@
+class InertiaHasSearchableController < ApplicationController
+  include Searchable
+
+  def index
+    render inertia: 'TestComponent', props: {
+      unrequested_prop: 'This will always compute even when not requested in a partial reload',
+    }
+  end
+end

--- a/spec/dummy/app/controllers/inertia_unoptimized_partial_reloads_controller.rb
+++ b/spec/dummy/app/controllers/inertia_unoptimized_partial_reloads_controller.rb
@@ -1,0 +1,19 @@
+class InertiaUnoptimizedPartialReloadsController < ApplicationController
+  inertia_share search: { query: '', results: [] }
+
+  def index
+    render inertia: 'TestComponent', props: {
+      expensive_prop: expensive_prop,
+    }
+  end
+
+  def with_exception
+    render inertia: 'TestComponent', props: {
+      expensive_prop: expensive_prop,
+    }
+  end
+
+  def expensive_prop
+    'Imagine this is slow to compute'
+  end
+end

--- a/spec/dummy/app/controllers/inertia_unoptimized_partial_reloads_controller.rb
+++ b/spec/dummy/app/controllers/inertia_unoptimized_partial_reloads_controller.rb
@@ -11,6 +11,7 @@ class InertiaUnoptimizedPartialReloadsController < ApplicationController
     render inertia: 'TestComponent', props: {
       expensive_prop: expensive_prop,
       another_expensive_prop: "another one",
+      callable_prop: -> { 'This is a callable prop' },
     }
   end
 

--- a/spec/dummy/app/controllers/inertia_unoptimized_partial_reloads_controller.rb
+++ b/spec/dummy/app/controllers/inertia_unoptimized_partial_reloads_controller.rb
@@ -7,9 +7,10 @@ class InertiaUnoptimizedPartialReloadsController < ApplicationController
     }
   end
 
-  def with_exception
+  def with_multiple
     render inertia: 'TestComponent', props: {
       expensive_prop: expensive_prop,
+      another_expensive_prop: "another one",
     }
   end
 

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -60,4 +60,5 @@ Rails.application.routes.draw do
   get 'unoptimized_partial_reloads' => 'inertia_unoptimized_partial_reloads#index'
   get 'unoptimized_partial_reloads_with_exception' => 'inertia_unoptimized_partial_reloads#with_exception'
   get 'unoptimized_partial_reloads_with_mutiple' => 'inertia_unoptimized_partial_reloads#with_multiple'
+  get 'has_searchable' => 'inertia_has_searchable#index'
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -59,4 +59,5 @@ Rails.application.routes.draw do
 
   get 'unoptimized_partial_reloads' => 'inertia_unoptimized_partial_reloads#index'
   get 'unoptimized_partial_reloads_with_exception' => 'inertia_unoptimized_partial_reloads#with_exception'
+  get 'unoptimized_partial_reloads_with_mutiple' => 'inertia_unoptimized_partial_reloads#with_multiple'
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -56,4 +56,7 @@ Rails.application.routes.draw do
   get 'conditional_share_show' => 'inertia_conditional_sharing#show'
   get 'conditional_share_edit' => 'inertia_conditional_sharing#edit'
   get 'conditional_share_show_with_a_problem' => 'inertia_conditional_sharing#show_with_a_problem'
+
+  get 'unoptimized_partial_reloads' => 'inertia_unoptimized_partial_reloads#index'
+  get 'unoptimized_partial_reloads_with_exception' => 'inertia_unoptimized_partial_reloads#with_exception'
 end

--- a/spec/inertia/partial_reload_spec.rb
+++ b/spec/inertia/partial_reload_spec.rb
@@ -50,6 +50,16 @@ RSpec.describe 'partial reloads', type: :request do
         expect(fake_std_err.messages[0].chomp).to(eq(warn_message))
       end
 
+      it 'does not warn about callable props' do
+        get unoptimized_partial_reloads_path, headers: {
+          'X-Inertia' => true,
+          'X-Inertia-Partial-Data' => 'search',
+          'X-Inertia-Partial-Component' => 'TestComponent',
+        }
+
+        expect(fake_std_err.messages[0].chomp).not_to include('callable_prop')
+      end
+
       context 'when there are multiple non-requested props defined as values' do
         it 'emits a different warning' do
           get unoptimized_partial_reloads_with_mutiple_path, headers: {

--- a/spec/inertia/partial_reload_spec.rb
+++ b/spec/inertia/partial_reload_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe 'partial reloads', type: :request do
     context 'when a non-requested prop is defined as a value' do
       let (:fake_std_err) {FakeStdErr.new}
       let (:warn_message) {'[InertiaRails]: WARNING! The :expensive_prop prop is being computed even though your partial reload did not request it because it is defined as a value. You might want to wrap these in a callable like a proc or InertiaRails::Lazy().'}
+      let (:warn_message_with_multiple) {'[InertiaRails]: WARNING! The :expensive_prop, :another_expensive_prop props are being computed even though your partial reload did not request them because they are defined as values. You might want to wrap these in a callable like a proc or InertiaRails::Lazy().'}
 
       around(:each) do |example|
         begin
@@ -47,6 +48,18 @@ RSpec.describe 'partial reloads', type: :request do
           'X-Inertia-Partial-Component' => 'TestComponent',
         }
         expect(fake_std_err.messages[0].chomp).to(eq(warn_message))
+      end
+
+      context 'when there are multiple non-requested props defined as values' do
+        it 'emits a different warning' do
+          get unoptimized_partial_reloads_with_mutiple_path, headers: {
+            'X-Inertia' => true,
+            'X-Inertia-Partial-Data' => 'search',
+            'X-Inertia-Partial-Component' => 'TestComponent',
+          }
+
+          expect(fake_std_err.messages[0].chomp).to(eq(warn_message_with_multiple))
+        end
       end
     end
   end

--- a/spec/inertia/partial_reload_spec.rb
+++ b/spec/inertia/partial_reload_spec.rb
@@ -1,19 +1,3 @@
-class FakeStdErr
-  attr_accessor :messages
-
-  def initialize
-    @messages = []
-  end
-
-  def write(msg)
-    @messages << msg
-  end
-
-  # Rails 5.0 + Ruby 2.6 require puts to be a public method
-  def puts(thing)
-  end
-end
-
 RSpec.describe 'partial reloads', type: :request do
   describe 'optimization guard rails' do
     context 'when a non-requested prop is defined as a value' do

--- a/spec/inertia/partial_reload_spec.rb
+++ b/spec/inertia/partial_reload_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe 'partial reloads', type: :request do
   describe 'optimization guard rails' do
     context 'when a non-requested prop is defined as a value' do
       let (:fake_std_err) {FakeStdErr.new}
-      let (:warn_message) {'[InertiaRails]: WARNING! The :expensive_prop prop is being computed even though your partial reload did not request it because it is defined as a value. You might want to wrap these in a callable like a proc or InertiaRails::Lazy().'}
-      let (:warn_message_with_multiple) {'[InertiaRails]: WARNING! The :expensive_prop, :another_expensive_prop props are being computed even though your partial reload did not request them because they are defined as values. You might want to wrap these in a callable like a proc or InertiaRails::Lazy().'}
+      let (:warn_message) {'[InertiaRails]: WARNING! The :expensive_prop prop is being computed even though your partial reload did not request it because it is defined as a value. You might want to wrap these in a callable like a lambda ->{} or InertiaRails::Lazy().'}
+      let (:warn_message_with_multiple) {'[InertiaRails]: WARNING! The :expensive_prop, :another_expensive_prop props are being computed even though your partial reload did not request them because they are defined as values. You might want to wrap these in a callable like a lambda ->{} or InertiaRails::Lazy().'}
 
       around(:each) do |example|
         begin

--- a/spec/inertia/partial_reload_spec.rb
+++ b/spec/inertia/partial_reload_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'partial reloads', type: :request do
       end
 
       context 'when the controller is configured to raise_on_unoptimized_partial_reloads' do
-        it 'emits a warning' do
+        it 'raises an error' do
           expect {
             get has_searchable_path, headers: {
               'X-Inertia' => true,

--- a/spec/inertia/partial_reload_spec.rb
+++ b/spec/inertia/partial_reload_spec.rb
@@ -1,0 +1,69 @@
+class FakeStdErr
+  attr_accessor :messages
+
+  def initialize
+    @messages = []
+  end
+
+  def write(msg)
+    @messages << msg
+  end
+
+  # Rails 5.0 + Ruby 2.6 require puts to be a public method
+  def puts(thing)
+  end
+end
+
+RSpec.describe 'partial reloads', type: :request do
+  describe 'optimization guard rails' do
+    context 'when a non-requested prop is defined as a value' do
+      let (:fake_std_err) {FakeStdErr.new}
+      let (:warn_message) {'[InertiaRails]: WARNING! The :expensive_prop prop is being computed even though your partial reload did not request it because it is defined as a value. You might want to wrap these in a callable like a proc or InertiaRails::Lazy().'}
+
+      around(:each) do |example|
+        begin
+          original_stderr = $stderr
+          $stderr         = fake_std_err
+
+          example.run
+        ensure
+          $std_err = original_stderr
+        end
+      end
+
+      it 'only returns the requested prop' do
+        get unoptimized_partial_reloads_path, headers: {
+          'X-Inertia' => true,
+          'X-Inertia-Partial-Data' => 'search',
+          'X-Inertia-Partial-Component' => 'TestComponent',
+        }
+
+        expect(JSON.parse(response.body)['props'].deep_symbolize_keys).to eq({
+          search: {
+            query: '',
+            results: [],
+          },
+        })
+      end
+
+      it 'computes the non-requested prop anyway' do
+        expect_any_instance_of(InertiaUnoptimizedPartialReloadsController).to receive(:expensive_prop).with(any_args)
+
+        get unoptimized_partial_reloads_path, headers: {
+          'X-Inertia' => true,
+          'X-Inertia-Partial-Data' => 'search',
+          'X-Inertia-Partial-Component' => 'TestComponent',
+        }
+      end
+
+      it 'emits a warning' do
+        get unoptimized_partial_reloads_path, headers: {
+          'X-Inertia' => true,
+          'X-Inertia-Partial-Data' => 'search',
+          'X-Inertia-Partial-Component' => 'TestComponent',
+        }
+        expect(fake_std_err.messages[0].chomp).to(eq(warn_message))
+      end
+    end
+  end
+end

--- a/spec/inertia/partial_reload_spec.rb
+++ b/spec/inertia/partial_reload_spec.rb
@@ -61,6 +61,18 @@ RSpec.describe 'partial reloads', type: :request do
           expect(fake_std_err.messages[0].chomp).to(eq(warn_message_with_multiple))
         end
       end
+
+      context 'when the controller is configured to raise_on_unoptimized_partial_reloads' do
+        it 'emits a warning' do
+          expect {
+            get has_searchable_path, headers: {
+              'X-Inertia' => true,
+              'X-Inertia-Partial-Data' => 'search',
+              'X-Inertia-Partial-Component' => 'TestComponent',
+            }
+          }.to raise_error(InertiaRails::UnoptimizedPartialReloadError, /unrequested_prop/)
+        end
+      end
     end
   end
 end

--- a/spec/inertia/rspec_helper_spec.rb
+++ b/spec/inertia/rspec_helper_spec.rb
@@ -1,21 +1,5 @@
 require_relative '../../lib/inertia_rails/rspec'
 
-class FakeStdErr
-  attr_accessor :messages
-
-  def initialize
-    @messages = []
-  end
-
-  def write(msg)
-    @messages << msg
-  end
-
-  # Rails 5.0 + Ruby 2.6 require puts to be a public method
-  def puts(thing)
-  end
-end
-
 RSpec.describe InertiaRails::RSpec, type: :request do
   describe 'correctly set up inertia tests with inertia: true', inertia: true do
     context 'with props' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,6 +13,8 @@ require 'rspec/rails'
 Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 require_relative './support/helper_module'
+require_relative './support/fake_std_error'
+
 # Add additional requires below this line. Rails is not loaded until this point!
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/support/fake_std_error.rb
+++ b/spec/support/fake_std_error.rb
@@ -1,0 +1,15 @@
+class FakeStdErr
+  attr_accessor :messages
+
+  def initialize
+    @messages = []
+  end
+
+  def write(msg)
+    @messages << msg
+  end
+
+  # Rails 5.0 + Ruby 2.6 require puts to be a public method
+  def puts(thing)
+  end
+end


### PR DESCRIPTION
One of our team members (hi @mattdb) raised a good point last week about a rough edge with partial reloading. If you don't wrap your props in callables, you run the risk of unnecessarily computing expensive props even though your response will only include the partial reloaded props. This is [called out in the docs](https://inertia-rails.dev/guide/partial-reloads#lazy-data-evaluation), but Matt pointed out that this gets tricky if you are sharing inertia data in concerns. An unoptimized prop can pretty easily slip through the cracks.

Say you have a search bar that's present on every page. You can drive it via Inertia, and it's a great use case for partial reloading:

```ruby
module Searchable
  extend ActiveSupport::Concern

  included do
    inertia_share do
      {
        search: { query: '', results: [] }
      }
    end
  end
end 

class ThingsController < ApplicationController
  include Searchable

  def index
    render inertia: 'Things/Index', props: { things: Thing.all }
  end
end
```

In this example, `Thing.all` will run every time the app partial reloads `:search`. And it's pretty easy for that to slip by if `Searchable` gets added by a different person than whoever coded up `ThingsController#index`.

I've really like the helpful exceptions that have been added in #121 , #137 and now in #152 . The PR adds something similar to help with the situation described above.

By default, InertiaRails will now emit a warning if it detects 1) a partial reload 2) with prop(s) that weren't requested with the partial reload and aren't callable.

There's also a new config option `raise_on_unoptimized_partial_reloads` which, as it says, will be more aggressive and raise an error if that occurs.

A few things I'm still pondering in the design:

- [ ] Should the config option be an enum instead of a boolean? Something like `:ignore`, `:warn`, `:raise`
- [ ] Maybe it should only raise in development/test? The intent is to be yelled at so you can fix it before it hits prod, but you probably don't want to throw errors at users if `Thing.all` just slows things down a bit
- [ ] Should you be able to configure props to ignore? i.e. `{ some_prop: 'some string' }` isn't worth optimizing.
- [ ] Add to docs (if we decide to merge)