### PR TITLE
Ostruct related spec failures

### DIFF
--- a/spec/inertia/ssr_spec.rb
+++ b/spec/inertia/ssr_spec.rb
@@ -1,4 +1,5 @@
 require 'net/http'
+# require 'ostruct
 
 RSpec.describe 'inertia ssr', type: :request do
   context 'ssr is enabled' do

--- a/spec/inertia/ssr_spec.rb
+++ b/spec/inertia/ssr_spec.rb
@@ -1,5 +1,5 @@
 require 'net/http'
-# require 'ostruct
+require 'ostruct'
 
 RSpec.describe 'inertia ssr', type: :request do
   context 'ssr is enabled' do


### PR DESCRIPTION
Specs from #152 passed just fine until we merged, and then began to [mysteriously fail](https://github.com/inertiajs/inertia-rails/actions/runs/11734988251/job/32692291978). The passing specs from the PR offer a clue:

![image](https://github.com/user-attachments/assets/584e2326-2287-44ad-aee1-8a86abba384f)

It would appear that our test suite was relying on Ruby's json library to load OpenStruct. They [stopped explicitly requiring it](https://github.com/ruby/json/commit/b507f9e404f86df5447b3088eb5ddd57a98317a7) earlier this year. Github Actions' Ruby 3.3.6 (which is now used in the 3.3 part of the test matrix) must be using that version of the library, so it never gets loaded, causing our error.

This PR just requires openstruct to get things working. it won't be included in the Ruby standard library in 3.5.0, so long term we'll either need to add it to the Gemfile or refactor the specs using it to use something like the new `Data` class.