### PR TITLE
Support dot notation for :only keys in partial reloads

### DIFF
--- a/docs/guide/partial-reloads.md
+++ b/docs/guide/partial-reloads.md
@@ -119,6 +119,8 @@ router.visit(url, {
 })
 ```
 
+:::
+
 Please remember that, by design, partial reloading filters props _before_ they are evaluated, so it can only target explicitly defined prop keys. Let's say you have this prop:
 
 `users: -> { User.all }`
@@ -126,8 +128,6 @@ Please remember that, by design, partial reloading filters props _before_ they a
 Requesting `only: ['users.name']` will exclude the entire `users` prop, since `users.name` is not available before evaluating the prop.
 
 Requesting `except: ['users.name']` will not exclude anything.
-
-:::
 
 ## Router shorthand
 

--- a/docs/guide/partial-reloads.md
+++ b/docs/guide/partial-reloads.md
@@ -46,6 +46,8 @@ router.visit(url, {
 
 ## Except certain props
 
+In addition to the only visit option you can also use the except option to specify which data the server should exclude. This option should also be an array of keys which correspond to the keys of the props.
+
 :::tabs key:frameworks
 == Vue
 
@@ -79,7 +81,53 @@ router.visit(url, {
 
 :::
 
-In addition to the only visit option you can also use the except option to specify which data the server should exclude. This option should also be an array of keys which correspond to the keys of the props.
+## Dot notation
+
+Both the `only` and `except` visit options support dot notation to specify nested data, and they can be used together. In the following example, only `settings.theme` will be rendered, but without its `colors` property.
+
+:::tabs key:frameworks
+== Vue
+
+```js
+import { router } from '@inertiajs/vue3'
+
+router.visit(url, {
+  only: ['settings.theme'],
+  except: ['setting.theme.colors'],
+})
+```
+
+== React
+
+```jsx
+import { router } from '@inertiajs/react'
+
+router.visit(url, {
+  only: ['settings.theme'],
+  except: ['setting.theme.colors'],
+})
+```
+
+== Svelte 4|Svelte 5
+
+```js
+import { router } from '@inertiajs/svelte'
+
+router.visit(url, {
+  only: ['settings.theme'],
+  except: ['setting.theme.colors'],
+})
+```
+
+Please remember that, by design, partial reloading filters props _before_ they are evaluated, so it can only target explicitly defined prop keys. Let's say you have this prop:
+
+`users: -> { User.all }`
+
+Requesting `only: ['users.name']` will exclude the entire `users` prop, since `users.name` is not available before evaluating the prop.
+
+Requesting `except: ['users.name']` will not exclude anything.
+
+:::
 
 ## Router shorthand
 

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -105,7 +105,7 @@ module InertiaRails
       props.reduce({}) do |transformed_props, (key, prop)|
         current_path = parent_path + [key]
 
-        if prop.is_a?(Hash)
+        if prop.is_a?(Hash) && prop.any?
           nested = deep_transform_props(prop, current_path, &block)
           transformed_props.merge!(key => nested) unless nested.empty?
         else

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -6,6 +6,9 @@ require_relative "inertia_rails"
 
 module InertiaRails
   class Renderer
+    KEEP_PROP = :keep
+    DONT_KEEP_PROP = :dont_keep
+
     attr_reader(
       :component,
       :configuration,
@@ -77,7 +80,7 @@ module InertiaRails
       _props = merge_props(shared_data, props)
 
       deep_transform_props _props do |prop, path|
-        next [:dont_keep] unless keep_prop?(prop, path)
+        next [DONT_KEEP_PROP] unless keep_prop?(prop, path)
 
         transformed_prop = case prop
         when BaseProp
@@ -88,7 +91,7 @@ module InertiaRails
           prop
         end
 
-        [:keep, transformed_prop]
+        [KEEP_PROP, transformed_prop]
       end
     end
 
@@ -110,7 +113,7 @@ module InertiaRails
           transformed_props.merge!(key => nested) unless nested.empty?
         else
           action, transformed_prop = block.call(prop, current_path)
-          transformed_props.merge!(key => transformed_prop) if action == :keep
+          transformed_props.merge!(key => transformed_prop) if action == KEEP_PROP
         end
 
         transformed_props

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -101,9 +101,9 @@ module InertiaRails
       }
     end
 
-    def deep_transform_props(props, parent_path = '', &block)
+    def deep_transform_props(props, parent_path = [], &block)
       props.reduce({}) do |transformed_props, (key, prop)|
-        current_path = [parent_path, key].reject(&:empty?).join('.')
+        current_path = parent_path + [key]
 
         if prop.is_a?(Hash)
           nested = deep_transform_props(prop, current_path, &block)
@@ -118,11 +118,11 @@ module InertiaRails
     end
 
     def partial_keys
-      (@request.headers['X-Inertia-Partial-Data'] || '').split(',').compact.map(&:to_sym)
+      (@request.headers['X-Inertia-Partial-Data'] || '').split(',').compact
     end
 
     def partial_except_keys
-      (@request.headers['X-Inertia-Partial-Except'] || '').split(',').filter_map(&:to_sym)
+      (@request.headers['X-Inertia-Partial-Except'] || '').split(',').compact
     end
 
     def rendering_partial_component?
@@ -150,19 +150,18 @@ module InertiaRails
       true
     end
 
-    def path_prefixes(path)
-      parts = path.split('.')
+    def path_prefixes(parts)
       (0...parts.length).map do |i|
         parts[0..i].join('.')
       end
     end
 
     def excluded_by_only_partial_keys?(path_with_prefixes)
-      partial_keys.present? && (path_with_prefixes & partial_keys.map(&:to_s)).empty?
+      partial_keys.present? && (path_with_prefixes & partial_keys).empty?
     end
 
     def excluded_by_except_partial_keys?(path_with_prefixes)
-      partial_except_keys.present? && (path_with_prefixes & partial_except_keys.map(&:to_s)).any?
+      partial_except_keys.present? && (path_with_prefixes & partial_except_keys).any?
     end
   end
 end

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -117,22 +117,6 @@ module InertiaRails
       end
     end
 
-    def deep_transform_values(hash, &block)
-      return block.call(hash) unless hash.is_a? Hash
-
-      hash.transform_values {|value| deep_transform_values(value, &block)}
-    end
-
-    def drop_partial_except_keys(hash)
-      partial_except_keys.each do |key|
-        parts = key.to_s.split('.').map(&:to_sym)
-        *initial_keys, last_key = parts
-        current = initial_keys.any? ? hash.dig(*initial_keys) : hash
-
-        current.delete(last_key) if current.is_a?(Hash) && !current[last_key].is_a?(AlwaysProp)
-      end
-    end
-
     def partial_keys
       (@request.headers['X-Inertia-Partial-Data'] || '').split(',').compact.map(&:to_sym)
     end

--- a/spec/dummy/app/controllers/inertia_render_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_render_test_controller.rb
@@ -24,6 +24,30 @@ class InertiaRenderTestController < ApplicationController
     }
   end
 
+  def deeply_nested_props
+    render inertia: 'TestComponent', props: {
+      flat: 'flat param',
+      lazy: InertiaRails.lazy('lazy param'),
+      nested_lazy: InertiaRails.lazy do
+        {
+          first: 'first nested lazy param',
+        }
+      end,
+      nested: {
+        first: 'first nested param',
+        second: 'second nested param',
+        deeply_nested: {
+          first: 'first deeply nested param',
+          second: false,
+          what_about_nil: nil,
+          deeply_nested_always: InertiaRails.always { 'deeply nested always prop' },
+          deeply_nested_lazy: InertiaRails.lazy { 'deeply nested lazy prop' }
+        }
+      },
+      always: InertiaRails.always { 'always prop' }
+    }
+  end
+
   def view_data
     render inertia: 'TestComponent', view_data: {
       name: 'Brian',

--- a/spec/dummy/app/controllers/inertia_render_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_render_test_controller.rb
@@ -36,6 +36,12 @@ class InertiaRenderTestController < ApplicationController
       nested: {
         first: 'first nested param',
         second: 'second nested param',
+        evaluated: -> do
+          {
+            first: 'first evaluated nested param',
+            second: 'second evaluated nested param'
+          }
+        end,
         deeply_nested: {
           first: 'first deeply nested param',
           second: false,

--- a/spec/dummy/app/controllers/inertia_render_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_render_test_controller.rb
@@ -40,6 +40,7 @@ class InertiaRenderTestController < ApplicationController
           first: 'first deeply nested param',
           second: false,
           what_about_nil: nil,
+          what_about_empty_hash: {},
           deeply_nested_always: InertiaRails.always { 'deeply nested always prop' },
           deeply_nested_lazy: InertiaRails.lazy { 'deeply nested lazy prop' }
         }

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
   get 'always_props' => 'inertia_render_test#always_props'
   get 'except_props' => 'inertia_render_test#except_props'
   get 'non_inertiafied' => 'inertia_test#non_inertiafied'
+  get 'deeply_nested_props' => 'inertia_render_test#deeply_nested_props'
 
   get 'instance_props_test' => 'inertia_rails_mimic#instance_props_test'
   get 'default_render_test' => 'inertia_rails_mimic#default_render_test'

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -111,6 +111,32 @@ RSpec.describe 'rendering inertia views', type: :request do
         is_expected.to include('Brandon')
       end
     end
+
+    context 'with dot notation' do
+      let(:headers) do
+        {
+          'X-Inertia' => true,
+          'X-Inertia-Partial-Data' => 'nested.first,nested.deeply_nested.second,nested.deeply_nested.what_about_nil',
+          'X-Inertia-Partial-Component' => 'TestComponent',
+        }
+      end
+
+      before { get deeply_nested_props_path, headers: headers }
+
+      it 'only renders the dot notated props' do
+        expect(response.parsed_body['props']).to eq(
+          'always' => 'always prop',
+          'nested' => {
+            'first' => 'first nested param',
+            'deeply_nested' => {
+              'second' => false,
+              'what_about_nil' => nil,
+              'deeply_nested_always' => 'deeply nested always prop',
+            },
+          },
+        )
+      end
+    end
   end
 
   context 'partial except rendering' do

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -191,6 +191,66 @@ RSpec.describe 'rendering inertia views', type: :request do
         )
       end
     end
+
+    context 'with only props that target transformed data' do
+      let(:headers) do
+        {
+          'X-Inertia' => true,
+          'X-Inertia-Partial-Component' => 'TestComponent',
+          'X-Inertia-Partial-Data' => 'nested.evaluated.first',
+        }
+      end
+
+      before { get deeply_nested_props_path, headers: headers }
+
+      it 'filters out the entire evaluated prop' do
+        expect(response.parsed_body['props']).to eq(
+          'always' => 'always prop',
+          'nested' => {
+            'deeply_nested' => {
+              'deeply_nested_always' => 'deeply nested always prop',
+            },
+          },
+        )
+      end
+    end
+
+    context 'with except props that target transformed data' do
+      let(:headers) do
+        {
+          'X-Inertia' => true,
+          'X-Inertia-Partial-Component' => 'TestComponent',
+          'X-Inertia-Partial-Except' => 'nested.evaluated.first',
+        }
+      end
+
+      before { get deeply_nested_props_path, headers: headers }
+
+      it 'renders the entire evaluated prop' do
+        expect(response.parsed_body['props']).to eq(
+          'always' => 'always prop',
+          'flat' => 'flat param',
+          'lazy' => 'lazy param',
+          'nested_lazy' => { 'first' => 'first nested lazy param' },
+          'nested' => {
+            'first' => 'first nested param',
+            'second' => 'second nested param',
+            'evaluated' => {
+              'first' => 'first evaluated nested param',
+              'second' => 'second evaluated nested param',
+            },
+            'deeply_nested' => {
+              'first' => 'first deeply nested param',
+              'second' => false,
+              'what_about_nil' => nil,
+              'what_about_empty_hash' => {},
+              'deeply_nested_always' => 'deeply nested always prop',
+              'deeply_nested_lazy' => 'deeply nested lazy prop',
+            },
+          },
+        )
+      end
+    end
   end
 
   context 'partial except rendering' do

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe 'rendering inertia views', type: :request do
       let(:headers) do
         {
           'X-Inertia' => true,
-          'X-Inertia-Partial-Data' => 'nested.first,nested.deeply_nested.second,nested.deeply_nested.what_about_nil',
+          'X-Inertia-Partial-Data' => 'nested.first,nested.deeply_nested.second,nested.deeply_nested.what_about_nil,nested.deeply_nested.what_about_empty_hash',
           'X-Inertia-Partial-Component' => 'TestComponent',
         }
       end
@@ -131,6 +131,7 @@ RSpec.describe 'rendering inertia views', type: :request do
             'deeply_nested' => {
               'second' => false,
               'what_about_nil' => nil,
+              'what_about_empty_hash' => {},
               'deeply_nested_always' => 'deeply nested always prop',
             },
           },


### PR DESCRIPTION
Resolves #157 

I also refactored the rendering logic a bit, to:

1. Only traverse the props hash a single time after it's merged with shared props
2. Put the prop filtering logic in a single place

Note: the renderer diff isn't very helpful; better to view the entire file to see how it looks now.

TODO:

- [x] add some more specs to test the interaction of all these crazy prop filtering types 😅
- [x] update docs to explain dot notation