### PR TITLE
Avoid monkey patching

### DIFF
--- a/lib/patches/better_errors.rb
+++ b/lib/patches/better_errors.rb
@@ -4,14 +4,16 @@
 # https://github.com/BetterErrors/better_errors/blob/v2.5.1/lib/better_errors/middleware.rb
 #
 
-if defined?(BetterErrors)
-  BetterErrors::Middleware.class_eval do
-    prepend(InertiaBetterErrors = Module.new do
-      def text?(env)
-        return false if env["HTTP_X_INERTIA"]
+module InertiaRails
+  module InertiaBetterErrors
+    def text?(env)
+      return false if env["HTTP_X_INERTIA"]
 
-        super
-      end
-    end)
+      super
+    end
   end
+end
+
+if defined?(BetterErrors)
+  BetterErrors::Middleware.include InertiaRails::InertiaBetterErrors
 end

--- a/lib/patches/debug_exceptions/patch-5-0.rb
+++ b/lib/patches/debug_exceptions/patch-5-0.rb
@@ -4,8 +4,8 @@
 # https://github.com/rails/rails/blob/5-0-stable/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
 #
 
-ActionDispatch::DebugExceptions.class_eval do
-  prepend(InertiaDebugExceptions = Module.new do
+module InertiaRails
+  module InertiaDebugExceptions
     def render_for_default_application(request, wrapper)
       template = create_template(request, wrapper)
       file = "rescues/#{wrapper.rescue_template}"
@@ -19,5 +19,9 @@ ActionDispatch::DebugExceptions.class_eval do
       end
       render(wrapper.status_code, body, format)
     end
-  end)
+  end
+end
+
+if defined?(ActionDispatch::DebugExceptions)
+  ActionDispatch::DebugExceptions.prepend InertiaRails::InertiaDebugExceptions
 end

--- a/lib/patches/debug_exceptions/patch-5-1.rb
+++ b/lib/patches/debug_exceptions/patch-5-1.rb
@@ -6,8 +6,8 @@
 # https://github.com/rails/rails/blob/6-0-stable/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
 #
 
-ActionDispatch::DebugExceptions.class_eval do
-  prepend(InertiaDebugExceptions = Module.new do
+module InertiaRails
+  module InertiaDebugExceptions
     def render_for_browser_request(request, wrapper)
       template = create_template(request, wrapper)
       file = "rescues/#{wrapper.rescue_template}"
@@ -22,5 +22,9 @@ ActionDispatch::DebugExceptions.class_eval do
 
       render(wrapper.status_code, body, format)
     end
-  end)
+  end
+end
+
+if defined?(ActionDispatch::DebugExceptions)
+  ActionDispatch::DebugExceptions.prepend InertiaRails::InertiaDebugExceptions
 end

--- a/lib/patches/mapper.rb
+++ b/lib/patches/mapper.rb
@@ -1,8 +1,12 @@
-ActionDispatch::Routing::Mapper.class_eval do
-  def inertia(args, &block)
-    route = args.keys.first
-    component = args.values.first
+module InertiaRails
+  module InertiaMapper
+    def inertia(args, &block)
+      route = args.keys.first
+      component = args.values.first
 
-    get(route => 'inertia_rails/static#static', defaults: {component: component})
+      get(route => 'inertia_rails/static#static', defaults: { component: component })
+    end
   end
 end
+
+ActionDispatch::Routing::Mapper.include InertiaRails::InertiaMapper

--- a/lib/patches/request.rb
+++ b/lib/patches/request.rb
@@ -1,9 +1,13 @@
-ActionDispatch::Request.class_eval do
-  def inertia?
-    key? 'HTTP_X_INERTIA'
-  end
+module InertiaRails
+  module InertiaRequest
+    def inertia?
+      key? 'HTTP_X_INERTIA'
+    end
 
-  def inertia_partial?
-    key?('HTTP_X_INERTIA_PARTIAL_COMPONENT')
+    def inertia_partial?
+      key?('HTTP_X_INERTIA_PARTIAL_COMPONENT')
+    end
   end
 end
+
+ActionDispatch::Request.include InertiaRails::InertiaRequest


### PR DESCRIPTION
Refactors the patches directory to leverage Ruby's module prepend mechanism instead of direct `class_eval` calls. This will introduce dedicated modules under the `InertiaRails` namespace that are systematically prepended to their target classes.

This architectural change offers several benefits:

- Improves debugging capabilities through clearer stack traces
- Better encapsulation of Rails core modifications
- More maintainable and predictable method lookup chain

The new approach provides a cleaner separation of concerns while maintaining the same functional behavior of the original implementation.