### PR TITLE
Unoptimized partial reload warnings

### DIFF
--- a/lib/inertia_rails.rb
+++ b/lib/inertia_rails.rb
@@ -21,6 +21,14 @@ end
 
 module InertiaRails
   class Error < StandardError; end
+  class UnoptimizedPartialReload < StandardError
+    attr_reader :paths
+
+    def initialize(paths)
+      @paths = paths
+      super("The #{paths.join(', ')} prop(s) were excluded in a partial reload but still evaluated because they are defined as values.")
+    end
+  end
 
   def self.deprecator # :nodoc:
     @deprecator ||= ActiveSupport::Deprecation.new

--- a/lib/inertia_rails/configuration.rb
+++ b/lib/inertia_rails/configuration.rb
@@ -22,6 +22,8 @@ module InertiaRails
 
       # Used to detect version drift between server and client.
       version: nil,
+
+      action_on_unoptimized_partial_reload: :log,
     }.freeze
 
     OPTION_NAMES = DEFAULTS.keys.freeze

--- a/lib/inertia_rails/engine.rb
+++ b/lib/inertia_rails/engine.rb
@@ -12,5 +12,20 @@ module InertiaRails
         include ::InertiaRails::Controller
       end
     end
+
+    initializer "inertia_rails.subscribe_to_notifications" do
+      if Rails.env.development? || Rails.env.test?
+        ActiveSupport::Notifications.subscribe('inertia_rails.unoptimized_partial_render') do |*args|
+          event = ActiveSupport::Notifications::Event.new(*args)
+
+          message =
+            "InertiaRails: The \"#{event.payload[:paths].join(', ')}\" " \
+          "prop(s) were excluded in a partial reload but still evaluated because they are defined as values. " \
+          "Consider wrapping them in something callable like a lambda."
+
+          Rails.logger.debug(message)
+        end
+      end
+    end
   end
 end

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -87,8 +87,8 @@ module InertiaRails
     end
 
     def prop_transformer
-      @prop_transformer ||= PropTransformer.new(merged_props, controller)
-        .select_transformed { |prop, path| keep_prop?(prop, path) }
+      @prop_transformer ||= PropTransformer.new(controller)
+        .select_transformed(merged_props){ |prop, path| keep_prop?(prop, path) }
     end
 
     def page
@@ -161,16 +161,20 @@ module InertiaRails
     class PropTransformer
       attr_reader :props, :unoptimized_prop_paths
 
-      def initialize(initial_props, controller)
-        @initial_props = initial_props
+      def initialize(controller)
         @controller = controller
         @unoptimized_prop_paths = []
+        @props = {}
       end
 
-      def select_transformed(&block)
-        @props = deep_transform_and_select(@initial_props, &block)
+      def select_transformed(initial_props, &block)
+        @unoptimized_prop_paths = []
+        @props = deep_transform_and_select(initial_props, &block)
+
         self
       end
+
+      private
 
       def deep_transform_and_select(original_props, parent_path = [], &block)
         original_props.reduce({}) do |transformed_props, (key, prop)|

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -149,12 +149,17 @@ module InertiaRails
 
     def validate_partial_reload_optimization
       if prop_transformer.unoptimized_prop_paths.any?
-        ActiveSupport::Notifications.instrument(
-          'inertia_rails.unoptimized_partial_render',
-          paths: prop_transformer.unoptimized_prop_paths,
-          controller: controller,
-          action: controller.action_name,
-        )
+        case configuration.action_on_unoptimized_partial_reload
+        when :log
+          ActiveSupport::Notifications.instrument(
+            'inertia_rails.unoptimized_partial_render',
+            paths: prop_transformer.unoptimized_prop_paths,
+            controller: controller,
+            action: controller.action_name,
+          )
+        when :raise
+          raise InertiaRails::UnoptimizedPartialReload.new(prop_transformer.unoptimized_prop_paths)
+        end
       end
     end
 

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -186,7 +186,7 @@ module InertiaRails
           elsif block.call(prop, current_path)
             transformed_props.merge!(key => transform_prop(prop))
           elsif !prop.respond_to?(:call)
-            @unoptimized_prop_paths << current_path.join(".")
+            track_unoptimized_prop(current_path)
           end
 
           transformed_props
@@ -202,6 +202,10 @@ module InertiaRails
         else
           prop
         end
+      end
+
+      def track_unoptimized_prop(path)
+        @unoptimized_prop_paths << path.join(".")
       end
     end
   end

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -149,12 +149,12 @@ module InertiaRails
 
     def validate_partial_reload_optimization
       if prop_transformer.unoptimized_prop_paths.any?
-        message =
-          "InertiaRails: The \"#{prop_transformer.unoptimized_prop_paths.join(', ')}\" " \
-          "prop(s) were excluded in a partial reload but still evaluated because they are defined as values. " \
-          "Consider wrapping them in something callable like a lambda."
-
-        controller.logger.warn(message)
+        ActiveSupport::Notifications.instrument(
+          'inertia_rails.unoptimized_partial_render',
+          paths: prop_transformer.unoptimized_prop_paths,
+          controller: controller,
+          action: controller.action_name,
+        )
       end
     end
 

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -9,7 +9,7 @@ end
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
-  
+
   config.cache_classes = false
 
   # Do not eager load code on boot. This avoids loading your whole application

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -393,6 +393,31 @@ RSpec.describe 'rendering inertia views', type: :request do
       end
     end
   end
+
+  context 'when there are unoptimized props' do
+    let(:headers) {{
+      'X-Inertia' => true,
+      'X-Inertia-Partial-Data' => 'nested.first',
+      'X-Inertia-Partial-Component' => 'TestComponent',
+    }}
+
+    it 'logs a warning' do
+      expect(Rails.logger).to receive(:warn).with(/flat, nested\.second/)
+      get except_props_path, headers: headers
+    end
+    #flat: 'flat param',
+    #lazy: InertiaRails.lazy('lazy param'),
+    #nested_lazy: InertiaRails.lazy do
+      #{
+        #first: 'first nested lazy param',
+      #}
+    #end,
+    #nested: {
+      #first: 'first nested param',
+      #second: 'second nested param'
+    #},
+    #always: InertiaRails.always { 'always prop' }
+  end
 end
 
 def inertia_div(page)

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -402,7 +402,7 @@ RSpec.describe 'rendering inertia views', type: :request do
     }}
 
     it 'logs a warning' do
-      expect(Rails.logger).to receive(:warn).with(/flat, nested\.second/)
+      expect(Rails.logger).to receive(:debug).with(/flat, nested\.second/)
       get except_props_path, headers: headers
     end
     #flat: 'flat param',

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -393,31 +393,6 @@ RSpec.describe 'rendering inertia views', type: :request do
       end
     end
   end
-
-  context 'when there are unoptimized props' do
-    let(:headers) {{
-      'X-Inertia' => true,
-      'X-Inertia-Partial-Data' => 'nested.first',
-      'X-Inertia-Partial-Component' => 'TestComponent',
-    }}
-
-    it 'logs a warning' do
-      expect(Rails.logger).to receive(:debug).with(/flat, nested\.second/)
-      get except_props_path, headers: headers
-    end
-    #flat: 'flat param',
-    #lazy: InertiaRails.lazy('lazy param'),
-    #nested_lazy: InertiaRails.lazy do
-      #{
-        #first: 'first nested lazy param',
-      #}
-    #end,
-    #nested: {
-      #first: 'first nested param',
-      #second: 'second nested param'
-    #},
-    #always: InertiaRails.always { 'always prop' }
-  end
 end
 
 def inertia_div(page)


### PR DESCRIPTION
I revisited this after:

1. Refactoring the renderer a bit in #163 
2. Perusing the Rails source for the behavior on unpermitted parameters (which is a analogous to this feature IMO)

The refactored renderer was much easier to add this feature to, and I liked Rails' use of ActiveSupport::Notifications for logging/raising errors. So here we are!