### PR TITLE
Fix to_hash called on errors raises an error

### DIFF
--- a/.github/workflows/generators.yml
+++ b/.github/workflows/generators.yml
@@ -45,6 +45,11 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
 
+      - name: Run generator tests
+        run: bundle exec rspec --tag type:generator
+        env:
+          RAILS_VERSION: ${{ matrix.rails }}
+
       - name: Set up Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/generators.yml
+++ b/.github/workflows/generators.yml
@@ -47,8 +47,6 @@ jobs:
 
       - name: Run generator tests
         run: bundle exec rspec --tag type:generator
-        env:
-          RAILS_VERSION: ${{ matrix.rails }}
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -33,8 +33,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.1', '3.2', '3.3']
-        rails: ['6.1', '7.0', '7.1', '7.2']
+        ruby: ['3.0', '3.1', '3.2', '3.3']
+        rails: ['6.1', '7.0', '7.1', '7.2', '8.0']
+        exclude:
+          - ruby: '3.0'
+            rails: '8.0'
+          - ruby: '3.1'
+            rails: '8.0'
+          - ruby: '3.0'
+            rails: '7.2'
+          - ruby: '3.1'
+            rails: '7.2'
 
     runs-on: ubuntu-latest
     name: Test against Ruby ${{ matrix.ruby }} / Rails ${{ matrix.rails }}
@@ -54,6 +63,9 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          # Use the latest version of RubyGems with Ruby 3.0 to avoid:
+          # https://bugs.ruby-lang.org/issues/19371
+          rubygems: ${{ startsWith(matrix.ruby-version, '3.0') && 'latest' || 'default' }}
           bundler-cache: true
         env:
           RAILS_VERSION:  ${{ matrix.rails }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -59,6 +59,6 @@ jobs:
           RAILS_VERSION:  ${{ matrix.rails }}
 
       - name: Run tests
-        run: bundle exec rspec
+        run: bundle exec rspec --tag ~type:generator
         env:
           RAILS_VERSION: ${{ matrix.rails }}

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in inertia_rails.gemspec
 gemspec
 
-version = ENV['RAILS_VERSION'] || '7.2'
+version = ENV['RAILS_VERSION'] || '8.0'
 gem 'rails', "~> #{version}.0"
 
 gem 'bundler', '~> 2.0'

--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -157,7 +157,14 @@ module InertiaRails
 
     def capture_inertia_errors(options)
       if (inertia_errors = options.dig(:inertia, :errors))
-        session[:inertia_errors] = inertia_errors.to_hash
+        if inertia_errors.respond_to?(:to_hash)
+          session[:inertia_errors] = inertia_errors.to_hash
+        else
+          InertiaRails.deprecator.warn(
+            "Object passed to `inertia: { errors: ... }` must respond to `to_hash`. Pass a hash-like object instead."
+          )
+          session[:inertia_errors] = inertia_errors
+        end
       end
     end
   end

--- a/spec/dummy/app/controllers/inertia_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_test_controller.rb
@@ -47,6 +47,10 @@ class InertiaTestController < ApplicationController
     redirect_to empty_test_path, inertia: { errors: { uh: 'oh' } }
   end
 
+  def redirect_with_non_hash_inertia_errors
+    redirect_to empty_test_path, inertia: { errors: 'uh oh' }
+  end
+
   def redirect_with_inertia_error_object
     redirect_to empty_test_path, inertia: { errors: MyError.new }
   end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
   get 'redirect_with_inertia_errors' => 'inertia_test#redirect_with_inertia_errors'
   post 'redirect_with_inertia_errors' => 'inertia_test#redirect_with_inertia_errors'
   post 'redirect_with_inertia_error_object' => 'inertia_test#redirect_with_inertia_error_object'
+  post 'redirect_with_non_hash_inertia_errors' => 'inertia_test#redirect_with_non_hash_inertia_errors'
   post 'redirect_back_with_inertia_errors' => 'inertia_test#redirect_back_with_inertia_errors'
   post 'redirect_back_or_to_with_inertia_errors' => 'inertia_test#redirect_back_or_to_with_inertia_errors'
   get 'error_404' => 'inertia_test#error_404'

--- a/spec/inertia/error_sharing_spec.rb
+++ b/spec/inertia/error_sharing_spec.rb
@@ -17,6 +17,18 @@ RSpec.describe 'errors shared automatically', type: :request do
       expect(session[:inertia_errors]).not_to be
     end
 
+    it 'accepts a non-hash error object' do
+      expect { post redirect_with_non_hash_inertia_errors_path, headers: headers }
+        .to output(/Object passed to `inertia: { errors: ... }` must respond to `to_hash`/).to_stderr
+      expect(response.headers['Location']).to eq(empty_test_url)
+      expect(session[:inertia_errors]).to eq('uh oh')
+
+      # Follow the redirect
+      get response.headers['Location'], headers: headers
+      expect(response.body).to include({ errors: 'uh oh' }.to_json)
+      expect(session[:inertia_errors]).not_to be
+    end
+
     it 'keeps errors around when the post has a stale version' do
       post redirect_with_inertia_errors_path, headers: headers
       expect(response.headers['Location']).to eq(empty_test_url)


### PR DESCRIPTION
Fixes #166 and adds a deprecation warning to prepare for requiring hashes in a future major update.