### PR TITLE
Add note about X-XSRF-TOKEN header

### DIFF
--- a/docs/guide/csrf-protection.md
+++ b/docs/guide/csrf-protection.md
@@ -57,6 +57,9 @@ Axios automatically checks for the existence of an `XSRF-TOKEN` cookie. If it's 
 
 The easiest way to implement this is using server-side middleware. Simply include the `XSRF-TOKEN` cookie on each response, and then verify the token using the `X-XSRF-TOKEN` header sent in the requests from axios. (That's basically what `inertia_rails` does).
 
+> [!NOTE]
+> `X-XSRF-TOKEN` header only works for [Inertia requests](/guide/the-protocol#inertia-responses). If you want to send a normal request you can use `X-CSRF-TOKEN` instead.
+
 ## Handling mismatches
 
 When a CSRF token mismatch occurs, Rails raises the `ActionController::InvalidAuthenticityToken` error. Since that isn't a valid Inertia response, the error is shown in a modal.


### PR DESCRIPTION
This PR adds a small note about `X-XSRF-TOKEN` header as discussed [here](https://github.com/inertiajs/inertia-rails/issues/170)

![image](https://github.com/user-attachments/assets/3d96a4e0-7229-456e-9b0b-2ed93893b141)
