### PR TITLE
Allow to set Inertia SSR URL via the ENV variable

### DIFF
--- a/lib/inertia_rails/configuration.rb
+++ b/lib/inertia_rails/configuration.rb
@@ -18,7 +18,7 @@ module InertiaRails
 
       # SSR options.
       ssr_enabled: false,
-      ssr_url: 'http://localhost:13714',
+      ssr_url: ENV.fetch('INERTIA_SSR_URL', 'http://localhost:13714'),
 
       # Used to detect version drift between server and client.
       version: nil,


### PR DESCRIPTION
This PR introduces the ability to set `ssr_url` dynamically using an ENV variable (`INERTIA_SSR_URL`) with a fallback value. This change is based on recent discussions about improving flexibility in configuring the Inertia SSR URL at:
* https://github.com/inertiajs/inertia-rails/pull/167