### PR TITLE
Improve framework detection logic and add test coverage

### DIFF
--- a/lib/inertia_rails/generators/helper.rb
+++ b/lib/inertia_rails/generators/helper.rb
@@ -4,8 +4,8 @@ module InertiaRails
   module Generators
     module Helper
       class << self
-        def guess_the_default_framework
-          package = Rails.root.join('package.json').read
+        def guess_the_default_framework(package_json_path = Rails.root.join("package.json"))
+          package = File.read(package_json_path)
           case package
           when %r{@inertiajs/react}
             'react'

--- a/lib/inertia_rails/generators/helper.rb
+++ b/lib/inertia_rails/generators/helper.rb
@@ -4,14 +4,16 @@ module InertiaRails
   module Generators
     module Helper
       class << self
-        def guess_the_default_framework(package_json_path = Rails.root.join("package.json"))
-          package = File.read(package_json_path)
-          case package
-          when %r{@inertiajs/react}
+        def guess_the_default_framework(package_json_path = Rails.root.join('package.json'))
+          package_json = JSON.parse(package_json_path.read)
+          dependencies = package_json['dependencies'] || {}
+
+          if dependencies['@inertiajs/react']
             'react'
-          when %r{@inertiajs/svelte}
-            package.match?(/"svelte": "\^5/) ? 'svelte' : 'svelte4'
-          when %r{@inertiajs/vue3}
+          elsif dependencies['@inertiajs/svelte']
+            version = dependencies['svelte'].gsub(/[\^~]/, '') # Remove ^ or ~ from version
+            version.start_with?('5') ? 'svelte' : 'svelte4'
+          elsif dependencies['@inertiajs/vue3']
             'vue'
           else
             Thor::Shell::Basic.new.say_error 'Could not determine the Inertia.js framework you are using.'

--- a/spec/fixtures/package_json_files/empty_package.json
+++ b/spec/fixtures/package_json_files/empty_package.json
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/spec/fixtures/package_json_files/react_package.json
+++ b/spec/fixtures/package_json_files/react_package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@inertiajs/react": "1.0.0"
+  }
+}

--- a/spec/fixtures/package_json_files/svelte4_package.json
+++ b/spec/fixtures/package_json_files/svelte4_package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@inertiajs/svelte": "1.0.0",
+    "svelte": "^4.0.0"
+  }
+}

--- a/spec/fixtures/package_json_files/svelte5_caret_package.json
+++ b/spec/fixtures/package_json_files/svelte5_caret_package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@inertiajs/svelte": "1.0.0",
+    "svelte": "^5.0.0"
+  }
+}

--- a/spec/fixtures/package_json_files/svelte5_exact_package.json
+++ b/spec/fixtures/package_json_files/svelte5_exact_package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@inertiajs/svelte": "1.0.0",
+    "svelte": "5.0.0"
+  }
+}

--- a/spec/fixtures/package_json_files/svelte5_tilde_package.json
+++ b/spec/fixtures/package_json_files/svelte5_tilde_package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@inertiajs/svelte": "1.0.0",
+    "svelte": "~5.0.0"
+  }
+}

--- a/spec/fixtures/package_json_files/vue_package.json
+++ b/spec/fixtures/package_json_files/vue_package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@inertiajs/vue3": "1.0.0"
+  }
+}

--- a/spec/generators/generators_helper_spec.rb
+++ b/spec/generators/generators_helper_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'thor'
+require_relative '../../lib/inertia_rails/generators/helper'
+
+RSpec.describe InertiaRails::Generators::Helper, type: :helper do
+  describe '#guess_the_default_framework' do
+    let(:package_json_path) { Pathname.new(File.expand_path("spec/fixtures/package_json_files/#{fixture_file_name}", Dir.pwd)) }
+
+    shared_examples 'framework detection' do |file_name, expected_framework|
+      let(:fixture_file_name) { file_name }
+
+      it "returns #{expected_framework.inspect} when inspect \"#{file_name}\"" do
+        expect(described_class.guess_the_default_framework(package_json_path)).to eq(expected_framework)
+      end
+    end
+
+    it_behaves_like 'framework detection', 'react_package.json', 'react'
+    it_behaves_like 'framework detection', 'svelte5_caret_package.json', 'svelte'
+    it_behaves_like 'framework detection', 'svelte5_exact_package.json', 'svelte'
+    it_behaves_like 'framework detection', 'svelte5_tilde_package.json', 'svelte'
+    it_behaves_like 'framework detection', 'svelte4_package.json', 'svelte4'
+    it_behaves_like 'framework detection', 'vue_package.json', 'vue'
+
+    # Handle exception
+    context 'when framework cannot be determined' do
+      let(:fixture_file_name) { 'empty_package.json' }
+
+      it 'raises an error' do
+        allow(described_class).to receive(:exit) # Prevent `exit` from terminating the test
+        expect(Thor::Shell::Basic).to receive_message_chain(:new, :say_error)
+          .with('Could not determine the Inertia.js framework you are using.')
+        described_class.guess_the_default_framework(package_json_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR performs some changes:

* Update logic to handle Svelte 5 dependencies with caret (^x.x.x), exact (x.x.x), and tilde (~x.x.x) versioning  to prevent exceptions when using the controller generator.
* Add test coverage for the `InertiaRailsContrib::GeneratorsHelper#guess_the_default_framework` method.

---

|  Before  |  After |
|--------|------- |
| ![BrodieMFL 2024-12-07 at 02 40 49](https://github.com/user-attachments/assets/20c26261-cba2-4e2d-886f-8173d5560b52)  | ![BrodieMFL 2024-12-07 at 02 40 16](https://github.com/user-attachments/assets/577ba7e7-41a3-42e7-a343-f7c3a7daab48) | 