### PR TITLE
Various installation generator fixes

### DIFF
--- a/.github/workflows/generators.yml
+++ b/.github/workflows/generators.yml
@@ -25,7 +25,7 @@ jobs:
         tailwind: [true, false]
         ruby: ['3.3']
         node: ['22']
-        inertia_version: ['1.2.0', 'next', 'beta']
+        inertia_version: ['1.2.0', '1.3', '2.0']
         exclude:
           # 1.2.0 does not support typescript
           - typescript: true

--- a/lib/generators/inertia/install/install_generator.rb
+++ b/lib/generators/inertia/install/install_generator.rb
@@ -78,8 +78,7 @@ module Inertia
         template 'initializer.rb', file_path('config/initializers/inertia_rails.rb')
 
         say 'Installing Inertia npm packages'
-        add_dependencies(*FRAMEWORKS[framework]['packages'])
-        add_dependencies(inertia_package)
+        add_dependencies(inertia_package, *FRAMEWORKS[framework]['packages'])
 
         unless File.read(vite_config_path).include?(FRAMEWORKS[framework]['vite_plugin_import'])
           say "Adding Vite plugin for #{framework}"

--- a/lib/generators/inertia/install/templates/svelte/inertia.ts.tt
+++ b/lib/generators/inertia/install/templates/svelte/inertia.ts.tt
@@ -32,7 +32,7 @@ createInertiaApp({
 
   setup({ el, App, props }) {
     if (el) {
-<%= "      // @ts-expect-error 1.3.0 beta contains types mismatch\n" if inertia_resolved_version == Gem::Version.new('1.3.0-beta.2') -%>
+<%= "      // @ts-expect-error 1.3.0 contains types mismatch\n" if inertia_resolved_version.release == Gem::Version.new('1.3.0') -%>
       mount(App, { target: el, props })
     } else {
       console.error(

--- a/lib/generators/inertia/install/templates/svelte4/inertia.ts.tt
+++ b/lib/generators/inertia/install/templates/svelte4/inertia.ts.tt
@@ -31,7 +31,7 @@ createInertiaApp({
 
   setup({ el, App, props }) {
     if (el) {
-      <%= "// @ts-expect-error 1.3.0 beta contains types mismatch\n" if inertia_resolved_version == Gem::Version.new('1.3.0-beta.2') -%>
+      <%= "// @ts-expect-error 1.3.0 beta contains types mismatch\n" if inertia_resolved_version.release == Gem::Version.new('1.3.0') -%>
       new App({ target: el, props })
     } else {
       console.error(


### PR DESCRIPTION
This PR:
- Fixes the Inertia versions matrix in CI.
- Merges the installation of framework and Inertia plugin packages into a single step to resolve potential compatibility issues (e.g., React 19 is not supported by Inertia 1.2).
- Expands the fix for the Inertia 1.3.0.beta.2 types mismatch to the release version.