### PR TITLE
Use to_json when rendering json response

### DIFF
--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -41,7 +41,7 @@ module InertiaRails
       end
       if @request.headers['X-Inertia']
         @response.set_header('X-Inertia', 'true')
-        @render_method.call json: page, status: @response.status, content_type: Mime[:json]
+        @render_method.call json: page.to_json, status: @response.status, content_type: Mime[:json]
       else
         return render_ssr if configuration.ssr_enabled rescue nil
         @render_method.call template: 'inertia', layout: layout, locals: view_data.merge(page: page)

--- a/lib/inertia_rails/rspec.rb
+++ b/lib/inertia_rails/rspec.rb
@@ -32,8 +32,9 @@ module InertiaRails
         else
           # Sequential Inertia request
           @view_data = {}
-          @props = params[:json][:props]
-          @component = params[:json][:component]
+          json = JSON.parse(params[:json])
+          @props = json["props"]
+          @component = json["component"]
         end
       end
     end
@@ -81,8 +82,7 @@ end
 
 RSpec::Matchers.define :have_exact_props do |expected_props|
   match do |inertia|
-  # Computed props have symbolized keys. 
-    expect(inertia.props).to eq expected_props.deep_symbolize_keys
+    expect(inertia.props).to eq expected_props
   end
 
   failure_message do |inertia|
@@ -92,8 +92,7 @@ end
 
 RSpec::Matchers.define :include_props do |expected_props|
   match do |inertia|
-  # Computed props have symbolized keys. 
-    expect(inertia.props).to include expected_props.deep_symbolize_keys
+    expect(inertia.props).to include expected_props
   end
 
   failure_message do |inertia|

--- a/spec/inertia/rails_mimic_spec.rb
+++ b/spec/inertia/rails_mimic_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'rendering when mimicking rails behavior', type: :request, inerti
     it 'has the props' do
       get instance_props_test_path
 
-      expect_inertia.to have_exact_props({'name' => 'Brandon', 'sport' => 'hockey'})
+      expect_inertia.to have_exact_props({name: 'Brandon', sport: 'hockey'})
     end
   end
 
@@ -31,7 +31,7 @@ RSpec.describe 'rendering when mimicking rails behavior', type: :request, inerti
       get default_render_test_path
 
       expect_inertia.to render_component('inertia_rails_mimic/default_render_test')
-      expect_inertia.to include_props({'name' => 'Brian'})
+      expect_inertia.to include_props({name: 'Brian'})
     end
 
     context 'a rendering transformation is provided' do

--- a/spec/inertia/rspec_helper_spec.rb
+++ b/spec/inertia/rspec_helper_spec.rb
@@ -38,15 +38,15 @@ RSpec.describe InertiaRails::RSpec, type: :request do
       before { get props_path, headers: {'X-Inertia': true} }
 
       it 'has props' do
-        expect_inertia.to have_exact_props({name: 'Brandon', sport: 'hockey'})
+        expect_inertia.to have_exact_props({"name" => 'Brandon', "sport" => 'hockey'})
       end
 
       it 'includes props' do
-        expect_inertia.to include_props({sport: 'hockey'})
+        expect_inertia.to include_props({"sport" => 'hockey'})
       end
 
       it 'can retrieve props' do
-        expect(inertia.props[:name]).to eq 'Brandon'
+        expect(inertia.props["name"]).to eq 'Brandon'
       end
     end
 
@@ -139,7 +139,7 @@ RSpec.describe InertiaRails::RSpec, type: :request do
         expect_inertia.to have_exact_props({
           someProperty: {
             property_a: "some value",
-            'property_b' => "this value",
+            property_b: "this value",
           },
           property_c: "some other value"
         })


### PR DESCRIPTION
I was trying to debug why an inertia json response was 5x slower than the initial html response.

After some investigation, it turns out that `render json: foo` does not actually do the same thing as `foo.to_json` does. It does a whole lot of rails magic instead, which is both a lot slower and inconsistent.

Changing this to use `page.to_json` ensures consistency with the props output in inertia.html.erb, avoiding weird inconsistencies between props renders and full page renders, and is also a lot faster (especially if you are using a library like Oj to optimise json generation).