### PR TITLE
renderer returns nil when the format is neither html nor x-inertia based

### DIFF
--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -44,6 +44,7 @@ module InertiaRails
         @render_method.call json: page.to_json, status: @response.status, content_type: Mime[:json]
       else
         return render_ssr if configuration.ssr_enabled rescue nil
+        return nil unless @request.format.html?
         @render_method.call template: 'inertia', layout: layout, locals: view_data.merge(page: page)
       end
     end

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -43,8 +43,8 @@ module InertiaRails
         @response.set_header('X-Inertia', 'true')
         @render_method.call json: page.to_json, status: @response.status, content_type: Mime[:json]
       else
-        return render_ssr if configuration.ssr_enabled rescue nil
         return nil unless @request.format.html?
+        return render_ssr if configuration.ssr_enabled rescue nil
         @render_method.call template: 'inertia', layout: layout, locals: view_data.merge(page: page)
       end
     end


### PR DESCRIPTION
The injected renderer returns nil when the format is neither html nor x-inertia based, so that the developer might probably reuse the controller for other formats including json or xml api servers.
