### PR TITLE
Fix inertia routes helper

### DIFF
--- a/lib/patches/mapper.rb
+++ b/lib/patches/mapper.rb
@@ -1,10 +1,23 @@
 module InertiaRails
   module InertiaMapper
-    def inertia(args, &block)
-      route = args.keys.first
-      component = args.values.first
+    def inertia(args)
+      route, component = extract_route_and_component(args)
+      @scope = @scope.new(module: nil)
+      get(route, to: 'inertia_rails/static#static', defaults: { component: component })
+    ensure
+      @scope = @scope.parent
+    end
 
-      get(route => 'inertia_rails/static#static', defaults: { component: component })
+    private
+
+    def extract_route_and_component(args)
+      if args.is_a?(Hash)
+        args.first
+      elsif @scope[:module].blank?
+        [args, args]
+      else
+        [args, InertiaRails.configuration.component_path_resolver(path: @scope[:module], action: args)]
+      end
     end
   end
 end

--- a/lib/patches/mapper.rb
+++ b/lib/patches/mapper.rb
@@ -3,23 +3,22 @@ module InertiaRails
     def inertia(*args, **options)
       path = args.any? ? args.first : options
       route, component = extract_route_and_component(path)
-      @scope = @scope.new(module: nil)
-      get(route, to: 'inertia_rails/static#static', defaults: { component: component }, **options)
-    ensure
-      @scope = @scope.parent
+      scope module: nil do
+        get(route, to: 'inertia_rails/static#static', defaults: { component: component }, **options)
+      end
     end
 
     private
 
-    def extract_route_and_component(args)
-      if args.is_a?(Hash)
-        args.first
+    def extract_route_and_component(path)
+      if path.is_a?(Hash)
+        path.first
       elsif resource_scope?
-        [args, InertiaRails.configuration.component_path_resolver(path: [@scope[:module], @scope[:controller]].compact.join('/'), action: args)]
+        [path, InertiaRails.configuration.component_path_resolver(path: [@scope[:module], @scope[:controller]].compact.join('/'), action: path)]
       elsif @scope[:module].blank?
-        [args, args]
+        [path, path]
       else
-        [args, InertiaRails.configuration.component_path_resolver(path: @scope[:module], action: args)]
+        [path, InertiaRails.configuration.component_path_resolver(path: @scope[:module], action: path)]
       end
     end
   end

--- a/lib/patches/mapper.rb
+++ b/lib/patches/mapper.rb
@@ -1,9 +1,10 @@
 module InertiaRails
   module InertiaMapper
-    def inertia(args)
-      route, component = extract_route_and_component(args)
+    def inertia(*args, **options)
+      path = args.any? ? args.first : options
+      route, component = extract_route_and_component(path)
       @scope = @scope.new(module: nil)
-      get(route, to: 'inertia_rails/static#static', defaults: { component: component })
+      get(route, to: 'inertia_rails/static#static', defaults: { component: component }, **options)
     ensure
       @scope = @scope.parent
     end
@@ -13,6 +14,8 @@ module InertiaRails
     def extract_route_and_component(args)
       if args.is_a?(Hash)
         args.first
+      elsif resource_scope?
+        [args, InertiaRails.configuration.component_path_resolver(path: [@scope[:module], @scope[:controller]].compact.join('/'), action: args)]
       elsif @scope[:module].blank?
         [args, args]
       else

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -46,7 +46,19 @@ Rails.application.routes.draw do
   get 'provided_props_test' => 'inertia_rails_mimic#provided_props_test'
 
   post 'redirect_to_share_test' => 'inertia_test#redirect_to_share_test'
+
   inertia 'inertia_route' => 'TestComponent'
+  inertia :inertia_route_with_default_component
+  scope :scoped, as: "scoped" do
+    inertia 'inertia_route' => 'TestComponent'
+  end
+  namespace :namespaced do
+    inertia inertia_route: 'TestComponent'
+    inertia :inertia_route_with_default_component
+    scope :scoped, as: "scoped" do
+      inertia :inertia_route_with_default_component
+    end
+  end
 
   get 'merge_shared' => 'inertia_merge_shared#merge_shared'
   get 'deep_merge_shared' => 'inertia_merge_shared#deep_merge_shared'

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -52,9 +52,11 @@ Rails.application.routes.draw do
   scope :scoped, as: "scoped" do
     inertia 'inertia_route' => 'TestComponent'
   end
-  namespace :namespaced do
-    inertia inertia_route: 'TestComponent'
+  resources :items do
+    inertia inertia_route: 'TestComponent', on: :member
     inertia :inertia_route_with_default_component
+    inertia :inertia_route_with_default_component_on_member, on: :member
+    inertia :inertia_route_with_default_component_on_collection, on: :collection
     scope :scoped, as: "scoped" do
       inertia :inertia_route_with_default_component
     end

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -58,6 +58,42 @@ RSpec.describe 'rendering inertia views', type: :request do
 
       it { is_expected.to include inertia_div(page) }
     end
+
+    context 'via a namespaced inertia route' do
+      before { get namespaced_inertia_route_path }
+
+      it { is_expected.to include inertia_div(page) }
+    end
+
+    context 'via a scoped inertia route' do
+      before { get scoped_inertia_route_path }
+
+      it { is_expected.to include inertia_div(page) }
+    end
+
+    context 'with a default component' do
+      let(:page) { InertiaRails::Renderer.new('inertia_route_with_default_component', controller, request, response, '').send(:page) }
+
+      before { get inertia_route_with_default_component_path }
+
+      it { is_expected.to include inertia_div(page) }
+    end
+
+    context 'with a default component namespaced' do
+      let(:page) { InertiaRails::Renderer.new('namespaced/inertia_route_with_default_component', controller, request, response, '').send(:page) }
+
+      before { get namespaced_inertia_route_with_default_component_path }
+
+      it { is_expected.to include inertia_div(page) }
+    end
+
+    context 'with a default component namespaced & scoped' do
+      let(:page) { InertiaRails::Renderer.new('namespaced/inertia_route_with_default_component', controller, request, response, '').send(:page) }
+
+      before { get namespaced_scoped_inertia_route_with_default_component_path }
+
+      it { is_expected.to include inertia_div(page) }
+    end
   end
 
   context 'subsequent requests' do

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe 'rendering inertia views', type: :request do
       it { is_expected.to include inertia_div(page) }
     end
 
-    context 'via a namespaced inertia route' do
-      before { get namespaced_inertia_route_path }
+    context 'via a resource inertia route' do
+      before { get inertia_route_item_path(id: 1) }
 
       it { is_expected.to include inertia_div(page) }
     end
@@ -79,18 +79,34 @@ RSpec.describe 'rendering inertia views', type: :request do
       it { is_expected.to include inertia_div(page) }
     end
 
-    context 'with a default component namespaced' do
-      let(:page) { InertiaRails::Renderer.new('namespaced/inertia_route_with_default_component', controller, request, response, '').send(:page) }
+    context 'with a default component resource' do
+      let(:page) { InertiaRails::Renderer.new('items/inertia_route_with_default_component', controller, request, response, '').send(:page) }
 
-      before { get namespaced_inertia_route_with_default_component_path }
+      before { get item_inertia_route_with_default_component_path(item_id: 1) }
 
       it { is_expected.to include inertia_div(page) }
     end
 
-    context 'with a default component namespaced & scoped' do
-      let(:page) { InertiaRails::Renderer.new('namespaced/inertia_route_with_default_component', controller, request, response, '').send(:page) }
+    context 'with a default component resource on member' do
+      let(:page) { InertiaRails::Renderer.new('items/inertia_route_with_default_component_on_member', controller, request, response, '').send(:page) }
 
-      before { get namespaced_scoped_inertia_route_with_default_component_path }
+      before { get inertia_route_with_default_component_on_member_item_path(id: 1) }
+
+      it { is_expected.to include inertia_div(page) }
+    end
+
+    context 'with a default component resource on collection' do
+      let(:page) { InertiaRails::Renderer.new('items/inertia_route_with_default_component_on_collection', controller, request, response, '').send(:page) }
+
+      before { get inertia_route_with_default_component_on_collection_items_path }
+
+      it { is_expected.to include inertia_div(page) }
+    end
+
+    context 'with a default component resource & scoped' do
+      let(:page) { InertiaRails::Renderer.new('items/inertia_route_with_default_component', controller, request, response, '').send(:page) }
+
+      before { get scoped_item_inertia_route_with_default_component_path(item_id: 1) }
 
       it { is_expected.to include inertia_div(page) }
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,8 @@ RSpec.configure do |config|
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
 
+  config.filter_run_when_matching :focus
+
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end


### PR DESCRIPTION
This PR improves `inertia` routes helper by adding support for:
- namespaced and scoped routes
```ruby
namespace :settings do
  inertia 'appearance' => 'settings/appearance'
end

scope :settings do
  inertia 'appearance' => 'settings/appearance'
end
```
- symbol notation for route paths
```ruby
inertia settings: 'settings'
```
- shorthand syntax with default component:
```ruby
inertia :settings # => pages/settings.jsx

namespace :settings do
  inertia :appearance # => pages/settings/appearance.jsx
end
```