### PR TITLE
Fix inertia helper for namespaced routes

### DIFF
--- a/lib/patches/mapper.rb
+++ b/lib/patches/mapper.rb
@@ -3,9 +3,7 @@ module InertiaRails
     def inertia(*args, **options)
       path = args.any? ? args.first : options
       route, component = extract_route_and_component(path)
-      scope module: nil do
-        get(route, to: 'inertia_rails/static#static', defaults: { component: component }, **options)
-      end
+      get(route, to: StaticController.action(:static), defaults: { component: component }, **options)
     end
 
     private

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -54,6 +54,9 @@ Rails.application.routes.draw do
   scope :scoped, as: "scoped" do
     inertia 'inertia_route' => 'TestComponent'
   end
+  namespace :namespaced do
+    inertia 'inertia_route' => 'TestComponent'
+  end
   resources :items do
     inertia inertia_route: 'TestComponent', on: :member
     inertia :inertia_route_with_default_component

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -76,6 +76,12 @@ RSpec.describe 'rendering inertia views', type: :request do
       it { is_expected.to include inertia_div(page) }
     end
 
+    context 'via a namespaced inertia route' do
+      before { get namespaced_inertia_route_path }
+
+      it { is_expected.to include inertia_div(page) }
+    end
+
     context 'with a default component' do
       let(:page) { InertiaRails::Renderer.new('inertia_route_with_default_component', controller, request, response, '').send(:page) }
 


### PR DESCRIPTION
This fix makes the output of `bin/rails routes` slightly less obvious, but it will certainly work in any situation.