### PR TITLE
Add `inertia_rendering?` method and set instance variable in renderer

### DIFF
--- a/lib/inertia_rails/helper.rb
+++ b/lib/inertia_rails/helper.rb
@@ -11,4 +11,8 @@ module InertiaRails::Helper
     )
     inertia_ssr_head
   end
+
+  def inertia_rendering?
+    controller.instance_variable_get("@_inertia_rendering")
+  end
 end

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -37,6 +37,7 @@ module InertiaRails
       @deep_merge = deep_merge.nil? ? configuration.deep_merge_shared_data : deep_merge
       @encrypt_history = encrypt_history.nil? ? configuration.encrypt_history : encrypt_history
       @clear_history = clear_history || controller.session[:inertia_clear_history] || false
+      @controller.instance_variable_set('@_inertia_rendering', true)
     end
 
     def render

--- a/spec/inertia/helper_spec.rb
+++ b/spec/inertia/helper_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe InertiaRails::Helper do
+  let(:controller) { ApplicationController.new }
+
+  let(:test_helper) do
+    Class.new do
+      include InertiaRails::Helper
+      attr_accessor :controller
+    end.new
+  end
+
+  before do
+    test_helper.controller = controller
+  end
+
+  describe '#inertia_rendering?' do
+    context 'when not rendering through Inertia' do
+      it 'returns nil' do
+        expect(test_helper.inertia_rendering?).to be_nil
+      end
+    end
+
+    context 'when rendering through Inertia' do
+      before do
+        controller.instance_variable_set('@_inertia_rendering', true)
+      end
+
+      it 'returns true' do
+        expect(test_helper.inertia_rendering?).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
We are introducing a new method `inertia_rendering?` in the `InertiaRails` helper to check if the controller is currently rendering an Inertia response.
This allow a view to conditionally render something based on this option i.e. the layout may include the `inertia` pack based on this.

P.S. ideally, this could be subtly mentioned somewhere in the docs but I'm new here so I'll leave that up to you (although Im open to add it if you have a suggestion on where and how to word it if you want)

Closes #208 