### PR TITLE
Add patch for validation error types on inertia:install

### DIFF
--- a/lib/generators/inertia/install/frameworks.yml
+++ b/lib/generators/inertia/install/frameworks.yml
@@ -16,6 +16,7 @@ react:
     "tsconfig.app.json": "tsconfig.app.json"
     "tsconfig.node.json": "tsconfig.node.json"
     "vite-env.d.ts": "%{js_destination_path}/vite-env.d.ts"
+    "inertia-rails.d.ts": "%{js_destination_path}/types/inertia-rails.d.ts"
   copy_files_js:
     "InertiaExample.jsx": "%{js_destination_path}/pages/InertiaExample.jsx"
   copy_files:
@@ -44,6 +45,7 @@ vue:
     "tsconfig.app.json": "tsconfig.app.json"
     "tsconfig.node.json": "tsconfig.node.json"
     "vite-env.d.ts": "%{js_destination_path}/vite-env.d.ts"
+    "inertia-rails.d.ts": "%{js_destination_path}/types/inertia-rails.d.ts"
   copy_files_js:
     "InertiaExample.vue": "%{js_destination_path}/pages/InertiaExample.vue"
 
@@ -64,6 +66,7 @@ svelte4:
     "tsconfig.json": "tsconfig.json"
     "tsconfig.node.json": "tsconfig.node.json"
     "vite-env.d.ts": "%{js_destination_path}/vite-env.d.ts"
+    "inertia-rails.d.ts": "%{js_destination_path}/types/inertia-rails.d.ts"
   copy_files_js:
     "InertiaExample.svelte": "%{js_destination_path}/pages/InertiaExample.svelte"
   copy_files:
@@ -89,6 +92,7 @@ svelte:
     "tsconfig.json": "tsconfig.json"
     "tsconfig.node.json": "tsconfig.node.json"
     "vite-env.d.ts": "%{js_destination_path}/vite-env.d.ts"
+    "inertia-rails.d.ts": "%{js_destination_path}/types/inertia-rails.d.ts"
   copy_files_js:
     "InertiaExample.svelte": "%{js_destination_path}/pages/InertiaExample.svelte"
   copy_files:

--- a/lib/generators/inertia/install/templates/react/inertia-rails.d.ts
+++ b/lib/generators/inertia/install/templates/react/inertia-rails.d.ts
@@ -1,0 +1,26 @@
+// See https://inertia-rails.dev/cookbook/handling-validation-error-types.md
+import type { FormDataConvertible, FormDataKeys } from '@inertiajs/core'
+import type { InertiaFormProps as OriginalProps } from '@inertiajs/react'
+
+type FormDataType = Record<string, FormDataConvertible>
+
+declare module '@inertiajs/react' {
+  interface InertiaFormProps<TForm extends FormDataType>
+    extends Omit<OriginalProps<TForm>, 'errors' | 'setError'> {
+    errors: Partial<Record<FormDataKeys<TForm>, string[]>>
+
+    setError(field: FormDataKeys<TForm>, value: string[]): void
+
+    setError(errors: Record<FormDataKeys<TForm>, string[]>): void
+  }
+
+  export { InertiaFormProps }
+
+  export function useForm<TForm extends FormDataType>(
+    initialValues?: TForm,
+  ): InertiaFormProps<TForm>
+  export function useForm<TForm extends FormDataType>(
+    rememberKey: string,
+    initialValues?: TForm,
+  ): InertiaFormProps<TForm>
+}

--- a/lib/generators/inertia/install/templates/svelte/inertia-rails.d.ts
+++ b/lib/generators/inertia/install/templates/svelte/inertia-rails.d.ts
@@ -1,0 +1,29 @@
+// See https://inertia-rails.dev/cookbook/handling-validation-error-types.md
+import type { FormDataConvertible, FormDataKeys } from '@inertiajs/core'
+import type { InertiaFormProps as OriginalProps } from '@inertiajs/svelte'
+import type { Writable } from 'svelte/store'
+
+type FormDataType = Record<string, FormDataConvertible>
+
+declare module '@inertiajs/svelte' {
+  interface InertiaFormProps<TForm extends FormDataType>
+    extends Omit<OriginalProps<TForm>, 'errors' | 'setError'> {
+    errors: Partial<Record<FormDataKeys<TForm>, string[]>>
+
+    setError(field: FormDataKeys<TForm>, value: string[]): this
+
+    setError(errors: Record<FormDataKeys<TForm>, string[]>): this
+  }
+
+  type InertiaForm<TForm extends FormDataType> = InertiaFormProps<TForm> & TForm
+
+  export { InertiaFormProps, InertiaForm }
+
+  export function useForm<TForm extends FormDataType>(
+    data: TForm | (() => TForm),
+  ): Writable<InertiaForm<TForm>>
+  export function useForm<TForm extends FormDataType>(
+    rememberKey: string,
+    data: TForm | (() => TForm),
+  ): Writable<InertiaForm<TForm>>
+}

--- a/lib/generators/inertia/install/templates/svelte4/inertia-rails.d.ts
+++ b/lib/generators/inertia/install/templates/svelte4/inertia-rails.d.ts
@@ -1,0 +1,29 @@
+// See https://inertia-rails.dev/cookbook/handling-validation-error-types.md
+import type { FormDataConvertible, FormDataKeys } from '@inertiajs/core'
+import type { InertiaFormProps as OriginalProps } from '@inertiajs/svelte'
+import type { Writable } from 'svelte/store'
+
+type FormDataType = Record<string, FormDataConvertible>
+
+declare module '@inertiajs/svelte' {
+  interface InertiaFormProps<TForm extends FormDataType>
+    extends Omit<OriginalProps<TForm>, 'errors' | 'setError'> {
+    errors: Partial<Record<FormDataKeys<TForm>, string[]>>
+
+    setError(field: FormDataKeys<TForm>, value: string[]): this
+
+    setError(errors: Record<FormDataKeys<TForm>, string[]>): this
+  }
+
+  type InertiaForm<TForm extends FormDataType> = InertiaFormProps<TForm> & TForm
+
+  export { InertiaFormProps, InertiaForm }
+
+  export function useForm<TForm extends FormDataType>(
+    data: TForm | (() => TForm),
+  ): Writable<InertiaForm<TForm>>
+  export function useForm<TForm extends FormDataType>(
+    rememberKey: string,
+    data: TForm | (() => TForm),
+  ): Writable<InertiaForm<TForm>>
+}

--- a/lib/generators/inertia/install/templates/vue/inertia-rails.d.ts
+++ b/lib/generators/inertia/install/templates/vue/inertia-rails.d.ts
@@ -1,0 +1,29 @@
+// See https://inertia-rails.dev/cookbook/handling-validation-error-types.md
+import type { FormDataConvertible, FormDataKeys } from '@inertiajs/core'
+import type { InertiaFormProps as OriginalProps } from '@inertiajs/vue3'
+
+type FormDataType = Record<string, FormDataConvertible>
+
+declare module '@inertiajs/vue3' {
+  interface InertiaFormProps<TForm extends FormDataType>
+    extends Omit<OriginalProps<TForm>, 'errors' | 'setError'> {
+    errors: Partial<Record<FormDataKeys<TForm>, string[]>>
+
+    setError(field: FormDataKeys<TForm>, value: string[]): this
+
+    setError(errors: Record<FormDataKeys<TForm>, string[]>): this
+  }
+
+  export type InertiaForm<TForm extends FormDataType> = TForm &
+    InertiaFormProps<TForm>
+
+  export { InertiaFormProps, InertiaForm }
+
+  export function useForm<TForm extends FormDataType>(
+    data: TForm | (() => TForm),
+  ): InertiaForm<TForm>
+  export function useForm<TForm extends FormDataType>(
+    rememberKey: string,
+    data: TForm | (() => TForm),
+  ): InertiaForm<TForm>
+}

--- a/spec/generators/install/install_generator_spec.rb
+++ b/spec/generators/install/install_generator_spec.rb
@@ -253,6 +253,9 @@ RSpec.describe Inertia::Generators::InstallGenerator, type: :generator do
         file('app/frontend/vite-env.d.ts') do
           contains('/// <reference types="vite/client" />')
         end
+        directory('app/frontend/types') do
+          file('inertia-rails.d.ts')
+        end
         file('tsconfig.node.json') do
           contains('"include": ["vite.config.ts"]')
         end


### PR DESCRIPTION
This is part of https://github.com/inertiajs/inertia-rails/pull/215

As [commented](https://github.com/inertiajs/inertia-rails/pull/215#issuecomment-2797236643) in that PR, this changes add the suggested `inertia-rails.d.ts` type overrides to the `inertia:install` generator.

> Considering that the code [examples](https://github.com/inertiajs/inertia-rails/blob/4ceb8c357f6bfa7acc5b9c9ced7030cfbfde53b3/docs/guide/validation.md?plain=1#L17) in the documentation and the [generators](https://github.com/inertiajs/inertia-rails/blob/4ceb8c357f6bfa7acc5b9c9ced7030cfbfde53b3/lib/generators/inertia/scaffold_controller/templates/controller.rb.tt#L50) pass the errors as arrays, maybe the global re-export should be part of the setup guide or even the inertia:install [generator](https://inertia-rails.dev/guide/server-side-setup#rails-generator).

Also, as suggested by @skryukov, a link to the yet-to-be-merged cookbook is included in the `inertia-rails.d.ts` file.
