### PR TITLE
fix: missing command on getting started

### DIFF
--- a/docs/cookbook/integrating-shadcn-ui.md
+++ b/docs/cookbook/integrating-shadcn-ui.md
@@ -14,7 +14,9 @@ If you're starting fresh, create a new Rails application with Inertia (or skip t
 rails new -JA shadcn-inertia-rails
 cd shadcn-inertia-rails
 
-rails generate inertia:install `--framework=react --typescript --vite --tailwind --no-interactive`
+bundle add inertia_rails
+
+rails generate inertia:install --framework=react --typescript --vite --tailwind --no-interactive
 Installing Inertia's Rails adapter
 ...
 ```
@@ -24,6 +26,8 @@ Installing Inertia's Rails adapter
 ```bash
 rails new -JA shadcn-inertia-rails
 cd shadcn-inertia-rails
+
+bundle add inertia_rails
 
 rails generate inertia:install --framework=react --vite --tailwind --no-interactive
 Installing Inertia's Rails adapter


### PR DESCRIPTION
Hi

There’s a missing step in the Getting Started tutorial. If you follow the instructions as they are, you’ll get the error:

```sh
Could not find generator 'inertia:install'
```
To fix this, we need to install the inertia_rails gem before running the generator.

Also thanks to @kengreeff for the [video](https://www.youtube.com/watch?v=lTSiqGRvuPo)
