### PR TITLE
Add `parent_controller` config option

### DIFF
--- a/app/controllers/inertia_rails/static_controller.rb
+++ b/app/controllers/inertia_rails/static_controller.rb
@@ -1,5 +1,5 @@
 module InertiaRails
-  class StaticController < ::ApplicationController
+  class StaticController < InertiaRails.configuration.parent_controller.constantize
     def static
       render inertia: params[:component]
     end

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -81,6 +81,14 @@ component and props.
 This allows Inertia to detect if the app running in the client is oudated,
 forcing a full page visit instead of an XHR visit on the next request.
 
-See [assets versioning](https://inertiajs.com/asset-versioning).
+See [assets versioning](/guide/asset-versioning).
 
 **Default**: `nil`
+
+### `parent_controller`
+
+Specifies the base controller class for the internal `StaticController` used to render [Shorthand routes](/guide/routing#shorthand-routes).
+
+By default, InertiaRails creates a `StaticController` that inherits from `ApplicationController`. You can use this option to specify a different base controller (for example, to include custom authentication, layout, or before actions).
+
+**Default**: `'::ApplicationController'`

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -30,36 +30,48 @@ class EventsController < ApplicationController
 end
 ```
 
+## Setting Configuration via Environment Variables
+
+Inertia Rails supports setting any configuration option via environment variables out of the box. For each option in the configuration, you can set an environment variable prefixed with `INERTIA_` and the option name in uppercase. For example: `INERTIA_SSR_ENABLED`.
+
+**Boolean values** (like `INERTIA_DEEP_MERGE_SHARED_DATA` or `INERTIA_SSR_ENABLED`) are parsed from the strings `"true"` or `"false"` (case-sensitive).
+
 ## Configuration Options
 
 ### `component_path_resolver`
 
-Use `component_path_resolver` to customize component path resolution when [`default_render`](#default_render) config value is set to `true`. The value should be callable and will receive the `path` and `action` parameters, returning a string component path. See [Automatically determine component name](/guide/responses#automatically-determine-component-name).
-
 **Default**: `->(path:, action:) { "#{path}/#{action}" }`
 
+Use `component_path_resolver` to customize component path resolution when [`default_render`](#default_render) config value is set to `true`. The value should be callable and will receive the `path` and `action` parameters, returning a string component path. See [Automatically determine component name](/guide/responses#automatically-determine-component-name).
+
 ### `deep_merge_shared_data`
+
+**Default**: `false`  
+**ENV**: `INERTIA_DEEP_MERGE_SHARED_DATA`
 
 When enabled, props will be deep merged with shared data, combining hashes
 with the same keys instead of replacing them.
 
-**Default**: `false`
-
 ### `default_render`
+
+**Default**: `false`  
+**ENV**: `INERTIA_DEFAULT_RENDER`
 
 Overrides Rails default rendering behavior to render using Inertia by default.
 
-**Default**: `false`
-
 ### `encrypt_history`
+
+**Default**: `false`  
+**ENV**: `INERTIA_ENCRYPT_HISTORY`
 
 When enabled, you instruct Inertia to encrypt your app's history, it uses
 the browser's built-in [`crypto` api](https://developer.mozilla.org/en-US/docs/Web/API/Crypto)
 to encrypt the current page's data before pushing it to the history state.
 
-**Default**: `false`
-
 ### `ssr_enabled` _(experimental)_
+
+**Default**: `false`  
+**ENV**: `INERTIA_SSR_ENABLED`
 
 Whether to use a JavaScript server to pre-render your JavaScript pages,
 allowing your visitors to receive fully rendered HTML when they first visit
@@ -67,28 +79,29 @@ your application.
 
 Requires a JS server to be available at `ssr_url`. [_Example_](https://github.com/ElMassimo/inertia-rails-ssr-template)
 
-**Default**: `false`
-
 ### `ssr_url` _(experimental)_
+
+**Default**: `"http://localhost:13714"`
+**ENV**: `INERTIA_SSR_URL`
 
 The URL of the JS server that will pre-render the app using the specified
 component and props.
 
-**Default**: `"http://localhost:13714"`
-
 ### `version` _(recommended)_
+
+**Default**: `nil`
+**ENV**: `INERTIA_VERSION`
 
 This allows Inertia to detect if the app running in the client is oudated,
 forcing a full page visit instead of an XHR visit on the next request.
 
 See [assets versioning](/guide/asset-versioning).
 
-**Default**: `nil`
-
 ### `parent_controller`
+
+**Default**: `'::ApplicationController'`
+**ENV**: `INERTIA_PARENT_CONTROLLER`
 
 Specifies the base controller class for the internal `StaticController` used to render [Shorthand routes](/guide/routing#shorthand-routes).
 
-By default, InertiaRails creates a `StaticController` that inherits from `ApplicationController`. You can use this option to specify a different base controller (for example, to include custom authentication, layout, or before actions).
-
-**Default**: `'::ApplicationController'`
+By default, Inertia Rails creates a `StaticController` that inherits from `ApplicationController`. You can use this option to specify a different base controller (for example, to include custom authentication, layout, or before actions).

--- a/lib/inertia_rails/configuration.rb
+++ b/lib/inertia_rails/configuration.rb
@@ -25,6 +25,9 @@ module InertiaRails
 
       # Used to detect version drift between server and client.
       version: nil,
+
+      # Allows configuring the base controller for StaticController
+      parent_controller: '::ApplicationController',
     }.freeze
 
     OPTION_NAMES = DEFAULTS.keys.freeze


### PR DESCRIPTION
### `parent_controller`

Specifies the base controller class for the internal `StaticController` used to render static Inertia pages.

By default, InertiaRails creates a `StaticController` that inherits from `ApplicationController`. You can use this option to specify a different base controller (for example, to include custom authentication, layout, or before actions).

**Default**: `'::ApplicationController'`

#### Example

Suppose you have a custom base controller:

```ruby
class MyCustomBaseController < ApplicationController
  before_action :authenticate_user!
end
```

Configure InertiaRails to use it:

```ruby
InertiaRails.configure do |config|
  config.parent_controller = 'MyCustomBaseController'
end
```

Now, the internal `StaticController` will inherit from `MyCustomBaseController`, and all static Inertia pages will require authentication.

#### When to Use

- When you need to add custom before actions, filters, or helpers to static Inertia pages.
- When your application has multiple base controllers and you want to use a specific one for static pages.