### PR TITLE
[Dev] Improve onboarding experience for contributors

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,38 @@
+# Use the official Ruby image as base
+FROM ruby:3.3-slim
+
+# Install system dependencies
+RUN apt-get update -qq && apt-get install -y \
+  build-essential \
+  git \
+  curl \
+  sqlite3 \
+  libsqlite3-dev \
+  libyaml-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js (for documentation site)
+RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
+  && apt-get install -y nodejs
+
+# Create a non-root user
+RUN groupadd --gid 1000 user \
+  && useradd --uid 1000 --gid user --shell /bin/bash --create-home user
+
+# Set up the working directory
+WORKDIR /workspace
+
+# Install bundler
+RUN gem install bundler
+
+# Create cache directory for gems
+RUN mkdir -p /usr/local/bundle && chown -R user:user /usr/local/bundle
+
+# Switch to non-root user
+USER user
+
+# Set up git config (helps with development)
+RUN git config --global init.defaultBranch main
+
+# Set the default shell
+SHELL ["/bin/bash", "-c"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -31,8 +31,5 @@ RUN mkdir -p /usr/local/bundle && chown -R user:user /usr/local/bundle
 # Switch to non-root user
 USER user
 
-# Set up git config (helps with development)
-RUN git config --global init.defaultBranch main
-
 # Set the default shell
 SHELL ["/bin/bash", "-c"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "name": "Inertia Rails Development",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "shopify.ruby-lsp",
+        "ms-vscode.vscode-json",
+        "redhat.vscode-yaml"
+      ]
+    }
+  },
+  "forwardPorts": [3000, 5173],
+  "postCreateCommand": "bin/setup",
+  "remoteUser": "user"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ..:/workspace:cached
+      - gem_cache:/usr/local/bundle
+    command: sleep infinity
+    environment:
+      - RAILS_ENV=development
+    working_dir: /workspace
+
+volumes:
+  gem_cache:

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 # Requiring logger fixes an issue between concurrent-ruby and activesupport in Rails < 7.1
 # https://github.com/rails/rails/issues/54260
 require 'logger'
-ENV['RAILS_ENV'] ||= 'test'
+ENV['RAILS_ENV'] = 'test'
 
 require File.expand_path('../dummy/config/environment', __FILE__)
 


### PR DESCRIPTION
**Problem Statement**

I'm addressing three main issues:

- Environment setup is often a large bottleneck for new contributors. I've lost count of the times where setting up a new project took 5x longer than writing the code change I wanted to contribute
- I have a lot of Ruby projects on the go and even with a version manager it's often a pain to keep my dev environment free of cross-contamination. Containerizing your development environment keeps your projects independent from changes on your host machine
- Many people (myself included) like having only the necessary extensions enabled in my IDE. I don't want a ton of Python/Rust/Elixir add-ons cluttering up a Ruby project

**What it does**

This PR adds a complete dev container setup to make getting started with inertia-rails development super straightforward. The project can be fully set up and ready for contributions just by opening a code editor that supports devcontainers!

Even if you don't use an editor that supports devcontainers, the provided Docker files also allow savvy users to get up-and-running quickly.

I'm told that this will also allow contribution via GitHub Codespaces but I haven't tested that

**Notes**

I don't mind at all if you don't accept this PR! It's not high effort but it helped me get set up while I look at #247.

If you're interested in this, I can add a little blurb on this in the README if you'd like 🤙 
