### PR TITLE
Fix svelte generator

### DIFF
--- a/.github/workflows/generators.yml
+++ b/.github/workflows/generators.yml
@@ -25,14 +25,7 @@ jobs:
         tailwind: [true, false]
         ruby: ['3.3']
         node: ['22']
-        inertia_version: ['1.2.0', '1.3', '2.0']
-        exclude:
-          # 1.2.0 does not support typescript
-          - typescript: true
-            inertia_version: '1.2.0'
-          # 1.2.0 doesn't support Svelte 5
-          - framework: svelte
-            inertia_version: '1.2.0'
+        inertia_version: ['2.0']
 
     name: ${{ matrix.framework }} (TS:${{ matrix.typescript }}, TW:${{ matrix.tailwind }}, Inertia:${{ matrix.inertia_version }})
 

--- a/.github/workflows/generators.yml
+++ b/.github/workflows/generators.yml
@@ -25,7 +25,7 @@ jobs:
         tailwind: [true, false]
         ruby: ['3.3']
         node: ['22']
-        inertia_version: ['2.0']
+        inertia_version: ['latest']
 
     name: ${{ matrix.framework }} (TS:${{ matrix.typescript }}, TW:${{ matrix.tailwind }}, Inertia:${{ matrix.inertia_version }})
 

--- a/lib/generators/inertia/install/frameworks.yml
+++ b/lib/generators/inertia/install/frameworks.yml
@@ -76,7 +76,7 @@ svelte:
   inertia_package: "@inertiajs/svelte"
   packages:
     - "svelte@5"
-    - "@sveltejs/vite-plugin-svelte@4"
+    - "@sveltejs/vite-plugin-svelte"
   packages_ts:
     - "@tsconfig/svelte@5"
     - "svelte-check"

--- a/lib/generators/inertia/install/frameworks.yml
+++ b/lib/generators/inertia/install/frameworks.yml
@@ -4,6 +4,7 @@ react:
     - "@vitejs/plugin-react"
     - "react"
     - "react-dom"
+    - "vite@latest"
   packages_ts:
     - "@types/react"
     - "@types/react-dom"
@@ -29,6 +30,7 @@ vue:
   packages:
     - "vue"
     - "@vitejs/plugin-vue"
+    - "vite@latest"
   packages_ts:
     - "typescript@~5.6.2"
     - "vue-tsc"
@@ -52,6 +54,7 @@ svelte4:
   packages:
     - "svelte@4"
     - "@sveltejs/vite-plugin-svelte@3"
+    - "vite@5"
   packages_ts:
     - "@tsconfig/svelte@4"
     - "svelte-check"
@@ -77,6 +80,7 @@ svelte:
   packages:
     - "svelte@5"
     - "@sveltejs/vite-plugin-svelte"
+    - "vite@latest"
   packages_ts:
     - "@tsconfig/svelte@5"
     - "svelte-check"

--- a/lib/generators/inertia/install/templates/svelte/inertia.js
+++ b/lib/generators/inertia/install/templates/svelte/inertia.js
@@ -2,11 +2,6 @@ import { createInertiaApp } from '@inertiajs/svelte'
 import  { mount } from 'svelte';
 
 createInertiaApp({
-  // Set default page title
-  // see https://inertia-rails.dev/guide/title-and-meta
-  //
-  // title: title => title ? `${title} - App` : 'App',
-
   // Disable progress bar
   //
   // see https://inertia-rails.dev/guide/progress-indicators

--- a/lib/generators/inertia/install/templates/svelte/inertia.ts.tt
+++ b/lib/generators/inertia/install/templates/svelte/inertia.ts.tt
@@ -2,11 +2,6 @@ import { createInertiaApp, type ResolvedComponent } from '@inertiajs/svelte'
 import { mount } from 'svelte'
 
 createInertiaApp({
-  // Set default page title
-  // see https://inertia-rails.dev/guide/title-and-meta
-  //
-  // title: title => title ? `${title} - App` : 'App',
-
   // Disable progress bar
   //
   // see https://inertia-rails.dev/guide/progress-indicators
@@ -25,7 +20,7 @@ createInertiaApp({
     // and use the following line.
     // see https://inertia-rails.dev/guide/pages#default-layouts
     //
-    // return { default: page.default, layout: page.layout || Layout }
+    // return { default: page.default, layout: page.layout || Layout } as ResolvedComponent
 
     return page
   },


### PR DESCRIPTION
Found some issues while implementing https://github.com/inertia-rails/svelte-starter-kit.

Also dropped `inertia@core < 2.0` from the CI pipeline: there's no reason to support it anymore for new apps. Everyone must use Inertia 2.0+ (doesn't break anything, and it's a generator anyway).