### PR TITLE
Fix `ActionView::MissingTemplate` for static controller

### DIFF
--- a/app/controllers/inertia_rails/static_controller.rb
+++ b/app/controllers/inertia_rails/static_controller.rb
@@ -1,7 +1,9 @@
 module InertiaRails
   class StaticController < InertiaRails.configuration.parent_controller.constantize
     def static
-      render inertia: params[:component]
+      respond_to do |format|
+        format.html { render inertia: params[:component] }
+      end
     end
   end
 end

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -62,6 +62,12 @@ RSpec.describe 'rendering inertia views', type: :request do
       before { get inertia_route_path }
 
       it { is_expected.to include inertia_div(page) }
+
+      context 'with non html format' do
+        it 'raises UnknownFormat error' do
+          expect { get '/inertia_route.json' }.to raise_error(ActionController::UnknownFormat)
+        end
+      end
     end
 
     context 'via a resource inertia route' do


### PR DESCRIPTION
There are two ways to address the `ActionView::MissingTemplate` issue: using a `respond_to` block or forcing the `:html` format.

After clarification from @richardboehme, we decided to go with `respond_to` 😂 

Fixes #248