### PR TITLE
Use `render inertia: props` by default for docs

### DIFF
--- a/docs/cookbook/inertia-modal.md
+++ b/docs/cookbook/inertia-modal.md
@@ -260,8 +260,8 @@ To define the base route for your modal, you need to use the `inertia_modal` ren
 
 class UsersController < ApplicationController
   def edit
-    render inertia: 'Users/Edit', props: { # [!code --]
-    render inertia_modal: 'Users/Edit', props: { # [!code ++]
+    render inertia: { # [!code --]
+    render inertia_modal: { # [!code ++]
       user:,
       roles: -> { Role.all },
     }
@@ -275,7 +275,7 @@ Then, you can pass the `base_url` parameter to the `inertia_modal` renderer to d
 
 class UsersController < ApplicationController
   def edit
-    render inertia_modal: 'Users/Edit', props: {
+    render inertia_modal: {
       user:,
       roles: -> { Role.all },
     } # [!code --]

--- a/docs/cookbook/server-managed-meta-tags.md
+++ b/docs/cookbook/server-managed-meta-tags.md
@@ -212,7 +212,7 @@ class EventsController < ApplicationController
   def show
     event = Event.find(params[:id])
 
-    render inertia: 'Event/Show', props: { event: event.as_json }, meta: [
+    render inertia: { event: event.as_json }, meta: [
       { title: "Check out the #{event.name} event!" },
       { name: 'description', content: event.description },
       { tag_name: 'script', type: 'application/ld+json', inner_content: { '@context': 'https://schema.org', '@type': 'Event', name: 'My Event' } }
@@ -232,7 +232,7 @@ class EventsController < ApplicationController
   before_action :set_meta_tags
 
   def show
-    render inertia: 'Event/Show', props: { event: Event.find(params[:id]) }
+    render inertia: { event: Event.find(params[:id]) }
   end
 
   private
@@ -319,12 +319,12 @@ class StoriesController < ApplicationController
 
   # Renders a single article:author meta tag
   def single_author
-    render inertia: 'Stories/Show'
+    render inertia: 'stories/show'
   end
 
   # Renders multiple article:author meta tags
   def multiple_authors
-    render inertia: 'Stories/Show', meta: [
+    render inertia: 'stories/show', meta: [
       { name: 'article:author', content: 'Dan Gilroy', allow_duplicates: true },
     ]
   end

--- a/docs/guide/authorization.md
+++ b/docs/guide/authorization.md
@@ -9,7 +9,7 @@ Here's an example of how you might do this in a Rails controller using the [Acti
 ```ruby
 class UsersController < ApplicationController
   def index
-    render inertia: 'Users/Index', props: {
+    render inertia: {
       can: {
         create_user: allowed_to?(:create, User)
       },

--- a/docs/guide/deferred-props.md
+++ b/docs/guide/deferred-props.md
@@ -11,7 +11,7 @@ To defer a prop, you can use the `InertiaRails.defer` method when returning your
 ```ruby
 class UsersController < ApplicationController
   def index
-    render inertia: 'Users/Index', props: {
+    render inertia: {
       users: -> { User.all },
       roles: -> { Role.all },
       permissions: InertiaRails.defer { Permission.all },
@@ -27,7 +27,7 @@ By default, all deferred props get fetched in one request after the initial page
 ```ruby
 class UsersController < ApplicationController
   def index
-    render inertia: 'Users/Index', props: {
+    render inertia: {
       users: -> { User.all },
       roles: -> { Role.all },
       permissions: InertiaRails.defer { Permission.all },

--- a/docs/guide/history-encryption.md
+++ b/docs/guide/history-encryption.md
@@ -22,7 +22,7 @@ If you'd like to enable history encryption globally, set the `encrypt_history` c
 You are able to opt out of encryption on specific pages by passing `false` to the `encrypt_history` option.
 
 ```ruby
-render inertia: 'Homepage', props: {}, encrypt_history: false
+render inertia: {}, encrypt_history: false
 ```
 
 ### Per-request encryption
@@ -30,7 +30,7 @@ render inertia: 'Homepage', props: {}, encrypt_history: false
 To encrypt the history of an individual request, simply pass `true` to the `encrypt_history` option.
 
 ```ruby
-render inertia: 'Dashboard', props: {}, encrypt_history: true
+render inertia: {}, encrypt_history: true
 ```
 
 ### Controller-level encryption
@@ -50,7 +50,7 @@ end
 To clear the history state on the server side, you can pass the `clear_history` option to the `render` method.
 
 ```ruby
-render inertia: 'Dashboard', props: {}, clear_history: true
+render inertia: {}, clear_history: true
 ```
 
 Once the response has rendered on the client, the encryption key will be rotated, rendering the previous history state unreadable.

--- a/docs/guide/pages.md
+++ b/docs/guide/pages.md
@@ -85,14 +85,14 @@ export default function Welcome({ user }) {
 
 :::
 
-Given the page above, you can render the page by returning an Inertia response from a controller or route. In this example, let's assume this page is stored at `app/frontend/pages/User/Show.(jsx|vue|svelte)` within a Rails application.
+Given the page above, you can render the page by returning an Inertia response from a controller or route. In this example, let's assume this page is stored at `app/frontend/pages/user/show.(jsx|vue|svelte)` within a Rails application.
 
 ```ruby
 class UsersController < ApplicationController
   def show
     user = User.find(params[:id])
 
-    render inertia: 'User/Show', props: { user: }
+    render inertia: { user: }
   end
 end
 ```

--- a/docs/guide/partial-reloads.md
+++ b/docs/guide/partial-reloads.md
@@ -210,7 +210,7 @@ For partial reloads to be most effective, be sure to also use lazy data evaluati
 ```ruby
 class UsersController < ApplicationController
   def index
-    render inertia: 'Users/Index', props: {
+    render inertia: {
       users: -> { User.all },
       companies: -> { Company.all },
     }
@@ -225,7 +225,7 @@ Additionally, Inertia provides an `InertiaRails.optional` method to specify that
 ```ruby
 class UsersController < ApplicationController
   def index
-    render inertia: 'Users/Index', props: {
+    render inertia: {
       users: InertiaRails.optional { User.all },
     }
   end
@@ -240,7 +240,7 @@ On the inverse, you can use the `InertiaRails.always` method to specify that a p
 ```ruby
 class UsersController < ApplicationController
   def index
-    render inertia: 'Users/Index', props: {
+    render inertia: {
       users: InertiaRails.always { User.all },
     }
   end
@@ -252,7 +252,7 @@ Here's a summary of each approach:
 ```ruby
 class UsersController < ApplicationController
   def index
-    render inertia: 'Users/Index', props: {
+    render inertia: {
       # ALWAYS included on standard visits
       # OPTIONALLY included on partial reloads
       # ALWAYS evaluated

--- a/docs/guide/routing.md
+++ b/docs/guide/routing.md
@@ -34,12 +34,12 @@ end
 
 Some server-side frameworks allow you to generate URLs from named routes. However, you will not have access to those helpers client-side. Here are a couple ways to still use named routes with Inertia.
 
-The first option is to generate URLs server-side and include them as props. Notice in this example how we're passing the `edit_url` and `create_url` to the `Users/Index` component.
+The first option is to generate URLs server-side and include them as props. Notice in this example how we're passing the `edit_url` and `create_url` to the `users/index` component.
 
 ```ruby
 class UsersController < ApplicationController
   def index
-    render inertia: 'Users/Index', props: {
+    render inertia: {
       users: User.all.map do |user|
         user.as_json(
           only: [ :id, :name, :email ]

--- a/docs/guide/server-side-setup.md
+++ b/docs/guide/server-side-setup.md
@@ -174,7 +174,7 @@ class EventsController < ApplicationController
   def show
     event = Event.find(params[:id])
 
-    render inertia: 'Event/Show', props: {
+    render inertia: {
       event: event.as_json(
         only: [:id, :title, :start_date, :description]
       )

--- a/docs/guide/shared-data.md
+++ b/docs/guide/shared-data.md
@@ -244,9 +244,9 @@ Let's say we want a particular action to change only part of that data structure
 ```ruby
 class CrazyScorersController < ApplicationController
   def index
-    render inertia: 'CrazyScorersComponent',
-      props: { basketball_data: { points: 100 } },
-      deep_merge: true
+    render inertia: {
+      basketball_data: { points: 100 }
+    }, deep_merge: true
   end
 end
 
@@ -283,9 +283,9 @@ class CrazyScorersController < ApplicationController
   end
 
   def index
-    render inertia: 'CrazyScorersComponent',
-      props: { basketball_data: { points: 100 } },
-      deep_merge: false
+    render inertia: {
+      basketball_data: { points: 100 }
+    }, deep_merge: false
   end
 end
 


### PR DESCRIPTION
This PR makes docs lean towards Rails defaults when rendering components by utilizing convention over configuration principles, so now we recommend using `render inertia: props` over `render inertia: 'users/show', props:`

Also, I've added an explicit warning about `use_inertia_instance_props`.