### PR TITLE
fix: copy svelte.config.js regardless of --example-page flag

### DIFF
--- a/lib/generators/inertia/install/frameworks.yml
+++ b/lib/generators/inertia/install/frameworks.yml
@@ -76,7 +76,6 @@ svelte:
   copy_files_js:
     "InertiaExample.svelte": "%{js_destination_path}/pages/inertia_example/index.svelte"
   copy_files:
-    "svelte.config.js": "svelte.config.js"
     "../assets/svelte.svg": "%{js_destination_path}/assets/svelte.svg"
     "../assets/inertia.svg": "%{js_destination_path}/assets/inertia.svg"
     "../assets/vite_ruby.svg": "%{js_destination_path}/assets/vite_ruby.svg"

--- a/lib/generators/inertia/install/install_generator.rb
+++ b/lib/generators/inertia/install/install_generator.rb
@@ -101,6 +101,12 @@ module Inertia
         say "Copying #{inertia_entrypoint} entrypoint"
         copy_file "#{framework}/#{inertia_entrypoint}", js_file_path("entrypoints/#{inertia_entrypoint}")
 
+        # Copy framework-specific config files
+        if svelte?
+          say 'Copying svelte.config.js'
+          copy_file 'svelte/svelte.config.js', file_path('svelte.config.js')
+        end
+
         say 'Copying InertiaController'
         copy_file 'inertia_controller.rb', file_path('app/controllers/inertia_controller.rb')
 


### PR DESCRIPTION
The svelte.config.js file is only created when using the `--example-page` flag (which is the default). When generators are run with `--no-example-page`, this essential configuration file is not created, causing Vite to display a warning:

`[vite-plugin-svelte] no Svelte config found at /path/to/project - using default configuration.`

While not breaking, this warning appears on every Vite server start and indicates missing project configuration that should be present for all Svelte projects.

The svelte.config.js file is listed in the copy_files section of frameworks.yml, which is only processed by the `install_example_page` method. This method is skipped when `--no-example-page` is used.

  Changes:

1. Remove svelte.config.js from copy_files in frameworks.yml to prevent duplication
2. Add explicit copying of svelte.config.js in the install_inertia method for Svelte framework