### PR TITLE
Update Svelte version to fit current Vite version

### DIFF
--- a/lib/generators/inertia/install/frameworks.yml
+++ b/lib/generators/inertia/install/frameworks.yml
@@ -57,8 +57,8 @@ svelte:
   inertia_package: "@inertiajs/svelte"
   packages:
     - "svelte@5"
-    - "@sveltejs/vite-plugin-svelte"
-    - "vite@latest"
+    - "@sveltejs/vite-plugin-svelte@4"
+    - "vite@5"
   packages_ts:
     - "@tsconfig/svelte@5"
     - "svelte-check"


### PR DESCRIPTION
[`ruby_vite`](https://vite-ruby.netlify.app/) is not updated to Vite 7 yet, so the latest versions do not work very well. Hopefully [it](https://github.com/ElMassimo/vite_ruby/issues/583) [will](https://github.com/ElMassimo/vite_ruby/discussions/577) be addressed. 

```
13:18:31 vite.1 | failed to load config from /Users/capripot/Developer/src/github.com/capripot/inertia-ssr2-test-ts/vite.config.ts
13:18:31 vite.1 | error when starting dev server:
13:18:31 vite.1 | Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@sveltejs/vite-plugin-svelte' imported from /Users/capripot/Developer/src/github.com/capripot/inertia-ssr2-test-ts/vite.config.ts.timestamp-1763846311646-4cf5869104465.mjs
13:18:31 vite.1 |     at Object.getPackageJSONURL (node:internal/modules/package_json_reader:267:9)
13:18:31 vite.1 |     at packageResolve (node:internal/modules/esm/resolve:768:81)
13:18:31 vite.1 |     at moduleResolve (node:internal/modules/esm/resolve:854:18)
13:18:31 vite.1 |     at defaultResolve (node:internal/modules/esm/resolve:984:11)
13:18:31 vite.1 |     at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:780:12)
13:18:31 vite.1 |     at #cachedDefaultResolve (node:internal/modules/esm/loader:704:25)
13:18:31 vite.1 |     at ModuleLoader.resolve (node:internal/modules/esm/loader:687:38)
13:18:31 vite.1 |     at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:305:38)
13:18:31 vite.1 |     at ModuleJob._link (node:internal/modules/esm/module_job:137:49)
13:18:31 vite.1 | exited with code 1
```

In the meantime, this change will be pinning to older versions for Svelte.