### PR TITLE
Fix forceIndicesArrayFormatInFormData value for install generator

### DIFF
--- a/lib/generators/inertia/install/templates/react/inertia.jsx
+++ b/lib/generators/inertia/install/templates/react/inertia.jsx
@@ -41,7 +41,7 @@ createInertiaApp({
 
   defaults: {
     form: {
-      forceIndicesArrayFormatInFormData: true,
+      forceIndicesArrayFormatInFormData: false,
     },
     future: {
       useDataInertiaHeadAttribute: true,

--- a/lib/generators/inertia/install/templates/react/inertia.tsx
+++ b/lib/generators/inertia/install/templates/react/inertia.tsx
@@ -41,7 +41,7 @@ void createInertiaApp({
 
   defaults: {
     form: {
-      forceIndicesArrayFormatInFormData: true,
+      forceIndicesArrayFormatInFormData: false,
     },
     future: {
       useDataInertiaHeadAttribute: true,

--- a/lib/generators/inertia/install/templates/svelte/inertia.js
+++ b/lib/generators/inertia/install/templates/svelte/inertia.js
@@ -39,7 +39,7 @@ createInertiaApp({
 
   defaults: {
     form: {
-      forceIndicesArrayFormatInFormData: true,
+      forceIndicesArrayFormatInFormData: false,
     },
     future: {
       useDataInertiaHeadAttribute: true,

--- a/lib/generators/inertia/install/templates/svelte/inertia.ts
+++ b/lib/generators/inertia/install/templates/svelte/inertia.ts
@@ -39,7 +39,7 @@ createInertiaApp({
 
   defaults: {
     form: {
-      forceIndicesArrayFormatInFormData: true,
+      forceIndicesArrayFormatInFormData: false,
     },
     future: {
       useDataInertiaHeadAttribute: true,

--- a/lib/generators/inertia/install/templates/vue/inertia.js
+++ b/lib/generators/inertia/install/templates/vue/inertia.js
@@ -37,13 +37,13 @@ createInertiaApp({
   },
 
   defaults: {
+    form: {
+      forceIndicesArrayFormatInFormData: false,
+    },
     future: {
       useDataInertiaHeadAttribute: true,
       useDialogForErrorModal: true,
       preserveEqualProps: true,
-    },
-    visitOptions: () => {
-      return { queryStringArrayFormat: "brackets" }
     },
   },
 }).catch((error) => {

--- a/lib/generators/inertia/install/templates/vue/inertia.ts
+++ b/lib/generators/inertia/install/templates/vue/inertia.ts
@@ -37,13 +37,13 @@ createInertiaApp({
   },
 
   defaults: {
+    form: {
+      forceIndicesArrayFormatInFormData: false,
+    },
     future: {
       useDataInertiaHeadAttribute: true,
       useDialogForErrorModal: true,
       preserveEqualProps: true,
-    },
-    visitOptions: () => {
-      return { queryStringArrayFormat: "brackets" }
     },
   },
 }).catch((error) => {


### PR DESCRIPTION
Another fix for install generator: `forceIndicesArrayFormatInFormData: true` is a default that we want to actually update to use brackets notation.