### PR TITLE
Fix incorrect file references in TypeScript templates

### DIFF
--- a/lib/generators/inertia/install/templates/react/InertiaExample.tsx
+++ b/lib/generators/inertia/install/templates/react/InertiaExample.tsx
@@ -34,7 +34,7 @@ export default function InertiaExample(
       <div className={cs.footer}>
         <div className={cs.card}>
           <p>
-            Edit <code><%= js_destination_path %>/pages/inertia_example/index.jsx</code> and save to test <abbr title="Hot Module Replacement">HMR</abbr>.
+            Edit <code><%= js_destination_path %>/pages/inertia_example/index.tsx</code> and save to test <abbr title="Hot Module Replacement">HMR</abbr>.
           </p>
         </div>
 

--- a/lib/generators/inertia/install/templates/vue/InertiaExample.ts.vue
+++ b/lib/generators/inertia/install/templates/vue/InertiaExample.ts.vue
@@ -17,7 +17,7 @@
     <div class="footer">
       <div class="card">
         <p>
-          Edit <code><%= js_destination_path %>/pages/inertia_example/index.ts.vue</code> and save to test <abbr title="Hot Module Replacement">HMR</abbr>.
+          Edit <code><%= js_destination_path %>/pages/inertia_example/index.vue</code> and save to test <abbr title="Hot Module Replacement">HMR</abbr>.
         </p>
       </div>
 


### PR DESCRIPTION
When I was creating a new Rails app with Inertia React, I noticed the HMR instruction text in the TypeScript templates points to incorrect file paths:

  - InertiaExample.tsx said to edit index.jsx, but the generated file is index.tsx

Also

  - InertiaExample.ts.vue said to edit index.ts.vue, but per frameworks.yml, the generated file is index.vue

First contribution here, happy to make any changes if needed 😀