### PR TITLE
Fix optional once props

### DIFF
--- a/lib/inertia_rails/inertia_rails.rb
+++ b/lib/inertia_rails/inertia_rails.rb
@@ -30,8 +30,8 @@ module InertiaRails
       LazyProp.new(value, &block)
     end
 
-    def optional(&block)
-      OptionalProp.new(&block)
+    def optional(...)
+      OptionalProp.new(...)
     end
 
     def always(&block)

--- a/spec/dummy/app/controllers/inertia_render_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_render_test_controller.rb
@@ -265,4 +265,18 @@ class InertiaRenderTestController < ApplicationController
       baz: InertiaRails::OnceProp.new { 'qux' },
     }
   end
+
+  def merge_once_props
+    render inertia: 'TestComponent', props: {
+      activity: InertiaRails.merge(once: true) { [{ id: 1, action: 'login' }] },
+      regular: 'regular prop',
+    }
+  end
+
+  def optional_once_props
+    render inertia: 'TestComponent', props: {
+      categories: InertiaRails.optional(once: true) { %w[category1 category2] },
+      regular: 'regular prop',
+    }
+  end
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -54,6 +54,8 @@ Rails.application.routes.draw do
   get 'once_props_not_fresh' => 'inertia_render_test#once_props_not_fresh'
   get 'once_props_fresh' => 'inertia_render_test#once_props_fresh'
   get 'once_props_fresh_and_non_fresh' => 'inertia_render_test#once_props_fresh_and_non_fresh'
+  get 'merge_once_props' => 'inertia_render_test#merge_once_props'
+  get 'optional_once_props' => 'inertia_render_test#optional_once_props'
   get 'non_inertiafied' => 'inertia_test#non_inertiafied'
   get 'deeply_nested_props' => 'inertia_render_test#deeply_nested_props'
 


### PR DESCRIPTION
This PR makes `InertiaRails.optional(once: true)` work by passing options to the prop initializer.