### PR TITLE
Fix 3.16.0 regression of all exception pages returning pure text error pages instead of Rails errors in development

### DIFF
--- a/lib/patches/debug_exceptions.rb
+++ b/lib/patches/debug_exceptions.rb
@@ -17,7 +17,7 @@ module InertiaRails
       template = create_template(request, wrapper)
       file = "rescues/#{wrapper.rescue_template}"
 
-      if content_type == Mime[:md]
+      if Mime[:md] && content_type == Mime[:md]
         body = template.render(template: file, layout: false, formats: [:text])
         format = 'text/markdown'
       elsif request.xhr? && !request.headers['X-Inertia']


### PR DESCRIPTION
## Problem

Rails development error pages show as plain text instead of the interactive HTML debug page when using inertia_rails v3.16.0 with Rails < 8.2:

<img width="719" height="313" alt="image" src="https://github.com/user-attachments/assets/67ea9952-8963-401f-86c4-9805ef53900e" />

The bug does not happen in v3.15.0. 

## Root Cause

In commit 732d20b, a Rails 8.2 compatibility fix was added. The new code checks:

```ruby
if content_type == Mime[:md]
  # render as markdown
```

However, in Rails < 8.2, `Mime[:md]` returns `nil` because the markdown MIME type isn't registered. When the method is called with the default `content_type = nil`, the condition `nil == nil` evaluates to `true`, causing ALL error pages to render as `text/markdown` instead of `text/html`.

## Solution

Guard the markdown check to ensure `Mime[:md]` is defined:

```ruby
if Mime[:md] && content_type == Mime[:md]
```

This maintains Rails 8.2+ compatibility while fixing the regression for Rails < 8.2.

## Testing

- Verified the logic fix with Rails runner
- All 474 existing specs pass
- Manually tested with a Rails 7.2 app - error pages now render as interactive HTML again
