### PR TITLE
Skip excluded hash props on partial reloads

### DIFF
--- a/lib/inertia_rails/props_resolver.rb
+++ b/lib/inertia_rails/props_resolver.rb
@@ -82,6 +82,8 @@ module InertiaRails
         prop = prop.to_inertia if prop.respond_to?(:to_inertia)
 
         if prop.is_a?(Hash) && prop.any?
+          next if !parent_was_resolved && excluded_by_partial_request?(path)
+
           nested = deep_transform_props(prop, path, parent_was_resolved: parent_was_resolved)
           transformed_props[key] = nested unless nested.empty?
           next

--- a/spec/inertia/props_resolver_spec.rb
+++ b/spec/inertia/props_resolver_spec.rb
@@ -912,6 +912,16 @@ RSpec.describe InertiaRails::PropsResolver do
       expect(page[:props]).not_to have_key(:user)
     end
 
+    it 'excludes nested always props when parent is not requested' do
+      page = resolve_partial(
+        { name: 'Jonathan', user: { name: 'Jonathon', errors: InertiaRails.always { { name: 'required' } } } },
+        'name'
+      )
+
+      expect(page[:props][:name]).to eq('Jonathan')
+      expect(page[:props]).not_to have_key(:user)
+    end
+
     it 'excludes props via except header' do
       page = resolve(
         { auth: { user: 'Jonathan', token: 'secret' } },

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -274,14 +274,9 @@ RSpec.describe 'rendering inertia views', type: :request do
 
       before { get deeply_nested_props_path, headers: headers }
 
-      it 'excludes everything but Always props' do
+      it 'excludes everything but top-level Always props' do
         expect(response.parsed_body['props']).to eq(
-          'always' => 'always prop',
-          'nested' => {
-            'deeply_nested' => {
-              'deeply_nested_always' => 'deeply nested always prop',
-            },
-          }
+          'always' => 'always prop'
         )
       end
     end
@@ -304,9 +299,6 @@ RSpec.describe 'rendering inertia views', type: :request do
             'evaluated' => {
               'first' => 'first evaluated nested param',
               'second' => 'second evaluated nested param',
-            },
-            'deeply_nested' => {
-              'deeply_nested_always' => 'deeply nested always prop',
             },
           }
         )


### PR DESCRIPTION
## Summary
While debugging a regression after upgrading to Inertia v3, I found that partial reloads can still traverse excluded hash containers.

When that happens, nested props can leak into the response even though the parent hash was not requested, leaving a partial version of the parent payload instead of excluding it entirely.

This adds the same partial-request guard that arrays already have before recursing into hashes.

The spec covers the smaller repro: an excluded parent hash with a nested `AlwaysProp` should stay excluded instead of leaking back into the response.
