### PR TITLE
Better SSR puma plugin lookup defaults

### DIFF
--- a/docs/guide/server-side-rendering.md
+++ b/docs/guide/server-side-rendering.md
@@ -361,6 +361,19 @@ The plugin automatically starts and stops the SSR Node.js process alongside Puma
 
 The plugin is a no-op when `ssr_enabled` is `false` or the SSR bundle is not found, so it is safe to add unconditionally.
 
+#### Bundle Resolution
+
+The plugin locates the SSR bundle using the following rules, in order:
+
+1. **Explicit config** — `config.ssr_bundle` (a path or an array of paths; the first existing file wins).
+2. **ViteRuby output** — if ViteRuby is loaded, it globs `<ssr_output_dir>/*.js`.
+3. **`ssr/` directory** — globs `ssr/*.js` in the project root (matches the `@inertiajs/vite` plugin's default SSR build output).
+4. **Legacy fallback** — checks `public/assets-ssr/*.js`.
+
+If none of the above finds a file, the plugin logs nothing and stays idle.
+
+#### Runtime Detection
+
 The JavaScript runtime is auto-detected from your lockfile (`bun.lockb` → Bun, `deno.lock` → Deno, otherwise Node.js). To override:
 
 ```ruby

--- a/lib/puma/plugin/inertia_ssr.rb
+++ b/lib/puma/plugin/inertia_ssr.rb
@@ -138,14 +138,17 @@ Puma::Plugin.create do
 
     return Array(config.ssr_bundle).find { |path| File.exist?(path) } if config.ssr_bundle
 
-    if defined?(ViteRuby)
-      ssr_dir = ViteRuby.config.ssr_output_dir
-      candidates = Dir.glob(File.join(ssr_dir, 'inertia.*')) if ssr_dir
-      return candidates.first if candidates&.any?
+    patterns = %w[ssr/*.js public/assets-ssr/*.js]
+    if defined?(ViteRuby) && (ssr_dir = ViteRuby.config.ssr_output_dir)
+      patterns.prepend(File.join(ssr_dir, '*.js'))
     end
 
-    path = 'public/assets-ssr/inertia.js'
-    path if File.exist?(path)
+    patterns.each do |pattern|
+      candidates = Dir.glob(pattern)
+      return candidates.first if candidates.any?
+    end
+
+    nil
   end
 
   def resolve_base_url


### PR DESCRIPTION
This PR esits lookup rules, in order:

1. **Explicit config** — `config.ssr_bundle` (a path or an array of paths; the first existing file wins).
2. **ViteRuby output** — if ViteRuby is loaded, it globs `<ssr_output_dir>/*.js`.
3. **`ssr/` directory** — globs `ssr/*.js` in the project root (matches the `@inertiajs/vite` plugin's default SSR build output).
4. **Legacy fallback** — checks `public/assets-ssr/*.js`.