### PR TITLE
Add prop-level caching and caching documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+* Skip excluded hash props on partial reloads (@erickreutz)
+* Fix Vite plugin insertion order in install generator (@onk)
+* Fix typo in `inertia()` plugin configuration example in docs (@onk)
+* Better SSR Puma plugin lookup defaults (@skryukov)
+* Add prop-level caching and caching documentation (@skryukov)
+
 ## [3.20.0] - 2026-04-04
 
 * Fix partial reload filtering with arrays

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -143,6 +143,7 @@ export default withMermaid({
             { text: 'Load when visible', link: '/guide/load-when-visible' },
             { text: 'Merging props', link: '/guide/merging-props' },
             { text: 'Once props', link: '/guide/once-props' },
+            { text: 'Cached props', link: '/guide/cached-props' },
             { text: 'Infinite scroll', link: '/guide/infinite-scroll' },
             { text: 'Remembering state', link: '/guide/remembering-state' },
           ],
@@ -159,6 +160,7 @@ export default withMermaid({
         {
           text: 'Advanced',
           items: [
+            { text: 'Caching', link: '/guide/caching' },
             { text: 'Asset versioning', link: '/guide/asset-versioning' },
             { text: 'Code splitting', link: '/guide/code-splitting' },
             { text: 'Configuration', link: '/guide/configuration' },

--- a/docs/guide/cached-props.md
+++ b/docs/guide/cached-props.md
@@ -1,0 +1,108 @@
+# Cached Props
+
+@available_since rails=master
+
+Cached props use your server-side cache store to avoid recomputing expensive data on every request. When the cache is warm, the block is never evaluated — Inertia serves the pre-serialized JSON directly.
+
+## Creating Cached Props
+
+To create a cached prop, use the `InertiaRails.cache` method. This method requires a cache key and a block that returns the prop data.
+
+```ruby
+class DashboardController < ApplicationController
+  def index
+    render inertia: {
+      stats: InertiaRails.cache('dashboard_stats') { Stats.compute },
+    }
+  end
+end
+```
+
+On the first request, the block is evaluated, serialized to JSON, and written to the cache. Subsequent requests serve the cached JSON without evaluating the block.
+
+## Cache Keys
+
+Cache keys determine when cached data is invalidated. Inertia supports several key formats.
+
+### String Keys
+
+The simplest form — a static string:
+
+```ruby
+InertiaRails.cache('sidebar_nav') { NavigationItem.tree }
+```
+
+### Active Record Objects
+
+Pass an Active Record object to derive the key from `cache_key_with_version`. The cache is automatically invalidated when the record is updated:
+
+```ruby
+InertiaRails.cache(@post) { PostSerializer.render(@post) }
+# Cache key: "inertia_rails/posts/1-20260410120000"
+```
+
+### Array Keys
+
+Pass an array to build a composite key:
+
+```ruby
+InertiaRails.cache(['stats', current_user.id]) { Stats.for(current_user) }
+# Cache key: "inertia_rails/stats/42"
+```
+
+## Cache Options
+
+You can pass `expires_in` and `race_condition_ttl` options to control cache behavior:
+
+```ruby
+InertiaRails.cache('stats', expires_in: 1.hour) { Stats.compute }
+
+InertiaRails.cache('stats', expires_in: 1.hour, race_condition_ttl: 10.seconds) { Stats.compute }
+```
+
+Alternatively, pass a hash with a `key` and options:
+
+```ruby
+InertiaRails.cache(key: 'stats', expires_in: 1.hour) { Stats.compute }
+```
+
+## Combining with Other Prop Types
+
+The `cache` option can be passed to [deferred](/guide/deferred-props) and [optional](/guide/partial-reloads#lazy-data-evaluation) props:
+
+```ruby
+class DashboardController < ApplicationController
+  def index
+    render inertia: {
+      # Deferred prop with caching
+      feed: InertiaRails.defer(cache: 'user_feed', group: 'feed') { current_user.feed },
+
+      # Optional prop with caching
+      categories: InertiaRails.optional(cache: @team) { @team.categories },
+    }
+  end
+end
+```
+
+The `cache` option accepts the same key formats as `InertiaRails.cache`: strings, Active Record objects, arrays, and hashes with options.
+
+```ruby
+InertiaRails.defer(cache: { key: 'feed', expires_in: 5.minutes }) { current_user.feed }
+```
+
+## Cache Store Configuration
+
+By default, Inertia uses `Rails.cache` as the cache store. You can configure a different store:
+
+```ruby
+# config/initializers/inertia.rb
+
+InertiaRails.configure do |config|
+  config.cache_store = ActiveSupport::Cache::MemoryStore.new
+end
+```
+
+All cached prop keys are automatically prefixed with `inertia_rails/` to avoid collisions with other cached data.
+
+> [!TIP]
+> For HTTP-level response caching with ETags, see the [Caching](/guide/caching) guide.

--- a/docs/guide/cached-props.md
+++ b/docs/guide/cached-props.md
@@ -15,7 +15,7 @@ To create a cached prop, use the `InertiaRails.cache` method. This method requir
 class DashboardController < ApplicationController
   def index
     render inertia: {
-      stats: InertiaRails.cache('dashboard_stats') { Stats.compute },
+      stats: InertiaRails.cache('dashboard_stats', expires_in: 1.hour) { Stats.compute },
     }
   end
 end
@@ -72,7 +72,7 @@ class DashboardController < ApplicationController
   def index
     render inertia: {
       # Deferred prop with caching
-      feed: InertiaRails.defer(cache: 'user_feed', group: 'feed') { current_user.feed },
+      feed: InertiaRails.defer(cache: { key: 'feed', expires_in: 5.minutes }, group: 'feed') { current_user.feed },
 
       # Optional prop with caching
       categories: InertiaRails.optional(cache: @team) { @team.categories },
@@ -90,3 +90,5 @@ InertiaRails.defer(cache: { key: 'feed', expires_in: 5.minutes }) { current_user
 ## Cache Store
 
 By default, Inertia uses `Rails.cache`. You can configure a different store via the [`cache_store`](/guide/configuration#cache_store) option. All cached prop keys are automatically prefixed with `inertia_rails/` to avoid collisions.
+
+For more information on configuring cache stores, cache key strategies, and expiration policies, see the [Rails low-level caching guide](https://guides.rubyonrails.org/caching_with_rails.html#low-level-caching-using-rails-cache).

--- a/docs/guide/cached-props.md
+++ b/docs/guide/cached-props.md
@@ -4,6 +4,9 @@
 
 Cached props use your server-side cache store to avoid recomputing expensive data on every request. When the cache is warm, the block is never evaluated — Inertia serves the pre-serialized JSON directly.
 
+> [!NOTE]
+> To understand when to use cached props vs once props vs HTTP caching, see the [Caching](/guide/caching) guide.
+
 ## Creating Cached Props
 
 To create a cached prop, use the `InertiaRails.cache` method. This method requires a cache key and a block that returns the prop data.
@@ -60,12 +63,6 @@ InertiaRails.cache('stats', expires_in: 1.hour) { Stats.compute }
 InertiaRails.cache('stats', expires_in: 1.hour, race_condition_ttl: 10.seconds) { Stats.compute }
 ```
 
-Alternatively, pass a hash with a `key` and options:
-
-```ruby
-InertiaRails.cache(key: 'stats', expires_in: 1.hour) { Stats.compute }
-```
-
 ## Combining with Other Prop Types
 
 The `cache` option can be passed to [deferred](/guide/deferred-props) and [optional](/guide/partial-reloads#lazy-data-evaluation) props:
@@ -90,19 +87,6 @@ The `cache` option accepts the same key formats as `InertiaRails.cache`: strings
 InertiaRails.defer(cache: { key: 'feed', expires_in: 5.minutes }) { current_user.feed }
 ```
 
-## Cache Store Configuration
+## Cache Store
 
-By default, Inertia uses `Rails.cache` as the cache store. You can configure a different store:
-
-```ruby
-# config/initializers/inertia.rb
-
-InertiaRails.configure do |config|
-  config.cache_store = ActiveSupport::Cache::MemoryStore.new
-end
-```
-
-All cached prop keys are automatically prefixed with `inertia_rails/` to avoid collisions with other cached data.
-
-> [!TIP]
-> For HTTP-level response caching with ETags, see the [Caching](/guide/caching) guide.
+By default, Inertia uses `Rails.cache`. You can configure a different store via the [`cache_store`](/guide/configuration#cache_store) option. All cached prop keys are automatically prefixed with `inertia_rails/` to avoid collisions.

--- a/docs/guide/caching.md
+++ b/docs/guide/caching.md
@@ -1,0 +1,67 @@
+# Caching
+
+Inertia Rails supports two complementary caching strategies: HTTP caching for full responses, and prop-level caching for expensive data. You can use them independently or together.
+
+## HTTP Caching
+
+Rails provides built-in HTTP caching via `stale?` and `fresh_when`. These work with Inertia responses, but require one adjustment: because the same URL returns HTML on the initial page load and JSON on subsequent Inertia visits, ETags must account for the request type.
+
+### Differentiating ETags
+
+Use the `etag` method in your controller to include `request.inertia?` in the ETag calculation:
+
+```ruby
+class ApplicationController < ActionController::Base
+  etag { request.inertia? }
+end
+```
+
+This ensures that HTML and JSON responses for the same URL produce different ETags, preventing the browser from serving a stale cached response in the wrong format.
+
+### Using `stale?`
+
+With the ETag differentiation in place, use `stale?` as you normally would in Rails:
+
+```ruby
+class PostsController < ApplicationController
+  def show
+    @post = Post.find(params[:id])
+
+    if stale?(@post)
+      render inertia: { post: @post.as_json }
+    end
+  end
+end
+```
+
+When the post hasn't changed, Rails returns a `304 Not Modified` response and skips rendering entirely.
+
+### Using `fresh_when`
+
+For simpler cases where you don't need conditional logic:
+
+```ruby
+class PostsController < ApplicationController
+  def show
+    @post = Post.find(params[:id])
+    fresh_when(@post)
+
+    render inertia: { post: @post.as_json }
+  end
+end
+```
+
+## Prop-Level Caching
+
+For caching individual props on the server side, see [Cached props](/guide/cached-props). Prop-level caching stores computed prop values in your Rails cache store, skipping expensive block evaluation on cache hits.
+
+```ruby
+class DashboardController < ApplicationController
+  def index
+    render inertia: {
+      stats: InertiaRails.cache('dashboard_stats', expires_in: 1.hour) { Stats.compute },
+      feed: InertiaRails.defer(cache: 'user_feed') { current_user.feed },
+    }
+  end
+end
+```

--- a/docs/guide/caching.md
+++ b/docs/guide/caching.md
@@ -1,6 +1,29 @@
 # Caching
 
-Inertia Rails supports two complementary caching strategies: HTTP caching for full responses, and prop-level caching for expensive data. You can use them independently or together.
+Inertia Rails offers several complementary strategies for avoiding redundant work. Each solves a different problem, and you can combine them.
+
+## Choosing a Strategy
+
+| Strategy                             | What it saves               | Where it lives          | Best for                                  |
+| ------------------------------------ | --------------------------- | ----------------------- | ----------------------------------------- |
+| [HTTP caching](#http-caching)        | Entire response render      | Browser / CDN           | Pages tied to a single record's freshness |
+| [Cached props](#prop-level-caching)  | Block evaluation            | Server-side cache store | Expensive queries or computations         |
+| [Once props](#once-props)            | Bandwidth and serialization | Client memory           | Large or rarely-changing shared data      |
+| [SSR caching](#ssr-response-caching) | SSR render request          | Server-side cache store | Avoiding redundant Node.js SSR calls      |
+
+In short: **cached props skip computing**, **once props skip sending**, **HTTP caching skips rendering**, and **SSR caching skips the SSR request**.
+
+These strategies are independent. A prop can be both cached on the server and marked as once so the client doesn't re-request it. HTTP caching can wrap an entire response that contains cached props. SSR caching can be layered on top of any combination.
+
+### Why only `defer` and `optional` support the `cache` option
+
+The `cache` option is available on [deferred](/guide/deferred-props) and [optional](/guide/partial-reloads#lazy-data-evaluation) props because these represent data that is loaded on demand — caching their result avoids re-evaluating expensive blocks on repeated requests.
+
+Other prop types don't need it:
+
+- **Once props** already skip evaluation when the client has the data. If the computation itself is expensive, use `InertiaRails.cache` directly in the block.
+- **Always props** are meant for cheap, frequently-changing data (flash messages, auth state). If the data is expensive enough to cache, it probably shouldn't be `always`.
+- **Merge and scroll props** describe how the client handles the data, not how the server computes it. If the underlying data is expensive, wrap it with `InertiaRails.cache` and pass the result.
 
 ## HTTP Caching
 
@@ -53,7 +76,7 @@ end
 
 ## Prop-Level Caching
 
-For caching individual props on the server side, see [Cached props](/guide/cached-props). Prop-level caching stores computed prop values in your Rails cache store, skipping expensive block evaluation on cache hits.
+Prop-level caching stores computed values in your Rails cache store, skipping expensive block evaluation on cache hits. See the [Cached props](/guide/cached-props) guide for full details.
 
 ```ruby
 class DashboardController < ApplicationController
@@ -63,5 +86,25 @@ class DashboardController < ApplicationController
       feed: InertiaRails.defer(cache: 'user_feed') { current_user.feed },
     }
   end
+end
+```
+
+## Once Props
+
+Once props are remembered by the client and excluded from subsequent responses. This saves bandwidth for data that rarely changes, such as shared navigation or role lists. See the [Once props](/guide/once-props) guide for full details.
+
+```ruby
+class ApplicationController < ActionController::Base
+  inertia_share countries: InertiaRails.once { Country.all }
+end
+```
+
+## SSR Response Caching
+
+When SSR is enabled, each page load sends a request to the Node.js server. SSR caching stores these responses so identical page data is only rendered once. See [SSR response caching](/guide/server-side-rendering#ssr-response-caching) for full details.
+
+```ruby
+InertiaRails.configure do |config|
+  config.ssr_cache = true
 end
 ```

--- a/docs/guide/caching.md
+++ b/docs/guide/caching.md
@@ -1,6 +1,6 @@
 # Caching
 
-Inertia Rails offers several complementary strategies for avoiding redundant work. Each solves a different problem, and you can combine them.
+Inertia Rails offers several complementary strategies for avoiding redundant work. Each solves a different problem, and you can combine them. If you're new to caching in Rails, start with the [Rails caching guide](https://guides.rubyonrails.org/caching_with_rails.html).
 
 ## Choosing a Strategy
 
@@ -83,7 +83,7 @@ class DashboardController < ApplicationController
   def index
     render inertia: {
       stats: InertiaRails.cache('dashboard_stats', expires_in: 1.hour) { Stats.compute },
-      feed: InertiaRails.defer(cache: 'user_feed') { current_user.feed },
+      feed: InertiaRails.defer(cache: { key: 'feed', expires_in: 5.minutes }) { current_user.feed },
     }
   end
 end

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -124,6 +124,16 @@ your application.
 
 Requires a JavaScript server to be available at `ssr_url`. [_Example_](https://github.com/ElMassimo/inertia-rails-ssr-template)
 
+### `ssr_cache`
+
+**Default**: `nil` (disabled)
+
+@available_since rails=master
+
+Cache SSR responses to avoid redundant Node.js render requests for identical page data. Accepts `true`, `false`/`nil`, or a Hash of `Rails.cache.fetch` options (e.g. `{ expires_in: 1.hour }`). Lambdas are supported and evaluated in the controller context. Can be overridden per render call.
+
+See [SSR response caching](/guide/server-side-rendering#ssr-response-caching) for usage examples.
+
 ### `ssr_url` _(experimental)_
 
 **Default**: `nil` (auto-detects from Vite dev server, falls back to `http://localhost:13714/render`)

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -71,6 +71,18 @@ def underscore_params
 end
 ```
 
+### `cache_store`
+
+**Default**: `nil` (falls back to `Rails.cache`)
+
+The cache store used for [cached props](/guide/cached-props) and [SSR response caching](/guide/server-side-rendering). Accepts any `ActiveSupport::Cache::Store` instance.
+
+```ruby
+InertiaRails.configure do |config|
+  config.cache_store = ActiveSupport::Cache::MemoryStore.new
+end
+```
+
 ### `deep_merge_shared_data`
 
 **Default**: `false`

--- a/docs/guide/deferred-props.md
+++ b/docs/guide/deferred-props.md
@@ -252,3 +252,21 @@ end
 ```
 
 For more information on once props, see the [once props](/guide/once-props) documentation.
+
+## Combining with Caching
+
+@available_since rails=master
+
+You may pass the `cache` option to a deferred prop to cache the resolved value on the server side. On cache hits, the block is not evaluated.
+
+```ruby
+class DashboardController < ApplicationController
+  def index
+    render inertia: {
+      feed: InertiaRails.defer(cache: 'user_feed', group: 'feed') { current_user.feed },
+    }
+  end
+end
+```
+
+For more information on cache keys and options, see the [cached props](/guide/cached-props) documentation.

--- a/docs/guide/deferred-props.md
+++ b/docs/guide/deferred-props.md
@@ -263,7 +263,7 @@ You may pass the `cache` option to a deferred prop to cache the resolved value o
 class DashboardController < ApplicationController
   def index
     render inertia: {
-      feed: InertiaRails.defer(cache: 'user_feed', group: 'feed') { current_user.feed },
+      feed: InertiaRails.defer(cache: { key: 'feed', expires_in: 5.minutes }, group: 'feed') { current_user.feed },
     }
   end
 end

--- a/docs/guide/once-props.md
+++ b/docs/guide/once-props.md
@@ -4,6 +4,9 @@
 
 Some data rarely changes, is expensive to compute, or is simply large. Rather than including this data in every response, you may use _once props_. These props are remembered by the client and reused on subsequent pages that include the same prop. This makes them ideal for [shared data](/guide/shared-data).
 
+> [!NOTE]
+> To understand when to use once props vs cached props vs HTTP caching, see the [Caching](/guide/caching) guide.
+
 ## Creating Once Props
 
 To create a once prop, use the `InertiaRails.once` method when returning your response. This method receives a block that returns the prop data.

--- a/docs/guide/partial-reloads.md
+++ b/docs/guide/partial-reloads.md
@@ -266,3 +266,21 @@ end
 ```
 
 For more information on once props, see the [once props](/guide/once-props) documentation.
+
+## Combining with Caching
+
+@available_since rails=master
+
+You may pass the `cache` option to an optional prop to cache the resolved value on the server side. On cache hits, the block is not evaluated.
+
+```ruby
+class UsersController < ApplicationController
+  def index
+    render inertia: {
+      users: InertiaRails.optional(cache: 'all_users') { User.all },
+    }
+  end
+end
+```
+
+For more information on cache keys and options, see the [cached props](/guide/cached-props) documentation.

--- a/docs/guide/server-side-rendering.md
+++ b/docs/guide/server-side-rendering.md
@@ -348,7 +348,7 @@ createServer(
 
 ### Puma Plugin
 
-@available_since rails=master
+@available_since rails=3.20.0
 
 The recommended way to run the SSR server in production is with the built-in Puma plugin. Add the plugin to your Puma configuration:
 

--- a/docs/guide/server-side-rendering.md
+++ b/docs/guide/server-side-rendering.md
@@ -480,6 +480,67 @@ InertiaRails.configure do |config|
 end
 ```
 
+## SSR Response Caching
+
+@available_since rails=3.19.0
+
+SSR rendering sends a request to the Node.js server for every page load. You can cache these responses to avoid redundant renders when the same page data is served repeatedly.
+
+### Enabling SSR Caching
+
+Set `ssr_cache` in your initializer:
+
+```ruby
+# config/initializers/inertia_rails.rb
+InertiaRails.configure do |config|
+  config.ssr_cache = true
+end
+```
+
+When enabled, the SSR response is cached using an MD5 digest of the page JSON as the cache key. Identical page data produces the same key, so the Node.js server is only called once per unique page.
+
+### Cache Options
+
+Pass a hash to control cache behavior:
+
+```ruby
+InertiaRails.configure do |config|
+  config.ssr_cache = { expires_in: 1.hour }
+end
+```
+
+### Dynamic Configuration
+
+Use a lambda for per-request control. The lambda is evaluated in the controller context:
+
+```ruby
+InertiaRails.configure do |config|
+  config.ssr_cache = -> { { expires_in: action_name == 'index' ? 1.hour : 5.minutes } }
+end
+```
+
+### Per-Render Override
+
+Override the global setting on individual render calls:
+
+```ruby
+class PostsController < ApplicationController
+  def show
+    render inertia: 'Posts/Show',
+      props: { post: @post.as_json },
+      ssr_cache: false  # skip caching for this render
+  end
+end
+```
+
+### Development Mode
+
+SSR caching is automatically disabled when the Vite dev server is running, since dev responses change frequently and should not be cached.
+
+### Cache Store
+
+SSR caching uses the same [`cache_store`](/guide/configuration#cache_store) as [cached props](/guide/cached-props). SSR cache keys are prefixed with `inertia_ssr/`.
+
 ## Disabling SSR
 
 Sometimes you may wish to disable server-side rendering for certain controllers or pages in your application. You may do so by setting the `ssr_enabled` option to `false` using `inertia_config`.

--- a/lib/inertia_rails.rb
+++ b/lib/inertia_rails.rb
@@ -12,6 +12,8 @@ require_relative 'inertia_rails/current'
 require_relative 'inertia_rails/errors'
 
 # props
+require_relative 'inertia_rails/raw_json'
+require_relative 'inertia_rails/prop_cacheable'
 require_relative 'inertia_rails/prop_onceable'
 require_relative 'inertia_rails/prop_mergeable'
 require_relative 'inertia_rails/base_prop'
@@ -19,6 +21,7 @@ require_relative 'inertia_rails/ignore_on_first_load_prop'
 require_relative 'inertia_rails/always_prop'
 require_relative 'inertia_rails/lazy_prop'
 require_relative 'inertia_rails/optional_prop'
+require_relative 'inertia_rails/cached_prop'
 require_relative 'inertia_rails/defer_prop'
 require_relative 'inertia_rails/merge_prop'
 require_relative 'inertia_rails/once_prop'
@@ -54,6 +57,10 @@ module InertiaRails
       @configuration ||= Configuration.default
     end
 
+    def cache_store
+      configuration.cache_store
+    end
+
     def deprecator # :nodoc:
       @deprecator ||= ActiveSupport::Deprecation.new
     end
@@ -80,6 +87,10 @@ module InertiaRails
 
     def deep_merge(match_on: nil, &block)
       MergeProp.new(deep_merge: true, match_on: match_on, &block)
+    end
+
+    def cache(...)
+      CachedProp.new(...)
     end
 
     def defer(...)

--- a/lib/inertia_rails/cached_prop.rb
+++ b/lib/inertia_rails/cached_prop.rb
@@ -4,13 +4,8 @@ module InertiaRails
   class CachedProp < BaseProp
     include PropCacheable
 
-    def initialize(cache_arg = nil, **options, &block)
-      cache_options = options.extract!(:key, :expires_in, :race_condition_ttl).compact
-      cache = cache_arg || cache_options.presence
-      cache = cache_options.merge(key: cache) if cache_arg && cache_options.any?
-      raise ArgumentError, 'cache key is required' if cache.blank?
-
-      super(**options, cache: cache, &block)
+    def initialize(key, **options, &block)
+      super(cache: options.merge!(key: key), &block)
     end
   end
 end

--- a/lib/inertia_rails/cached_prop.rb
+++ b/lib/inertia_rails/cached_prop.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module InertiaRails
+  class CachedProp < BaseProp
+    include PropCacheable
+
+    def initialize(cache_arg = nil, **options, &block)
+      cache_options = options.extract!(:key, :expires_in, :race_condition_ttl).compact
+      cache = cache_arg || cache_options.presence
+      cache = cache_options.merge(key: cache) if cache_arg && cache_options.any?
+      raise ArgumentError, 'cache key is required' if cache.blank?
+
+      super(**options, cache: cache, &block)
+    end
+  end
+end

--- a/lib/inertia_rails/configuration.rb
+++ b/lib/inertia_rails/configuration.rb
@@ -71,6 +71,10 @@ module InertiaRails
 
       # Whether to include shared prop keys in the page response metadata.
       expose_shared_prop_keys: true,
+
+      # Cache store for prop-level caching and SSR response caching.
+      # Defaults to Rails.cache when nil.
+      cache_store: nil,
     }.freeze
 
     OPTION_NAMES = DEFAULTS.keys.freeze
@@ -139,6 +143,10 @@ module InertiaRails
     # Returns the callable without evaluating it — called with (error, page) by the renderer.
     def on_ssr_error
       @options[:on_ssr_error]
+    end
+
+    def cache_store
+      @options[:cache_store] || Rails.cache
     end
 
     OPTION_NAMES.each do |option|

--- a/lib/inertia_rails/defer_prop.rb
+++ b/lib/inertia_rails/defer_prop.rb
@@ -4,6 +4,7 @@ module InertiaRails
   class DeferProp < IgnoreOnFirstLoadProp
     prepend PropOnceable
     prepend PropMergeable
+    prepend PropCacheable
 
     DEFAULT_GROUP = 'default'
 

--- a/lib/inertia_rails/optional_prop.rb
+++ b/lib/inertia_rails/optional_prop.rb
@@ -3,5 +3,6 @@
 module InertiaRails
   class OptionalProp < IgnoreOnFirstLoadProp
     prepend PropOnceable
+    prepend PropCacheable
   end
 end

--- a/lib/inertia_rails/prop_cacheable.rb
+++ b/lib/inertia_rails/prop_cacheable.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module InertiaRails
+  module PropCacheable
+    def initialize(**props, &block)
+      cache_arg = props.delete(:cache)
+
+      if cache_arg.is_a?(Hash)
+        raise ArgumentError, 'cache: hash requires a :key' unless cache_arg.key?(:key)
+
+        @cache_key = derive_cache_key(cache_arg.delete(:key))
+        @cache_options = cache_arg.freeze
+      elsif cache_arg
+        @cache_key = derive_cache_key(cache_arg)
+        @cache_options = nil
+      end
+
+      super
+    end
+
+    def cached?
+      !@cache_key.nil?
+    end
+
+    def call(controller, **context)
+      return super unless cached?
+
+      json = InertiaRails.cache_store.fetch(@cache_key, **(@cache_options || {})) { super.to_json }
+      RawJson.new(json)
+    end
+
+    private
+
+    def derive_cache_key(raw_key)
+      expanded = ActiveSupport::Cache.expand_cache_key(raw_key)
+      "inertia_rails/#{expanded}"
+    end
+  end
+end

--- a/lib/inertia_rails/raw_json.rb
+++ b/lib/inertia_rails/raw_json.rb
@@ -3,6 +3,10 @@
 module InertiaRails
   # Wraps a pre-serialized JSON string so it embeds directly
   # into a larger JSON structure without re-serialization.
+  #
+  # - JSON.generate calls #to_json, embedding the raw string.
+  # - ActiveSupport::JSON.encode calls #as_json first, which
+  #   returns parsed Ruby data that the encoder re-serializes.
   class RawJson
     def initialize(json_string)
       @json_string = json_string
@@ -13,7 +17,7 @@ module InertiaRails
     end
 
     def as_json(*)
-      self
+      JSON.parse(@json_string)
     end
   end
 end

--- a/lib/inertia_rails/raw_json.rb
+++ b/lib/inertia_rails/raw_json.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module InertiaRails
+  # Wraps a pre-serialized JSON string so it embeds directly
+  # into a larger JSON structure without re-serialization.
+  class RawJson
+    def initialize(json_string)
+      @json_string = json_string
+    end
+
+    def to_json(*)
+      @json_string
+    end
+
+    def as_json(*)
+      self
+    end
+  end
+end

--- a/lib/inertia_rails/ssr_renderer.rb
+++ b/lib/inertia_rails/ssr_renderer.rb
@@ -12,7 +12,7 @@ module InertiaRails
       return unless bundle_exists?
 
       if (cache_options = cache_options_hash)
-        Rails.cache.fetch(cache_key, **cache_options) { request }
+        InertiaRails.cache_store.fetch(cache_key, **cache_options) { request }
       else
         request
       end

--- a/spec/dummy/app/controllers/inertia_render_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_render_test_controller.rb
@@ -315,6 +315,13 @@ class InertiaRenderTestController < ApplicationController
     }
   end
 
+  def optional_cached_props
+    render inertia: 'TestComponent', props: {
+      categories: InertiaRails.optional(cache: 'categories_key') { %w[category1 category2] },
+      regular: 'regular prop',
+    }
+  end
+
   def cached_props
     render inertia: 'TestComponent', props: {
       name: 'Brian',

--- a/spec/dummy/app/controllers/inertia_render_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_render_test_controller.rb
@@ -314,4 +314,18 @@ class InertiaRenderTestController < ApplicationController
       regular: 'regular prop',
     }
   end
+
+  def cached_props
+    render inertia: 'TestComponent', props: {
+      name: 'Brian',
+      stats: InertiaRails.cache('stats_key') { { count: 42 } },
+    }
+  end
+
+  def cached_deferred_props
+    render inertia: 'TestComponent', props: {
+      name: 'Brian',
+      feed: InertiaRails.defer(cache: 'feed_key', group: 'feed') { %w[fresh_item] },
+    }
+  end
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -59,6 +59,8 @@ Rails.application.routes.draw do
   get 'once_props_fresh_and_non_fresh' => 'inertia_render_test#once_props_fresh_and_non_fresh'
   get 'merge_once_props' => 'inertia_render_test#merge_once_props'
   get 'optional_once_props' => 'inertia_render_test#optional_once_props'
+  get 'cached_props' => 'inertia_render_test#cached_props'
+  get 'cached_deferred_props' => 'inertia_render_test#cached_deferred_props'
   get 'non_inertiafied' => 'inertia_test#non_inertiafied'
   get 'deeply_nested_props' => 'inertia_render_test#deeply_nested_props'
 

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
   get 'once_props_fresh_and_non_fresh' => 'inertia_render_test#once_props_fresh_and_non_fresh'
   get 'merge_once_props' => 'inertia_render_test#merge_once_props'
   get 'optional_once_props' => 'inertia_render_test#optional_once_props'
+  get 'optional_cached_props' => 'inertia_render_test#optional_cached_props'
   get 'cached_props' => 'inertia_render_test#cached_props'
   get 'cached_deferred_props' => 'inertia_render_test#cached_deferred_props'
   get 'non_inertiafied' => 'inertia_test#non_inertiafied'

--- a/spec/inertia/cached_prop_spec.rb
+++ b/spec/inertia/cached_prop_spec.rb
@@ -35,21 +35,9 @@ RSpec.describe InertiaRails::CachedProp do
     end
   end
 
-  describe 'InertiaRails.cache(key: ..., expires_in: ...) { block }' do
-    it 'passes options to cache store' do
-      prop = InertiaRails.cache(key: 'stats', expires_in: 0.1) { 'value' }
-      prop.call(controller)
-
-      expect(cache_store.read('inertia_rails/stats')).to eq('"value"')
-
-      travel 1.second
-      expect(cache_store.read('inertia_rails/stats')).to be_nil
-    end
-  end
-
   describe 'InertiaRails.cache(key, expires_in: ...) { block }' do
     it 'accepts positional key with keyword options' do
-      prop = InertiaRails.cache('stats', expires_in: 0.1) { 'value' }
+      prop = InertiaRails.cache('stats', expires_in: 1.second) { 'value' }
       prop.call(controller)
 
       expect(cache_store.read('inertia_rails/stats')).to eq('"value"')
@@ -68,36 +56,18 @@ RSpec.describe InertiaRails::CachedProp do
     end
   end
 
-  describe 'InertiaRails.cache({key: ..., expires_in: ...}) { block }' do
-    it 'accepts a positional hash with key and options' do
-      prop = InertiaRails.cache({ key: 'stats', expires_in: 0.1 }) { 'value' }
-      prop.call(controller)
-
-      expect(cache_store.read('inertia_rails/stats')).to eq('"value"')
-
-      travel 1.second
-      expect(cache_store.read('inertia_rails/stats')).to be_nil
-    end
-  end
-
   describe 'InertiaRails.cache(ar_object, expires_in: ...) { block }' do
     it 'accepts AR object with keyword options' do
       ar_object = double('ARObject')
       allow(ar_object).to receive(:cache_key_with_version).and_return('posts/1-20260410')
 
-      prop = InertiaRails.cache(ar_object, expires_in: 0.1) { 'value' }
+      prop = InertiaRails.cache(ar_object, expires_in: 1.second) { 'value' }
       prop.call(controller)
 
       expect(cache_store.read('inertia_rails/posts/1-20260410')).to eq('"value"')
 
-      travel 1.second
+      travel 2.seconds
       expect(cache_store.read('inertia_rails/posts/1-20260410')).to be_nil
-    end
-  end
-
-  describe 'InertiaRails.cache { block } with no key' do
-    it 'raises ArgumentError' do
-      expect { InertiaRails.cache { 'value' } }.to raise_error(ArgumentError, /cache key is required/)
     end
   end
 end

--- a/spec/inertia/cached_prop_spec.rb
+++ b/spec/inertia/cached_prop_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+RSpec.describe InertiaRails::CachedProp do
+  let(:controller) do
+    controller = ApplicationController.new
+    request = double('Request')
+    allow(controller).to receive(:request).and_return(request)
+    allow(request).to receive(:headers).and_return({})
+    controller
+  end
+
+  let(:cache_store) { ActiveSupport::Cache::MemoryStore.new }
+
+  before do
+    allow(InertiaRails).to receive(:cache_store).and_return(cache_store)
+  end
+
+  describe 'InertiaRails.cache(key) { block }' do
+    it 'caches the block result and returns RawJson' do
+      call_count = 0
+      prop = InertiaRails.cache('stats') do
+        call_count += 1
+        { count: 42 }
+      end
+
+      result = prop.call(controller)
+      expect(result).to be_a(InertiaRails::RawJson)
+      expect(result.to_json).to eq({ count: 42 }.to_json)
+      expect(call_count).to eq(1)
+
+      result2 = prop.call(controller)
+      expect(result2).to be_a(InertiaRails::RawJson)
+      expect(result2.to_json).to eq({ count: 42 }.to_json)
+      expect(call_count).to eq(1)
+    end
+  end
+
+  describe 'InertiaRails.cache(key: ..., expires_in: ...) { block }' do
+    it 'passes options to cache store' do
+      prop = InertiaRails.cache(key: 'stats', expires_in: 0.1) { 'value' }
+      prop.call(controller)
+
+      expect(cache_store.read('inertia_rails/stats')).to eq('"value"')
+
+      travel 1.second
+      expect(cache_store.read('inertia_rails/stats')).to be_nil
+    end
+  end
+
+  describe 'InertiaRails.cache(key, expires_in: ...) { block }' do
+    it 'accepts positional key with keyword options' do
+      prop = InertiaRails.cache('stats', expires_in: 0.1) { 'value' }
+      prop.call(controller)
+
+      expect(cache_store.read('inertia_rails/stats')).to eq('"value"')
+    end
+  end
+
+  describe 'InertiaRails.cache(ar_object) { block }' do
+    it 'derives key from cache_key_with_version' do
+      ar_object = double('ARObject')
+      allow(ar_object).to receive(:cache_key_with_version).and_return('posts/1-20260410')
+
+      prop = InertiaRails.cache(ar_object) { { title: 'Hello' } }
+      prop.call(controller)
+
+      expect(cache_store.read('inertia_rails/posts/1-20260410')).to eq({ title: 'Hello' }.to_json)
+    end
+  end
+
+  describe 'InertiaRails.cache({key: ..., expires_in: ...}) { block }' do
+    it 'accepts a positional hash with key and options' do
+      prop = InertiaRails.cache({ key: 'stats', expires_in: 0.1 }) { 'value' }
+      prop.call(controller)
+
+      expect(cache_store.read('inertia_rails/stats')).to eq('"value"')
+
+      travel 1.second
+      expect(cache_store.read('inertia_rails/stats')).to be_nil
+    end
+  end
+
+  describe 'InertiaRails.cache(ar_object, expires_in: ...) { block }' do
+    it 'accepts AR object with keyword options' do
+      ar_object = double('ARObject')
+      allow(ar_object).to receive(:cache_key_with_version).and_return('posts/1-20260410')
+
+      prop = InertiaRails.cache(ar_object, expires_in: 0.1) { 'value' }
+      prop.call(controller)
+
+      expect(cache_store.read('inertia_rails/posts/1-20260410')).to eq('"value"')
+
+      travel 1.second
+      expect(cache_store.read('inertia_rails/posts/1-20260410')).to be_nil
+    end
+  end
+
+  describe 'InertiaRails.cache { block } with no key' do
+    it 'raises ArgumentError' do
+      expect { InertiaRails.cache { 'value' } }.to raise_error(ArgumentError, /cache key is required/)
+    end
+  end
+end

--- a/spec/inertia/prop_cacheable_spec.rb
+++ b/spec/inertia/prop_cacheable_spec.rb
@@ -90,12 +90,12 @@ RSpec.describe InertiaRails::PropCacheable do
 
     context 'with cache: hash (extended format)' do
       it 'extracts key and passes options to cache store' do
-        prop = prop_class.new(cache: { key: 'test_key', expires_in: 0.1 }) { 'value' }
+        prop = prop_class.new(cache: { key: 'test_key', expires_in: 1.second }) { 'value' }
         prop.call(controller)
 
         expect(cache_store.read('inertia_rails/test_key')).to eq('"value"')
 
-        travel 1.second
+        travel 2.seconds
         expect(cache_store.read('inertia_rails/test_key')).to be_nil
       end
     end

--- a/spec/inertia/prop_cacheable_spec.rb
+++ b/spec/inertia/prop_cacheable_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+RSpec.describe InertiaRails::PropCacheable do
+  let(:controller) do
+    controller = ApplicationController.new
+    request = double('Request')
+    allow(controller).to receive(:request).and_return(request)
+    allow(request).to receive(:headers).and_return({})
+    controller
+  end
+
+  let(:cache_store) { ActiveSupport::Cache::MemoryStore.new }
+
+  before do
+    allow(InertiaRails).to receive(:cache_store).and_return(cache_store)
+  end
+
+  # Test via DeferProp which prepends PropCacheable
+  let(:prop_class) { InertiaRails::DeferProp }
+
+  describe '#cached?' do
+    it 'defaults to false' do
+      prop = prop_class.new { 'value' }
+      expect(prop.cached?).to be false
+    end
+
+    it 'returns true when cache is set with a string key' do
+      prop = prop_class.new(cache: 'my_key') { 'value' }
+      expect(prop.cached?).to be true
+    end
+
+    it 'returns true when cache is set with a hash key' do
+      prop = prop_class.new(cache: { key: 'my_key', expires_in: 5 }) { 'value' }
+      expect(prop.cached?).to be true
+    end
+
+    it 'raises ArgumentError when cache is a hash without :key' do
+      expect { prop_class.new(cache: { expires_in: 5 }) { 'value' } }
+        .to raise_error(ArgumentError, /requires a :key/)
+    end
+  end
+
+  describe '#call' do
+    context 'without cache' do
+      it 'evaluates the block normally' do
+        prop = prop_class.new { 'computed' }
+        expect(prop.call(controller)).to eq('computed')
+      end
+    end
+
+    context 'with cache: string key' do
+      it 'evaluates block on cache miss, caches, and returns RawJson' do
+        call_count = 0
+        prop = prop_class.new(cache: 'test_key') do
+          call_count += 1
+          { items: [1, 2, 3] }
+        end
+
+        result = prop.call(controller)
+        expect(result).to be_a(InertiaRails::RawJson)
+        expect(result.to_json).to eq({ items: [1, 2, 3] }.to_json)
+        expect(call_count).to eq(1)
+        expect(cache_store.read('inertia_rails/test_key')).to eq({ items: [1, 2, 3] }.to_json)
+      end
+
+      it 'returns RawJson on cache hit without evaluating block' do
+        cache_store.write('inertia_rails/test_key', '{"items":[1,2,3]}')
+
+        call_count = 0
+        prop = prop_class.new(cache: 'test_key') do
+          call_count += 1
+          'should not run'
+        end
+
+        result = prop.call(controller)
+        expect(result).to be_a(InertiaRails::RawJson)
+        expect(result.to_json).to eq('{"items":[1,2,3]}')
+        expect(call_count).to eq(0)
+      end
+    end
+
+    context 'with cache: array key' do
+      it 'derives cache key from array' do
+        prop = prop_class.new(cache: %w[stats user_1]) { { count: 42 } }
+        prop.call(controller)
+
+        expect(cache_store.read('inertia_rails/stats/user_1')).to eq({ count: 42 }.to_json)
+      end
+    end
+
+    context 'with cache: hash (extended format)' do
+      it 'extracts key and passes options to cache store' do
+        prop = prop_class.new(cache: { key: 'test_key', expires_in: 0.1 }) { 'value' }
+        prop.call(controller)
+
+        expect(cache_store.read('inertia_rails/test_key')).to eq('"value"')
+
+        travel 1.second
+        expect(cache_store.read('inertia_rails/test_key')).to be_nil
+      end
+    end
+
+    context 'with cache: AR-like object' do
+      it 'derives key from cache_key_with_version' do
+        ar_object = double('ARObject')
+        allow(ar_object).to receive(:cache_key_with_version).and_return('users/1-20260410')
+
+        prop = prop_class.new(cache: ar_object) { { name: 'Bob' } }
+        prop.call(controller)
+
+        expect(cache_store.read('inertia_rails/users/1-20260410')).to eq({ name: 'Bob' }.to_json)
+      end
+    end
+
+    context 'cache does not interfere with other prop options' do
+      it 'preserves group option on DeferProp' do
+        prop = prop_class.new(cache: 'key', group: 'sidebar') { 'value' }
+        expect(prop.group).to eq('sidebar')
+        expect(prop.cached?).to be true
+      end
+
+      it 'preserves once option on DeferProp' do
+        prop = prop_class.new(cache: 'key', once: true) { 'value' }
+        expect(prop.once?).to be true
+        expect(prop.cached?).to be true
+      end
+    end
+  end
+end

--- a/spec/inertia/raw_json_spec.rb
+++ b/spec/inertia/raw_json_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe InertiaRails::RawJson do
   end
 
   describe '#as_json' do
-    it 'returns self' do
+    it 'returns a value compatible with JSON encoding' do
       raw = described_class.new('[1,2,3]')
-      expect(raw.as_json).to be(raw)
+      expect { ActiveSupport::JSON.encode(data: raw) }.not_to raise_error
     end
   end
 

--- a/spec/inertia/raw_json_spec.rb
+++ b/spec/inertia/raw_json_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+RSpec.describe InertiaRails::RawJson do
+  describe '#to_json' do
+    it 'returns the raw JSON string' do
+      raw = described_class.new('[1,2,3]')
+      expect(raw.to_json).to eq('[1,2,3]')
+    end
+  end
+
+  describe '#as_json' do
+    it 'returns self' do
+      raw = described_class.new('[1,2,3]')
+      expect(raw.as_json).to be(raw)
+    end
+  end
+
+  describe 'embedding in JSON.generate' do
+    it 'embeds the raw string without double-escaping' do
+      raw = described_class.new('{"items":[1,2,3]}')
+      hash = { component: 'Test', props: { data: raw, name: 'Bob' } }
+
+      json = JSON.generate(hash)
+      parsed = JSON.parse(json)
+
+      expect(parsed['props']['data']).to eq({ 'items' => [1, 2, 3] })
+      expect(parsed['props']['name']).to eq('Bob')
+    end
+
+    it 'embeds arrays correctly' do
+      raw = described_class.new('[{"id":1},{"id":2}]')
+      hash = { items: raw }
+
+      parsed = JSON.parse(JSON.generate(hash))
+      expect(parsed['items']).to eq([{ 'id' => 1 }, { 'id' => 2 }])
+    end
+  end
+
+  describe 'embedding in ActiveSupport::JSON.encode' do
+    it 'embeds the raw string without double-escaping' do
+      raw = described_class.new('{"items":[1,2,3]}')
+      hash = { component: 'Test', props: { data: raw } }
+
+      parsed = JSON.parse(ActiveSupport::JSON.encode(hash))
+      expect(parsed['props']['data']).to eq({ 'items' => [1, 2, 3] })
+    end
+  end
+
+  describe 'embedding in Hash#to_json' do
+    it 'embeds the raw string without double-escaping' do
+      raw = described_class.new('[1,2,3]')
+      hash = { data: raw }
+
+      parsed = JSON.parse(hash.to_json)
+      expect(parsed['data']).to eq([1, 2, 3])
+    end
+  end
+end

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -945,6 +945,59 @@ RSpec.describe 'rendering inertia views', type: :request do
         end
       end
     end
+
+    context 'cached optional prop' do
+      context 'on first load' do
+        before { get optional_cached_props_path, headers: headers }
+
+        it 'excludes optional prop from props' do
+          expect(response.parsed_body['props']).to eq({ 'regular' => 'regular prop' })
+        end
+
+        it 'does not write to cache on first load' do
+          expect(cache_store.read('inertia_rails/categories_key')).to be_nil
+        end
+      end
+
+      context 'on partial reload (cache miss)' do
+        let(:headers) do
+          {
+            'X-Inertia' => true,
+            'X-Inertia-Partial-Data' => 'categories',
+            'X-Inertia-Partial-Component' => 'TestComponent',
+          }
+        end
+
+        before { get optional_cached_props_path, headers: headers }
+
+        it 'evaluates block and returns data' do
+          expect(response.parsed_body['props']['categories']).to eq(%w[category1 category2])
+        end
+
+        it 'writes result to cache' do
+          expect(cache_store.read('inertia_rails/categories_key')).to eq(%w[category1 category2].to_json)
+        end
+      end
+
+      context 'on partial reload (cache hit)' do
+        let(:headers) do
+          {
+            'X-Inertia' => true,
+            'X-Inertia-Partial-Data' => 'categories',
+            'X-Inertia-Partial-Component' => 'TestComponent',
+          }
+        end
+
+        before do
+          cache_store.write('inertia_rails/categories_key', '["cached_cat"]')
+          get optional_cached_props_path, headers: headers
+        end
+
+        it 'returns cached data without evaluating block' do
+          expect(response.parsed_body['props']['categories']).to eq(%w[cached_cat])
+        end
+      end
+    end
   end
 
   context 'view configuration options' do

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -859,6 +859,94 @@ RSpec.describe 'rendering inertia views', type: :request do
     end
   end
 
+  context 'cached prop rendering' do
+    let(:headers) { { 'X-Inertia' => true } }
+    let(:cache_store) { ActiveSupport::Cache::MemoryStore.new }
+
+    before do
+      allow(InertiaRails).to receive(:cache_store).and_return(cache_store)
+    end
+
+    context 'InertiaRails.cache in props' do
+      before { get cached_props_path, headers: headers }
+
+      it 'includes cached prop value in response' do
+        expect(response.parsed_body['props']).to eq(
+          'name' => 'Brian',
+          'stats' => { 'count' => 42 }
+        )
+      end
+
+      it 'writes to cache store' do
+        expect(cache_store.read('inertia_rails/stats_key')).to eq({ count: 42 }.to_json)
+      end
+
+      it 'returns RawJson on second request' do
+        get cached_props_path, headers: headers
+        expect(response.parsed_body['props']['stats']).to eq({ 'count' => 42 })
+      end
+    end
+
+    context 'cached deferred prop' do
+      context 'on first load' do
+        before { get cached_deferred_props_path, headers: headers }
+
+        it 'excludes deferred prop from props' do
+          expect(response.parsed_body['props']).to eq({ 'name' => 'Brian' })
+        end
+
+        it 'includes deferredProps metadata' do
+          expect(response.parsed_body['deferredProps']).to eq(
+            'feed' => ['feed']
+          )
+        end
+
+        it 'does not write to cache on first load' do
+          expect(cache_store.read('inertia_rails/feed_key')).to be_nil
+        end
+      end
+
+      context 'on partial reload (cache miss)' do
+        let(:headers) do
+          {
+            'X-Inertia' => true,
+            'X-Inertia-Partial-Data' => 'feed',
+            'X-Inertia-Partial-Component' => 'TestComponent',
+          }
+        end
+
+        before { get cached_deferred_props_path, headers: headers }
+
+        it 'evaluates block and returns fresh data' do
+          expect(response.parsed_body['props']['feed']).to eq(%w[fresh_item])
+        end
+
+        it 'writes result to cache' do
+          expect(cache_store.read('inertia_rails/feed_key')).to eq(%w[fresh_item].to_json)
+        end
+      end
+
+      context 'on partial reload (cache hit)' do
+        let(:headers) do
+          {
+            'X-Inertia' => true,
+            'X-Inertia-Partial-Data' => 'feed',
+            'X-Inertia-Partial-Component' => 'TestComponent',
+          }
+        end
+
+        before do
+          cache_store.write('inertia_rails/feed_key', '["cached_item"]')
+          get cached_deferred_props_path, headers: headers
+        end
+
+        it 'returns cached data without evaluating block' do
+          expect(response.parsed_body['props']['feed']).to eq(%w[cached_item])
+        end
+      end
+    end
+  end
+
   context 'view configuration options' do
     after do
       InertiaRails.configure do |config|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -55,6 +55,7 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.include HelperModule
+  config.include ActiveSupport::Testing::TimeHelpers
 end
 
 require 'rails-controller-testing'


### PR DESCRIPTION
This PR adds `InertiaRails.cache` for server-side prop caching, and docs on caching.