### PR TITLE
Fix release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release (X.Y.Z, without the v prefix)'
+        description: "Version to release (X.Y.Z, without the v prefix)"
         required: true
         type: string
 
@@ -45,7 +45,8 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
         with:
-          ruby-version: "3.4"
+          ruby-version: "4.0"
+          bundler: latest
           bundler-cache: true
 
       - name: Configure git identity


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Summary

The bundler-cache: true step in release.yml is using Bundler 2 (shipped with Ruby 3.4.9) which rewrites Gemfile.lock — our lockfile  was generated by Bundler 4 (contains sha256= checksums and BUNDLED WITH  4.0.4). Bundler 2 strips the checksums on bundle lock, leaving the  working tree dirty before bin/prepare_publish runs.

## Test plan

Release a gem, right?

## Checklist

- [ ] Tests added or updated
- [ ] `CHANGELOG.md` updated (for user-facing changes)
