### PR TITLE
Fix release script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /spec/reports/
 /tmp/
 /.cache/
+/vendor/
 /Gemfile.lock
 .DS_Store
 

--- a/bin/prepare_publish
+++ b/bin/prepare_publish
@@ -8,16 +8,15 @@
 # This script:
 #   1. Validates the version and git state
 #   2. Bumps VERSION in lib/inertia_rails/version.rb
-#   3. Refreshes Gemfile.lock
-#   4. Replaces `rails=master` with `rails=X.Y.Z` in docs @available_since markers
-#   5. Stamps today's date on the CHANGELOG header (or inserts a new one)
-#   6. Runs tests and the linter
-#   7. Creates a release commit and a vX.Y.Z tag
+#   3. Replaces `rails=master` with `rails=X.Y.Z` in docs @available_since markers
+#   4. Stamps today's date on the CHANGELOG header (or inserts a new one)
+#   5. Runs tests and the linter
+#   6. Creates a release commit and a vX.Y.Z tag
 #
-# With --dry-run: runs steps 1-6, shows the diff that would be committed, then
+# With --dry-run: runs steps 1-5, shows the diff that would be committed, then
 # stops without creating a commit or tag. Files are left modified so you can
 # inspect them — reset with:
-#   git checkout -- lib/inertia_rails/version.rb Gemfile.lock CHANGELOG.md docs && bundle install
+#   git checkout -- lib/inertia_rails/version.rb CHANGELOG.md docs
 #
 # Pushing the tag triggers .github/workflows/push_gem.yml, which publishes to
 # rubygems.org via trusted publishing and creates a GitHub release.
@@ -88,11 +87,7 @@ info "Bumping VERSION to $VERSION..."
 # `ruby -i -pe` keeps behavior identical on macOS and Linux (sed -i differs).
 ruby -i -pe "gsub(/VERSION = '[^']*'/, \"VERSION = '${VERSION}'\")" lib/inertia_rails/version.rb
 
-# -- 4. Refresh Gemfile.lock --------------------------------------------------
-info "Updating Gemfile.lock..."
-bundle install --quiet
-
-# -- 5. Update docs @available_since markers ---------------------------------
+# -- 4. Update docs @available_since markers ---------------------------------
 info "Replacing rails=master in docs..."
 # Only touch files that actually reference rails=master to keep mtimes sane.
 MATCHING_DOCS=$(grep -rl --include='*.md' 'rails=master' docs || true)
@@ -105,7 +100,7 @@ else
   warn "No 'rails=master' markers found in docs (already released?)"
 fi
 
-# -- 6. Update CHANGELOG ------------------------------------------------------
+# -- 5. Update CHANGELOG ------------------------------------------------------
 info "Updating CHANGELOG.md..."
 VERSION="$VERSION" TODAY="$TODAY" ruby -i -e '
   content = ARGF.read
@@ -121,7 +116,7 @@ VERSION="$VERSION" TODAY="$TODAY" ruby -i -e '
   end
 ' CHANGELOG.md
 
-# -- 7. Run tests and linter --------------------------------------------------
+# -- 6. Run tests and linter --------------------------------------------------
 info "Running RSpec..."
 # Skip spec/generators — those require a full Rails/Node setup and are
 # covered by .github/workflows/generators.yml separately.
@@ -133,7 +128,7 @@ bundle exec rake test
 info "Running RuboCop..."
 bundle exec rubocop
 
-# -- 8. Commit and tag (or stop, if dry run) ----------------------------------
+# -- 7. Commit and tag (or stop, if dry run) ----------------------------------
 if [[ "$DRY_RUN" == "true" ]]; then
   info "Dry run complete — showing pending changes:"
   echo
@@ -141,16 +136,16 @@ if [[ "$DRY_RUN" == "true" ]]; then
   echo
   warn "No commit or tag was created."
   echo "To inspect the changes in detail: git diff"
-  echo "To reset the working tree:        git checkout -- lib/inertia_rails/version.rb Gemfile.lock CHANGELOG.md docs && bundle install"
+  echo "To reset the working tree:        git checkout -- lib/inertia_rails/version.rb CHANGELOG.md docs"
   exit 0
 fi
 
 info "Creating release commit and tag..."
-git add lib/inertia_rails/version.rb Gemfile.lock CHANGELOG.md docs
+git add lib/inertia_rails/version.rb CHANGELOG.md docs
 git commit -m "Bump to $VERSION"
 git tag "$TAG"
 
-# -- 9. Done ------------------------------------------------------------------
+# -- 8. Done ------------------------------------------------------------------
 info "Release $TAG prepared!"
 echo
 echo "Review the changes:"


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Summary

`/vendor/` wasn't ignored leading release script to fail.

## Test plan

Release a gem

## Checklist

- [ ] Tests added or updated
- [ ] `CHANGELOG.md` updated (for user-facing changes)
