### PR TITLE
Get token from Github App so preparer has permissions to create commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,19 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.GEM_RELEASE_PREPARER_APP_ID }}
+          private-key: ${{ secrets.GEM_RELEASE_PREPARER_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: master
           # Full history so the tag-existence check and the push both work.
           fetch-depth: 0
+          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Setup System
         run: sudo apt-get install -y libsqlite3-dev


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Summary

* Release script needs permissions in order to create commits and tags on the repo
* Attempt 4? 5? to get automated gem releases wired up
## Test plan

## Checklist

- [ N/A] Tests added or updated
- [ N/A] `CHANGELOG.md` updated (for user-facing changes)
