### PR TITLE
Improve publish release workflow

### DIFF
--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v5.0.1
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@d5126b9b3579e429dd52e51e68624dda2e05be25 # v1.267.0
+        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
         with:
           bundler-cache: true
           ruby-version: '4.0'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,14 +5,25 @@ name: Prepare Release
 # .github/workflows/push_gem.yml, which publishes to rubygems.org via
 # trusted publishing and creates a GitHub release.
 #
-# To use: Actions tab → "Prepare Release" → Run workflow → enter version.
+# To use: Actions tab → "Prepare Release" → Run workflow → select bump type.
+# For an exact version, set bump to "none" and fill in version_override.
 
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: "Version to release (X.Y.Z, without the v prefix)"
+      bump:
+        description: "Version bump type. Set to 'none' when using version_override."
         required: true
+        type: choice
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+          - none
+      version_override:
+        description: "Exact version to release (X.Y.Z). Mutually exclusive with bump type — set bump to 'none' when using this."
+        required: false
         type: string
 
 permissions:
@@ -22,7 +33,7 @@ jobs:
   release:
     if: github.repository == 'inertiajs/inertia-rails'
     runs-on: ubuntu-latest
-    name: Prepare release v${{ inputs.version }}
+    name: Prepare release (${{ inputs.version_override || inputs.bump }})
 
     permissions:
       contents: write
@@ -43,9 +54,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: master
-          # Full history so the tag-existence check and the push both work.
+          # Full history so tag resolution and the push both work.
           fetch-depth: 0
           token: ${{ steps.generate_token.outputs.token }}
+
+      - name: Resolve version
+        id: version
+        run: bin/resolve_version "${{ inputs.bump }}" "${{ inputs.version_override }}"
 
       - name: Setup System
         run: sudo apt-get install -y libsqlite3-dev
@@ -63,17 +78,17 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Run bin/prepare_publish
-        run: bin/prepare_publish "${{ inputs.version }}"
+        run: bin/prepare_publish "${{ steps.version.outputs.version }}"
 
       - name: Push commit and tag
-        run: git push --atomic origin master "refs/tags/v${{ inputs.version }}"
+        run: git push --atomic origin master "refs/tags/v${{ steps.version.outputs.version }}"
 
       - name: Summary
         run: |
           {
-            echo "### Release v${{ inputs.version }} prepared"
+            echo "### Release v${{ steps.version.outputs.version }} prepared"
             echo
-            echo "Tag \`v${{ inputs.version }}\` has been pushed."
+            echo "Tag \`v${{ steps.version.outputs.version }}\` has been pushed."
             echo
             echo "The [Publish gem to rubygems.org](../../actions/workflows/push_gem.yml) workflow will publish the gem and create a GitHub release."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/bin/resolve_version
+++ b/bin/resolve_version
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Resolve the version to release from a bump type and/or an override.
+#
+# Usage:
+#   bin/resolve_version <bump> [version_override]
+#
+#   bump             - One of: patch, minor, major, none
+#   version_override - Exact version (X.Y.Z). Requires bump to be "none".
+#
+# Examples:
+#   bin/resolve_version patch            # → e.g. 3.2.1
+#   bin/resolve_version none 4.0.0       # → 4.0.0
+#
+# Prints the resolved version to stdout.
+# When $GITHUB_OUTPUT is set (GitHub Actions), also writes version=X.Y.Z to it.
+
+set -euo pipefail
+
+RED='\033[0;31m'
+NC='\033[0m'
+
+error() {
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    echo "::error::$1"
+  else
+    printf "${RED}==> ERROR:${NC} %s\n" "$1" >&2
+  fi
+  exit 1
+}
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: bin/resolve_version <bump> [version_override]" >&2
+  exit 1
+fi
+
+BUMP="$1"
+OVERRIDE="${2:-}"
+
+if [[ -n "$OVERRIDE" && "$BUMP" != "none" ]]; then
+  error "Specify either a bump type OR a version override, not both. Set bump to 'none' when using version_override."
+fi
+
+if [[ -z "$OVERRIDE" && "$BUMP" == "none" ]]; then
+  error "Specify either a bump type or a version override."
+fi
+
+if [[ -n "$OVERRIDE" ]]; then
+  VERSION="$OVERRIDE"
+else
+  LATEST_TAG=$(git describe --tags --abbrev=0)
+  CURRENT="${LATEST_TAG#v}"
+  IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+  case "$BUMP" in
+    major) VERSION="$((MAJOR + 1)).0.0" ;;
+    minor) VERSION="${MAJOR}.$((MINOR + 1)).0" ;;
+    patch) VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
+    *)     error "Unknown bump type: $BUMP (expected patch, minor, major, or none)" ;;
+  esac
+fi
+
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  error "Invalid version format: $VERSION (expected X.Y.Z)"
+fi
+
+echo "$VERSION"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+fi


### PR DESCRIPTION
<!-- Thanks for contributing! -->

* Fixes the push gem workflow (ruby-setup version did not have Ruby 4.0 available)
* Add patch/minor/major dropdown for gem release UI to remove fat finger risk

<!-- What changed and why? Link to a related issue if there is one. -->

## Test plan

I ran `bin/resolve_version` locally, but can't fully test until the CI runs the job

## Checklist

- [N/A] Tests added or updated
- [ N/A] `CHANGELOG.md` updated (for user-facing changes)
