### PR TITLE
Skip session cleanup in middleware when session was never loaded

### DIFF
--- a/docs/guide/csrf-protection.md
+++ b/docs/guide/csrf-protection.md
@@ -69,33 +69,29 @@ createInertiaApp({
 })
 ```
 
-## Stateless Controllers in Hybrid Applications
+## Sessionless Controllers in Hybrid Applications
 
 When Inertia coexists with sessionless controllers in the same Rails application — such as token-authenticated API endpoints, webhook receivers, or any controller that does not rely on the session — it's important to configure CSRF protection correctly on those controllers.
 
 A common pattern is to reach for `skip_forgery_protection`:
 
 ```ruby
-class StatelessController < ApplicationController
+class SessionlessController < ApplicationController
   skip_forgery_protection
 end
 ```
 
 However, `skip_forgery_protection` only removes the `verify_authenticity_token` before-action — it does not disable the CSRF infrastructure. Rails' `protect_against_forgery?` still returns `true`, so InertiaRails' after-action fires and calls `form_authenticity_token`, which reads and writes `session[:_csrf_token]`. This causes a session record to be loaded (and created, if one doesn't exist) for every request, even though the controller has explicitly opted out of CSRF.
 
-The correct approach is to use the `:null_session` strategy instead:
+The correct approach is to set `allow_forgery_protection` to `false` on the controller class:
 
 ```ruby
-class StatelessController < ApplicationController
-  protect_from_forgery with: :null_session
+class SessionlessController < ApplicationController
+  self.allow_forgery_protection = false
 end
 ```
 
-With `:null_session`, Rails runs `verify_authenticity_token` but handles the expected absence of a CSRF token by substituting a `NullSessionHash` for the real session. This causes `protect_against_forgery?` to return `false` for the remainder of that request — InertiaRails' after-action is correctly skipped, and no session I/O occurs.
-
-This is also what the [Rails source recommends](https://github.com/rails/rails/blob/main/actionpack/lib/action_controller/metal/request_forgery_protection.rb) for sessionless endpoints within an otherwise session-based application:
-
-> "APIs may want to disable this behavior since they are typically designed to be state-less [...] One way to achieve this is to use the `:null_session` strategy instead, which allows unverified requests to be handled, but with an empty session."
+`allow_forgery_protection` is a per-class setting — it does not affect other controllers in the application. Setting it to `false` makes `protect_against_forgery?` return `false`, so InertiaRails' after-action is unconditionally skipped — no XSRF cookie is set, `form_authenticity_token` is never called, and no session I/O occurs.
 
 ## Handling Mismatches
 

--- a/docs/guide/csrf-protection.md
+++ b/docs/guide/csrf-protection.md
@@ -69,6 +69,34 @@ createInertiaApp({
 })
 ```
 
+## Stateless Controllers in Hybrid Applications
+
+When Inertia coexists with sessionless controllers in the same Rails application — such as token-authenticated API endpoints, webhook receivers, or any controller that does not rely on the session — it's important to configure CSRF protection correctly on those controllers.
+
+A common pattern is to reach for `skip_forgery_protection`:
+
+```ruby
+class StatelessController < ApplicationController
+  skip_forgery_protection
+end
+```
+
+However, `skip_forgery_protection` only removes the `verify_authenticity_token` before-action — it does not disable the CSRF infrastructure. Rails' `protect_against_forgery?` still returns `true`, so InertiaRails' after-action fires and calls `form_authenticity_token`, which reads and writes `session[:_csrf_token]`. This causes a session record to be loaded (and created, if one doesn't exist) for every request, even though the controller has explicitly opted out of CSRF.
+
+The correct approach is to use the `:null_session` strategy instead:
+
+```ruby
+class StatelessController < ApplicationController
+  protect_from_forgery with: :null_session
+end
+```
+
+With `:null_session`, Rails runs `verify_authenticity_token` but handles the expected absence of a CSRF token by substituting a `NullSessionHash` for the real session. This causes `protect_against_forgery?` to return `false` for the remainder of that request — InertiaRails' after-action is correctly skipped, and no session I/O occurs.
+
+This is also what the [Rails source recommends](https://github.com/rails/rails/blob/main/actionpack/lib/action_controller/metal/request_forgery_protection.rb) for sessionless endpoints within an otherwise session-based application:
+
+> "APIs may want to disable this behavior since they are typically designed to be state-less [...] One way to achieve this is to use the `:null_session` strategy instead, which allows unverified requests to be handled, but with an empty session."
+
 ## Handling Mismatches
 
 When a CSRF token mismatch occurs, Rails raises the `ActionController::InvalidAuthenticityToken` error which results in a `419` error page. Since that isn't a valid Inertia response, the error is shown in a modal.

--- a/lib/inertia_rails/middleware.rb
+++ b/lib/inertia_rails/middleware.rb
@@ -26,10 +26,16 @@ module InertiaRails
         request = ActionDispatch::Request.new(@env)
 
         # Inertia session data is added via redirect_to
+        # Guard with session.loaded? to avoid forcing session I/O (and unnecessary
+        # database writes) on requests that never accessed the session, e.g. token-
+        # authenticated API endpoints. If the session was never loaded the Inertia
+        # keys cannot have been set, so the cleanup would be a no-op anyway.
         unless keep_inertia_session_options?(status)
-          request.session.delete(:inertia_errors)
-          request.session.delete(:inertia_clear_history)
-          request.session.delete(:inertia_preserve_fragment)
+          if request.session.loaded?
+            request.session.delete(:inertia_errors)
+            request.session.delete(:inertia_clear_history)
+            request.session.delete(:inertia_preserve_fragment)
+          end
         end
 
         status = 303 if inertia_non_post_redirect?(status)

--- a/lib/inertia_rails/middleware.rb
+++ b/lib/inertia_rails/middleware.rb
@@ -27,15 +27,13 @@ module InertiaRails
 
         # Inertia session data is added via redirect_to
         # Guard with session.loaded? to avoid forcing session I/O (and unnecessary
-        # database writes) on requests that never accessed the session, e.g. token-
-        # authenticated API endpoints. If the session was never loaded the Inertia
-        # keys cannot have been set, so the cleanup would be a no-op anyway.
-        unless keep_inertia_session_options?(status)
-          if request.session.loaded?
-            request.session.delete(:inertia_errors)
-            request.session.delete(:inertia_clear_history)
-            request.session.delete(:inertia_preserve_fragment)
-          end
+        # database writes) on requests that never accessed the session, e.g. sessionless
+        # controllers. If the session was never loaded the Inertia keys cannot have been
+        # set, so the cleanup would be a no-op anyway.
+        unless keep_inertia_session_options?(status) || !request.session.loaded?
+          request.session.delete(:inertia_errors)
+          request.session.delete(:inertia_clear_history)
+          request.session.delete(:inertia_preserve_fragment)
         end
 
         status = 303 if inertia_non_post_redirect?(status)

--- a/spec/inertia/middleware_spec.rb
+++ b/spec/inertia/middleware_spec.rb
@@ -30,6 +30,27 @@ RSpec.describe 'InertiaRails::Middleware', type: :request do
     end
   end
 
+  context 'session loading guard' do
+    it 'does not load the session when the request never accesses it' do
+      get non_inertiafied_path
+
+      # The middleware must not call session.delete (which triggers load_for_write!)
+      # on requests that never touched the session — e.g. token-authenticated API endpoints.
+      expect(request.session.loaded?).to be(false)
+    end
+
+    it 'still cleans up inertia session keys when the session was loaded during the request' do
+      post redirect_with_inertia_errors_path
+      expect(session[:inertia_errors]).to be_present
+
+      # The follow-up GET causes Inertia to read inertia_errors from the session (loading it).
+      # The middleware should then find session.loaded? == true and clean up the keys.
+      get empty_test_path
+      expect(request.session.loaded?).to be(true)
+      expect(session[:inertia_errors]).to be_nil
+    end
+  end
+
   context 'a redirect status was passed with an http method that preserves itself on 302 redirect' do
     subject { response.status }
 


### PR DESCRIPTION
Hello 👋  Thanks for the amazing work on this gem 🙌

## Problem

`InertiaRails::Middleware` unconditionally calls `session.delete` on three Inertia session keys after every response:

```ruby
unless keep_inertia_session_options?(status)
  request.session.delete(:inertia_errors)
  request.session.delete(:inertia_clear_history)
  request.session.delete(:inertia_preserve_fragment)
end
```

`session.delete` calls `load_for_write!` internally, which loads (and in the case of a fresh request, creates) the session regardless of whether the request ever touched it. In apps where Inertia coexists with sessionless controllers (e.g. token-authenticated API endpoints, webhook receivers), this causes the session to be loaded and committed on **every** request, producing unnecessary database writes:

```
SAVEPOINT active_record_1
INSERT INTO "sessions" (...)
RELEASE SAVEPOINT active_record_1
SELECT "sessions".* WHERE "session_id" = $1
```

## Root cause

The three Inertia keys can only exist in the session if they were written there during a prior `redirect_to`. If the session was never loaded during the current request, those keys provably cannot be present — the cleanup is a no-op that still forces session I/O.

## Fix

Merge the `session.loaded?` guard into the outer `unless` condition:

```ruby
unless keep_inertia_session_options?(status) || !request.session.loaded?
  request.session.delete(:inertia_errors)
  request.session.delete(:inertia_clear_history)
  request.session.delete(:inertia_preserve_fragment)
end
```

- If `session.loaded?` is `false`, the Inertia keys cannot have been set — skip entirely.
- If `session.loaded?` is `true`, existing behaviour is preserved exactly.

## Tests

Two new regression tests are added to `middleware_spec.rb`:

1. **Does not load the session** for a request that never accesses it — asserts `request.session.loaded?` remains `false` after the response (would fail against the old code).
2. **Still cleans up inertia session keys** when the session was legitimately loaded during the request — asserts `session[:inertia_errors]` is `nil` after following a redirect that stored errors.

## Documentation

A new **Sessionless Controllers in Hybrid Applications** section is added to the CSRF protection guide.

While investigating this issue we found that a related problem arises when sessionless controllers use `skip_forgery_protection`. `skip_forgery_protection` only removes the `verify_authenticity_token` before-action — it does not disable the CSRF infrastructure. `protect_against_forgery?` still returns `true`, so InertiaRails' after-action in the controller calls `form_authenticity_token` and loads the session on every request.

The correct per-class configuration for sessionless controllers is `self.allow_forgery_protection = false`. This makes `protect_against_forgery?` return `false` unconditionally, so InertiaRails' after-action is skipped entirely — no XSRF cookie, no `form_authenticity_token` call, no session I/O. The setting is scoped to the controller class and does not affect the rest of the application.

> **Note:** An earlier version of this PR recommended `protect_from_forgery with: :null_session` instead. That was a mistake — `null_session` only prevents session I/O on non-GET requests (it works by substituting a `NullSessionHash` on CSRF verification failure, which only fires for non-safe methods). `allow_forgery_protection = false` is the correct tool: it disables the CSRF infrastructure at the class level regardless of request method.

The middleware fix in this PR addresses the remaining session I/O from the cleanup loop for any controller that never loaded the session, regardless of CSRF configuration.