### PR TITLE
Fix changelog bump & reverse failed bump commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.21.0] - 2026-04-12
-
-* TODO: fill in changelog
-
 ## [Unreleased]
 
 * Skip excluded hash props on partial reloads (@erickreutz)

--- a/bin/prepare_publish
+++ b/bin/prepare_publish
@@ -97,7 +97,7 @@ if [[ -n "$MATCHING_DOCS" ]]; then
     echo "  updated $file"
   done
 else
-  warn "No 'rails=master' markers found in docs (already released?)"
+  echo "No 'rails=master' markers found in docs"
 fi
 
 # -- 5. Update CHANGELOG ------------------------------------------------------
@@ -106,13 +106,13 @@ VERSION="$VERSION" TODAY="$TODAY" ruby -i -e '
   content = ARGF.read
   version = ENV.fetch("VERSION")
   header = "## [#{version}] - #{ENV.fetch("TODAY")}"
-  existing = /^## \[#{Regexp.escape(version)}\][^\n]*$/
-  new_section = "#{header}\n\n* TODO: fill in changelog\n\n## ["
+  unreleased = /^## \[Unreleased\]\s*$/
 
-  if content.sub!(existing, header) || content.sub!(/^## \[/, new_section)
+  if content.match?(unreleased)
+    content.sub!(unreleased, "## [Unreleased]\n\n#{header}\n")
     File.write("CHANGELOG.md", content)
   else
-    abort "CHANGELOG.md: could not find a release header to anchor the new section"
+    abort "CHANGELOG.md: could not find ## [Unreleased] header"
   end
 ' CHANGELOG.md
 

--- a/docs/guide/cached-props.md
+++ b/docs/guide/cached-props.md
@@ -1,6 +1,6 @@
 # Cached Props
 
-@available_since rails=3.21.0
+@available_since rails=master
 
 Cached props use your server-side cache store to avoid recomputing expensive data on every request. When the cache is warm, the block is never evaluated — Inertia serves the pre-serialized JSON directly.
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -128,7 +128,7 @@ Requires a JavaScript server to be available at `ssr_url`. [_Example_](https://g
 
 **Default**: `nil` (disabled)
 
-@available_since rails=3.21.0
+@available_since rails=master
 
 Cache SSR responses to avoid redundant Node.js render requests for identical page data. Accepts `true`, `false`/`nil`, or a Hash of `Rails.cache.fetch` options (e.g. `{ expires_in: 1.hour }`). Lambdas are supported and evaluated in the controller context. Can be overridden per render call.
 

--- a/docs/guide/deferred-props.md
+++ b/docs/guide/deferred-props.md
@@ -255,7 +255,7 @@ For more information on once props, see the [once props](/guide/once-props) docu
 
 ## Combining with Caching
 
-@available_since rails=3.21.0
+@available_since rails=master
 
 You may pass the `cache` option to a deferred prop to cache the resolved value on the server side. On cache hits, the block is not evaluated.
 

--- a/docs/guide/partial-reloads.md
+++ b/docs/guide/partial-reloads.md
@@ -269,7 +269,7 @@ For more information on once props, see the [once props](/guide/once-props) docu
 
 ## Combining with Caching
 
-@available_since rails=3.21.0
+@available_since rails=master
 
 You may pass the `cache` option to an optional prop to cache the resolved value on the server side. On cache hits, the block is not evaluated.
 

--- a/lib/inertia_rails/version.rb
+++ b/lib/inertia_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module InertiaRails
-  VERSION = '3.21.0'
+  VERSION = '3.20.0'
 end


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Summary

Now bin/prepare_release expects changelog to be up to date before release.

## Test plan

You guessed it - release a gem

## Checklist

- [ ] Tests added or updated
- [ ] `CHANGELOG.md` updated (for user-facing changes)
