### PR TITLE
Support `layout` renderer option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.21.0] - 2026-04-12
-
-* TODO: fill in changelog
-
 ## [Unreleased]
 
 * Skip excluded hash props on partial reloads (@erickreutz)
@@ -15,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix typo in `inertia()` plugin configuration example in docs (@onk)
 * Better SSR Puma plugin lookup defaults (@skryukov)
 * Add prop-level caching and caching documentation (@skryukov)
+* Skip session cleanup in middleware when session was never loaded (@khamusa)
+* Support `layout` option in `render inertia:` calls (@skryukov)
 
 ## [3.20.0] - 2026-04-04
 

--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -112,6 +112,16 @@ module InertiaRails
       view_assigns.except(*@_inertia_skip_props)
     end
 
+    # Rails < 8: _normalize_options overwrites :layout with a resolved default,
+    # making an explicit `layout: false` indistinguishable from "not provided".
+    # Stash the original value so the renderer can tell the two apart.
+    def _normalize_options(options)
+      if options.key?(:inertia) && options.key?(:layout)
+        options[:_inertia_layout] = options[:layout]
+      end
+      super
+    end
+
     def inertia_configuration
       self.class._inertia_configuration.bind_controller(self)
     end

--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -116,9 +116,7 @@ module InertiaRails
     # making an explicit `layout: false` indistinguishable from "not provided".
     # Stash the original value so the renderer can tell the two apart.
     def _normalize_options(options)
-      if options.key?(:inertia) && options.key?(:layout)
-        options[:_inertia_layout] = options[:layout]
-      end
+      options[:_inertia_layout] = options[:layout] if options.key?(:inertia) && options.key?(:layout)
       super
     end
 

--- a/lib/inertia_rails/engine.rb
+++ b/lib/inertia_rails/engine.rb
@@ -15,6 +15,14 @@ module InertiaRails
     initializer 'inertia_rails.renderer' do
       ActiveSupport.on_load(:action_controller) do
         ActionController::Renderers.add :inertia do |component, options|
+          # See Controller#_normalize_options — restore the user's original
+          # :layout or discard the Rails-injected default.
+          if options.key?(:_inertia_layout)
+            options[:layout] = options.delete(:_inertia_layout)
+          else
+            options.delete(:layout)
+          end
+
           InertiaRails::Renderer.new(
             component,
             self,

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -27,6 +27,7 @@ module InertiaRails
       @encrypt_history = options.fetch(:encrypt_history, @configuration.encrypt_history)
       @clear_history = options.fetch(:clear_history, controller.session[:inertia_clear_history] || false)
       @preserve_fragment = options.fetch(:preserve_fragment, controller.session[:inertia_preserve_fragment] || false)
+      @layout_override = options.fetch(:layout) { @configuration.layout }
       @ssr_cache = options[:ssr_cache]
 
       deep_merge = options.fetch(:deep_merge, @configuration.deep_merge_shared_data)
@@ -70,7 +71,7 @@ module InertiaRails
     end
 
     def layout
-      layout = @configuration.layout
+      layout = @layout_override
       layout.nil? || layout
     end
 

--- a/spec/dummy/app/controllers/inertia_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_test_controller.rb
@@ -15,6 +15,14 @@ class InertiaTestController < ApplicationController
     render inertia: 'EmptyTestComponent'
   end
 
+  def with_inline_layout
+    render inertia: 'EmptyTestComponent', layout: 'testing'
+  end
+
+  def without_layout
+    render inertia: 'EmptyTestComponent', layout: false
+  end
+
   def redirect_test
     redirect_to :empty_test
   end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
   get 'share_with_inherited' => 'inertia_child_share_test#share_with_inherited'
   get 'empty_test' => 'inertia_test#empty_test'
   get 'with_different_layout' => 'inertia_test#with_different_layout'
+  get 'with_inline_layout' => 'inertia_test#with_inline_layout'
+  get 'without_layout' => 'inertia_test#without_layout'
   get 'redirect_test' => 'inertia_test#redirect_test'
   get 'inertia_request_test' => 'inertia_test#inertia_request_test'
   get 'inertia_partial_request_test' => 'inertia_test#inertia_partial_request_test'

--- a/spec/inertia/configuration_spec.rb
+++ b/spec/inertia/configuration_spec.rb
@@ -172,6 +172,22 @@ RSpec.describe 'Inertia configuration', type: :request do
         it { is_expected.not_to render_template 'application' }
       end
 
+      context 'with an inline layout option' do
+        before { get with_inline_layout_path }
+
+        it { is_expected.to render_template 'inertia' }
+        it { is_expected.to render_template 'testing' }
+        it { is_expected.not_to render_template 'application' }
+      end
+
+      context 'with layout: false' do
+        before { get without_layout_path }
+
+        it { is_expected.to render_template 'inertia' }
+        it { is_expected.not_to render_template 'testing' }
+        it { is_expected.not_to render_template 'application' }
+      end
+
       context 'opting out of a different layout for Inertia' do
         before do
           InertiaRails.configure { |c| c.layout = true }

--- a/spec/inertia/renderer_spec.rb
+++ b/spec/inertia/renderer_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe InertiaRails::Renderer do
                              encrypt_history: true,
                              deep_merge_shared_data: false,
                              clear_history: false,
-                             expose_shared_prop_keys: true)
+                             expose_shared_prop_keys: true,
+                             layout: true)
 
       controller = double('controller',
                           inertia_configuration: configuration,


### PR DESCRIPTION
## Summary

- Support the standard Rails `layout:` render option in Inertia responses, e.g. `render inertia: 'Component', layout: 'admin'`
- Also supports `layout: false` to render without a layout
- The inline option takes precedence over `inertia_config` / global configuration

Fixes #363

## Checklist

- [x] Tests added or updated
- [x] `CHANGELOG.md` updated (for user-facing changes)
