### PR TITLE
Use params.expect instead of params.require.permit (Rails 8+)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Use `params.expect` instead of `params.require(...).permit(...)` in scaffold generator and docs
+
 ## [3.21.0] - 2026-04-14
 
 * Skip excluded hash props on partial reloads (@erickreutz)

--- a/docs/guide/forms.md
+++ b/docs/guide/forms.md
@@ -2499,7 +2499,7 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :email)
+    params.expect(user: [:name, :email])
   end
 end
 ```

--- a/docs/guide/redirects.md
+++ b/docs/guide/redirects.md
@@ -19,7 +19,7 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :email)
+    params.expect(user: [:name, :email])
   end
 end
 ```

--- a/docs/guide/validation.md
+++ b/docs/guide/validation.md
@@ -21,7 +21,7 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :email)
+    params.expect(user: [:name, :email])
   end
 end
 ```

--- a/lib/generators/inertia/scaffold_controller/templates/controller.rb.tt
+++ b/lib/generators/inertia/scaffold_controller/templates/controller.rb.tt
@@ -75,7 +75,7 @@ class <%= controller_class_name %>Controller < <%= parent_controller %>
       <%- if attributes_names.empty? -%>
       params.fetch(:<%= singular_table_name %>, {})
       <%- else -%>
-      params.require(:<%= singular_table_name %>).permit(<%= permitted_params %>)
+      params.expect(<%= singular_table_name %>: [<%= permitted_params %>])
       <%- end -%>
     end
 

--- a/lib/generators/inertia/scaffold_controller/templates/controller.rb.tt
+++ b/lib/generators/inertia/scaffold_controller/templates/controller.rb.tt
@@ -74,8 +74,10 @@ class <%= controller_class_name %>Controller < <%= parent_controller %>
     def <%= "#{singular_table_name}_params" %>
       <%- if attributes_names.empty? -%>
       params.fetch(:<%= singular_table_name %>, {})
-      <%- else -%>
+      <%- elsif Rails::VERSION::MAJOR >= 8 -%>
       params.expect(<%= singular_table_name %>: [<%= permitted_params %>])
+      <%- else -%>
+      params.require(:<%= singular_table_name %>).permit(<%= permitted_params %>)
       <%- end -%>
     end
 


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Summary

Replaces `params.require(:model).permit(...)` with `params.expect(model: [...])` introduced in Rails 8.

`params.expect` is the safer, more explicit successor to `params.require(...).permit(...)`. It raises `ActionController::ParameterMissing` for unexpected input shapes and avoids the [array-of-permitted-scalars bypass](https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-expect) that the old pattern was susceptible to.

Changes:
- **Scaffold generator template** (`lib/generators/inertia/scaffold_controller/templates/controller.rb.tt`): generated controller code now uses `params.expect`
- **Docs** (`docs/guide/validation.md`, `docs/guide/forms.md`, `docs/guide/redirects.md`): updated illustrative examples to reflect the modern Rails 8 API

Reference: https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-expect

## Test plan

- Ran the existing test suite — no failures.
- Verified scaffold output manually: generated controller uses `params.expect(model: [:attr1, :attr2])`.
- Doc changes are illustrative only (no executable code).

## Checklist

- [ ] Tests added or updated
- [x] `CHANGELOG.md` updated (for user-facing changes)
