### PR TITLE
set an explicit `formats: :html` when rendering Inertia responses

### DIFF
--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -56,10 +56,20 @@ module InertiaRails
         ssr = @configuration.ssr_enabled && ssr_render
         if ssr
           @controller.instance_variable_set('@_inertia_ssr_head', ssr['head'].join.html_safe)
-          @render_method.call html: ssr['body'].html_safe, layout: layout, locals: @view_data.merge(page: page)
+          @render_method.call(
+            html: ssr['body'].html_safe,
+            layout: layout,
+            locals: @view_data.merge(page: page),
+            formats: :html
+          )
         else
           @controller.instance_variable_set('@_inertia_page', page)
-          @render_method.call template: 'inertia', layout: layout, locals: @view_data.merge(page: page)
+          @render_method.call(
+            template: 'inertia',
+            layout: layout,
+            locals: @view_data.merge(page: page),
+            formats: :html
+          )
         end
       end
     end


### PR DESCRIPTION
Most of the time, this is unnecessary, since Inertia requests are almost always traditional HTML requests automatically.

However, when a user is making unexpected requests (like trying to change the format of a request to see what the server will respond to), the request may come in as an XML request (or something else entirely), and we want to render our app's error page via Inertia:

```ruby

class ErrorsController < ApplicationController
  # ...

  def not_found
    respond_to do |format|
      format.json { render json: { error: 'not_found' }, status: :not_found }
      format.any { render inertia: 'error', props: { status: 'not_found' }, status: :not_found }
    end
  end
end
```

Unfortunately, that doesn't work because, without an explicit `formats: :html`, this exception gets raised:

```
ActionView::MissingTemplate: Missing template /inertia with {locale: [:en], formats: [:xml], variants: [], handlers: [:raw, :erb, :html, :builder, :ruby]}.
```

Passing `formats: :html` to `render` in the controller doesn't do the trick, as those additional options are not passed down to the underlying `render_method` call. That wouldn't be a bad idea either, but it seems important to explicitly render `formats: :html` when rendering an Inertia request, which resolves this issue altogether without the user having to do anything else.