### PR TITLE
Fix vite install to use configured package manager in generator

### DIFF
--- a/lib/generators/inertia/install/install_generator.rb
+++ b/lib/generators/inertia/install/install_generator.rb
@@ -223,7 +223,8 @@ module Inertia
               say_error 'Failed to install Vite Rails gem', :red
               exit(false)
             end
-            if (capture = run('bundle exec vite install', capture: !verbose?))
+            vite_ruby_install_options = package_manager.present? ? "--package-manager=#{package_manager.name}" : ''
+            if (capture = run("bundle exec vite install #{vite_ruby_install_options}", capture: !verbose?))
               rename_application_js_to_ts if typescript?
               run('bundle binstub vite_ruby', capture: !verbose?) unless File.exist?(file_path('bin/vite'))
               say 'Vite Rails successfully installed', :green


### PR DESCRIPTION
### Description

When running the `inertia:install` generator with the `--package-manager` option (e.g., `pnpm`), the underlying `vite install` command executed by Vite Ruby does not respect this choice. As a result, it defaults to using `npm`, creating a `package-lock.json` alongside the existing `pnpm-lock.yaml`, which leads to conflicts in `node_modules`.

This PR fixes the issue by passing the selected package manager option directly to the `bundle exec vite install` command.

### Steps to reproduce

```bash
rails new my_app --skip-js
cd my_app
bundle add inertia_rails
rails generate inertia:install --package-manager=pnpm --vite --typescript --framework=react --tailwind --force --verbose
```

### Expected behavior

The installation should be managed entirely by the specified package manager (`pnpm` in this case).

### Actual behavior

Vite Ruby runs the installation using `npm`, causing both `package-lock.json` and `pnpm-lock.yaml` to coexist, which corrupts the `node_modules` directory.

### Workaround

Currently, the issue can be avoided by explicitly passing an environment variable:
```bash
VITE_RUBY_PACKAGE_MANAGER=pnpm rails generate inertia:install --package-manager=pnpm --vite --typescript --framework=react --tailwind --force --verbose
```

Vite Ruby prioritizes this environment variable if present.

### Proposed solution

If the `--package-manager` option is present in the generator, pass the `--package-manager` flag to the vite install command as well.
