### PR TITLE
Specify the initializer run order for middleware insertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* Use `params.expect` instead of `params.require(...).permit(...)` in scaffold generator and docs
+* Specify initializer run order for middleware insertion to avoid frozen middleware stack errors on Rails 8.1+ (@julik)
+* Set an explicit `formats: :html` when rendering Inertia responses (@agrobbin)
+* Use `params.expect` instead of `params.require(...).permit(...)` in scaffold generator and docs (@tyrro)
+* Add railsfullstack.com to Awesome page (@code-creativeapps)
 
 ## [3.21.0] - 2026-04-14
 

--- a/lib/inertia_rails/engine.rb
+++ b/lib/inertia_rails/engine.rb
@@ -3,7 +3,7 @@
 module InertiaRails
   class Engine < ::Rails::Engine
     initializer 'inertia_rails.configure_rails_initialization' do |app|
-      app.middleware.use ::InertiaRails::Middleware
+      app.config.app_middleware.use ::InertiaRails::Middleware
     end
 
     initializer 'inertia_rails.action_controller' do

--- a/lib/inertia_rails/engine.rb
+++ b/lib/inertia_rails/engine.rb
@@ -2,8 +2,8 @@
 
 module InertiaRails
   class Engine < ::Rails::Engine
-    initializer 'inertia_rails.configure_rails_initialization' do |app|
-      app.config.app_middleware.use ::InertiaRails::Middleware
+    initializer 'inertia_rails.configure_rails_initialization', before: :build_middleware_stack do |app|
+      app.middleware.use ::InertiaRails::Middleware
     end
 
     initializer 'inertia_rails.action_controller' do


### PR DESCRIPTION
https://github.com/rails/rails/pull/53615 changed the initializers from an Array to a sorted graph. In absence of some care the initializer can end up in a spot where the middleware stack is already frozen, preventing any Rails app code from running - down to not being able to run `bin/rails middleware` or `bin/rails g <any generator>`:

```
julik@thicc cora (geneva_drive_with_metadata) $ bin/rails middleware
warning: parser/current is loading parser/ruby34, which recognizes 3.4.0-dev-compliant syntax, but you are running 3.4.2.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
DEPRECATION WARNING: ActiveSupport::Configurable is deprecated without replacement, and will be removed in Rails 8.2.

You can emulate the previous behavior with `class_attribute`.
 (called from <main> at /Users/julik/Code/every/cora/config/application.rb:7)
/Users/julik/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.1.3/lib/action_dispatch/middleware/stack.rb:162:in 'Array#push': can't modify frozen Array: [Rack::MiniProfiler, Rack::Events, Honeybadger::Rack::UserInformer, Honeybadger::Rack::UserFeedback, Honeybadger::Rack::ErrorNotifier, Rack::Sendfile, ActionDispatch::Static, ActionDispatch::Executor, Debugbar::TrackCurrentRequest, Debugbar::QuietRoutes, ConnectionPoolStats, ActionDispatch::ServerTiming, ActiveSupport::Cache::Strategy::LocalCache::Middleware, Rack::Runtime, Rack::MethodOverride, ActionDispatch::RequestId, ActionDispatch::RemoteIp, Sprockets::Rails::QuietAssets, Rails::Rack::Logger, ActionDispatch::ShowExceptions, WebConsole::Middleware, ActionDispatch::DebugExceptions, Appsignal::Rack::RailsInstrumentation, ActionDispatch::ActionableExceptions, ActionDispatch::Reloader, ActionDispatch::Callbacks, ActiveRecord::Migration::CheckPending, ActionDispatch::Cookies, ActionDispatch::Session::CookieStore, ActionDispatch::Flash, ActionDispatch::ContentSecurityPolicy::Middleware, Rack::Head, Rack::ConditionalGet, Rack::ETag, Rack::TempfileReaper, Warden::Manager, Rack::Static, Rack::Attack, Blazer::Ai::Middleware, Prosopite::Middleware::Rack, TerminalRateLimit, OmniAuth::Strategies::GoogleOauth2, OmniAuth::Strategies::Every, Flipper::Middleware::Memoizer] (FrozenError)
	from /Users/julik/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.1.3/lib/action_dispatch/middleware/stack.rb:162:in 'ActionDispatch::MiddlewareStack#use'
	from /Users/julik/Code/libs/inertia-rails/lib/inertia_rails/engine.rb:6:in 'block in <class:Engine>'
	from /Users/julik/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/initializable.rb:24:in 'BasicObject#instance_exec'
	from /Users/julik/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/initializable.rb:24:in 'Rails::Initializable::Initializer#run'
	from /Users/julik/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/initializable.rb:103:in 'block in Rails::Initializable#run_initializers'
	from /Users/julik/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/tsort-0.2.0/lib/tsort.rb:231:in 'block in TSort.tsort_each'
	from /Users/julik/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/tsort-0.2.0/lib/tsort.rb:353:in 'block (2 levels) in TSort.each_strongly_connected_component'
	from /Users/julik/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/tsort-0.2.0/lib/tsort.rb:434:in 'TSort.each_strongly_connected_component_from'
	from /Users/julik/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/tsort-0.2.0/lib/tsort.rb:352:in 'block in TSort.each_strongly_connected_component'
	from /Users/julik/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/initializable.rb:59:in 'Array#each'
	from /Users/julik/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/initializable.rb:59:in 'Rails::Initializable::Collection#each'
	from /Users/julik/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/tsort-0.2.0/lib/tsort.rb:350:in 'Method#call'
	from /Users/julik/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/tsort-0.2.0/lib/tsort.rb:350:in 'TSort.each_strongly_connected_component'
	from /Users/julik/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/tsort-0.2.0/lib/tsort.rb:229:in 'TSort.tsort_each'
	from /Users/julik/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/tsort-0.2.0/lib/tsort.rb:208:in 'TSort#tsort_each'
	from /Users/julik/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/initializable.rb:102:in 'Rails::Initializable#run_initializers'
	from /Users/julik/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/application.rb:442:in 'Rails::Application#initialize!'
	from /Users/julik/Code/every/cora/config/environment.rb:5:in '<main>'
	from /Users/julik/.rbenv/versions/3.4.2/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require'
```

This is - sadly - non-deterministic and means that any middleware injection from an engine which does not specify its spot can hit a frozen middleware stack. I can't see how to make a "truly" minimal repro for this - but specifying when the initializer should run (where it gets ordered into) seems to help.

