### PR TITLE
Add CSP nonce to initial page script (when needed)

### DIFF
--- a/lib/inertia_rails/helper.rb
+++ b/lib/inertia_rails/helper.rb
@@ -36,8 +36,14 @@ module InertiaRails
       id ||= config.root_dom_id
 
       if config.use_script_element_for_initial_page
+        script_options = { 'data-page': id, type: 'application/json' }
+        if respond_to?(:content_security_policy_nonce, true)
+          nonce = content_security_policy_nonce
+          script_options[:nonce] = nonce if nonce.present?
+        end
+
         safe_join([
-                    tag.script(page.to_json.html_safe, 'data-page': id, type: 'application/json'),
+                    tag.script(page.to_json.html_safe, **script_options),
                     tag.div(id: id)
                   ], "\n")
       else

--- a/spec/inertia/helper_spec.rb
+++ b/spec/inertia/helper_spec.rb
@@ -19,6 +19,53 @@ RSpec.describe InertiaRails::Helper, type: :helper do
     end
   end
 
+  describe '#inertia_root' do
+    let(:page) do
+      {
+        component: 'TestComponent',
+        props: { message: 'Hello' },
+        url: '/test',
+        version: nil,
+      }
+    end
+
+    def stub_content_security_policy_nonce(value)
+      helper.singleton_class.define_method(:content_security_policy_nonce) { value }
+    end
+
+    context 'when using a script element for the initial page' do
+      with_inertia_config use_script_element_for_initial_page: true
+
+      it 'renders the script tag with the Rails CSP nonce' do
+        stub_content_security_policy_nonce('test-nonce')
+
+        expect(helper.inertia_root(page: page)).to include(
+          '<script data-page="app" type="application/json" nonce="test-nonce">'
+        )
+      end
+
+      it 'does not render a nonce attribute when Rails does not provide a nonce' do
+        stub_content_security_policy_nonce(nil)
+
+        expect(helper.inertia_root(page: page)).not_to include(' nonce=')
+      end
+    end
+
+    context 'when using a data-page attribute for the initial page' do
+      with_inertia_config use_script_element_for_initial_page: false
+
+      it 'preserves the existing non-script rendering' do
+        stub_content_security_policy_nonce('test-nonce')
+
+        result = helper.inertia_root(page: page)
+
+        expect(result).to include('<div id="app" data-page=')
+        expect(result).not_to include('<script')
+        expect(result).not_to include(' nonce=')
+      end
+    end
+  end
+
   describe '#inertia_meta_tags' do
     context 'basic rendering' do
       before do


### PR DESCRIPTION
### What is this?

InertiaRails can render the initial page payload in an `application/json` script tag when `use_script_element_for_initial_page` is enabled. Rails apps with strict CSP settings may require every script tag to include the per-request nonce, but `inertia_root` currently renders that JSON script without one.

In our app, that caused CSP violations during an upgrade and required an app-level monkey patch to add the nonce. This PR moves that behavior into the built-in helper by resolving Rails' `content_security_policy_nonce` when
available and adding it to the script tag.

The existing `data-page` div rendering is preserved when script mode is disabled.

### Example problem

A Rails app using a strict CSP can enable nonces for scripts:

```ruby
# config/initializers/content_security_policy.rb
Rails.application.config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
Rails.application.config.content_security_policy_nonce_directives = %w[script-src]
```

Then, if the app enables script-based initial page data:

```ruby
InertiaRails.configure do |config|
  config.use_script_element_for_initial_page = true
end
```

`inertia_root` currently renders:

```html
<script data-page="app" type="application/json">
  {"component":"Users/Index","props":{}}
</script>
<div id="app"></div>
```

That `<script>` has no nonce, so strict CSP setups can reject it even though it is `type="application/json"`.

After this change, when Rails provides a CSP nonce, the rendered HTML becomes:

```html
<script data-page="app" type="application/json" nonce="abc123">
  {"component":"Users/Index","props":{}}
</script>
<div id="app"></div>
```

When `use_script_element_for_initial_page` is disabled, the existing behavior stays the same:

```html
<div id="app" data-page="{...}"></div>
```