### PR TITLE
Fix TypeScript packages installed as dependencies instead of devDependencies

### DIFF
--- a/lib/generators/inertia/install/install_generator.rb
+++ b/lib/generators/inertia/install/install_generator.rb
@@ -142,7 +142,7 @@ module Inertia
       def install_typescript
         say 'Adding TypeScript support'
 
-        add_dependencies(*FRAMEWORKS[framework]['packages_ts'])
+        add_dependencies(*FRAMEWORKS[framework]['packages_ts'], dev: true)
 
         say 'Copying tsconfig and types'
 
@@ -282,8 +282,8 @@ module Inertia
         @package_manager ||= JSPackageManager.new(self)
       end
 
-      def add_dependencies(*packages)
-        package_manager.add_dependencies(*packages)
+      def add_dependencies(*packages, dev: false)
+        package_manager.add_dependencies(*packages, dev: dev)
       end
 
       def vite_config_path

--- a/lib/generators/inertia/install/js_package_manager.rb
+++ b/lib/generators/inertia/install/js_package_manager.rb
@@ -15,10 +15,11 @@ module Inertia
         name.present?
       end
 
-      def add_dependencies(*dependencies)
+      def add_dependencies(*dependencies, dev: false)
+        dev_flag = dev ? ' -D' : ''
         options = @generator.options[:verbose] ? '' : ' --silent'
         @generator.in_root do
-          @generator.run "#{name} add #{dependencies.join(' ')}#{options}"
+          @generator.run "#{name} add#{dev_flag} #{dependencies.join(' ')}#{options}"
         end
       end
 


### PR DESCRIPTION
## Problem

When running `rails generate inertia:install --typescript`, all packages listed under `packages_ts` in `frameworks.yml` are installed as regular `dependencies` instead of `devDependencies`.

Affected packages:
- **React**: `@types/react`, `@types/react-dom`, `typescript`
- **Vue**: `typescript`, `vue-tsc`
- **Svelte**: `@tsconfig/svelte`, `svelte-check`, `typescript`, `tslib`

These are all build-time / type-checking tools. None of them are needed at runtime.

## Root cause

`JSPackageManager#add_dependencies` always runs `yarn add <packages>` without the `-D` flag:

```ruby
# lib/generators/inertia/install/js_package_manager.rb
def add_dependencies(*dependencies)
  options = @generator.options[:verbose] ? '' : ' --silent'
  @generator.in_root do
    @generator.run "#{name} add #{dependencies.join(' ')}#{options}"
  end
end
```

## Practical impact

Beyond the incorrect placement in `package.json`, this causes a hard failure with Yarn 4 when a downstream tool (e.g. a Rails app template) tries to add `svelte-check` as a dev dependency after the generator has already placed it in `dependencies`:

```
Usage Error: Package "svelte-check" is already listed as a regular dependency -
remove the -D,-P flags or remove it from your dependencies first
```

## Fix

Add a `dev:` keyword argument to `add_dependencies` in both `JSPackageManager` and the private wrapper in `InstallGenerator`. Pass `dev: true` when installing TypeScript packages.

```ruby
# js_package_manager.rb
def add_dependencies(*dependencies, dev: false)
  dev_flag = dev ? " -D" : ""
  silent_flag = @generator.options[:verbose] ? "" : " --silent"
  @generator.in_root do
    @generator.run "#{name} add#{dev_flag} #{dependencies.join(" ")}#{silent_flag}"
  end
end
```

The `-D` flag is supported by all four package managers (`yarn`, `npm`, `pnpm`, `bun`).