### PR TITLE
Add `rescue` option to defer props & update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Add `rescue: true` option to `InertiaRails.defer` to rescue and report exceptions raised while resolving a deferred prop (@skryukov)
 * Add CSP nonce to the initial page script when needed (@nicholaspufal)
 * Fix Vite install to use the configured package manager in the generator (@akicho8)
 * Fix TypeScript packages installed as dependencies instead of devDependencies (@alec-c4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Add CSP nonce to the initial page script when needed (@nicholaspufal)
+* Fix Vite install to use the configured package manager in the generator (@akicho8)
+* Fix TypeScript packages installed as dependencies instead of devDependencies (@alec-c4)
+
 ## [3.21.1] - 2026-05-19
 
 * Specify initializer run order for middleware insertion to avoid frozen middleware stack errors on Rails 8.1+ (@julik)

--- a/docs/guide/client-side-setup.md
+++ b/docs/guide/client-side-setup.md
@@ -305,7 +305,7 @@ The callback receives the React element and must return a new element. This is w
 The callback receives a `Map` that serves as Svelte's component context. Values set here are accessible in your components via `getContext()`.
 </Svelte>
 
-A second `{ ssr }` argument is also available, allowing you to conditionally apply logic based on the rendering environment.
+A second argument provides the current rendering environment via `ssr`, allowing you to conditionally apply logic based on where the app is running.
 
 :::tabs key:frameworks
 
@@ -348,6 +348,46 @@ createInertiaApp({
       context.set('analytics', createAnalytics())
     }
   },
+})
+```
+
+:::
+
+The second argument also includes the current `page` object, giving you access to the component name, URL, version, and shared props before the app renders. Useful for configuring plugins or providers with server-driven state like the user's locale.
+
+:::tabs key:frameworks
+
+== Vue
+
+```js
+createInertiaApp({
+    withApp(app, { page }) {
+        const i18n = createI18n({ locale: page.props.locale })
+
+        app.use(i18n)
+    },
+})
+```
+
+== React
+
+```jsx
+createInertiaApp({
+    withApp(app, { page }) {
+        const i18n = createI18n({ locale: page.props.locale })
+
+        return <I18nProvider i18n={i18n}>{app}</I18nProvider>
+    },
+})
+```
+
+== Svelte
+
+```js
+createInertiaApp({
+    withApp(context, { page }) {
+        context.set('locale', page.props.locale)
+    },
 })
 ```
 
@@ -526,6 +566,19 @@ createInertiaApp({
 ```
 
 If you change the `id` of the root element, be sure to update it [server-side](/guide/server-side-setup#root-template) as well.
+
+## Content Security Policy
+
+@available_since core=3.1.0
+
+For applications using a [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) that restricts inline styles, you may pass a `nonce` to `createInertiaApp()`. The nonce is applied to the inline styles Inertia injects for the [progress bar](/guide/progress-indicators) and the [error modal](/guide/error-handling), allowing them through your CSP.
+
+```js
+createInertiaApp({
+  nonce: "your-csp-nonce",
+  // ...
+});
+```
 
 ## HTTP Client
 

--- a/docs/guide/client-side-setup.md
+++ b/docs/guide/client-side-setup.md
@@ -361,11 +361,11 @@ The second argument also includes the current `page` object, giving you access t
 
 ```js
 createInertiaApp({
-    withApp(app, { page }) {
-        const i18n = createI18n({ locale: page.props.locale })
+  withApp(app, { page }) {
+    const i18n = createI18n({ locale: page.props.locale })
 
-        app.use(i18n)
-    },
+    app.use(i18n)
+  },
 })
 ```
 
@@ -373,11 +373,11 @@ createInertiaApp({
 
 ```jsx
 createInertiaApp({
-    withApp(app, { page }) {
-        const i18n = createI18n({ locale: page.props.locale })
+  withApp(app, { page }) {
+    const i18n = createI18n({ locale: page.props.locale })
 
-        return <I18nProvider i18n={i18n}>{app}</I18nProvider>
-    },
+    return <I18nProvider i18n={i18n}>{app}</I18nProvider>
+  },
 })
 ```
 
@@ -385,9 +385,9 @@ createInertiaApp({
 
 ```js
 createInertiaApp({
-    withApp(context, { page }) {
-        context.set('locale', page.props.locale)
-    },
+  withApp(context, { page }) {
+    context.set('locale', page.props.locale)
+  },
 })
 ```
 
@@ -575,9 +575,9 @@ For applications using a [Content Security Policy](https://developer.mozilla.org
 
 ```js
 createInertiaApp({
-  nonce: "your-csp-nonce",
+  nonce: 'your-csp-nonce',
   // ...
-});
+})
 ```
 
 ## HTTP Client

--- a/docs/guide/deferred-props.md
+++ b/docs/guide/deferred-props.md
@@ -235,6 +235,100 @@ export default () => (
 
 The `reloading` prop is `false` on the initial load and becomes `true` whenever a partial reload is in progress for the deferred keys. It returns to `false` once the reload completes.
 
+## Error Handling
+
+@available_since rails=master core=3.1.0
+
+By default, exceptions thrown while resolving a deferred prop result in an error response. You may instruct Inertia to rescue these exceptions by passing `rescue: true` to `InertiaRails.defer`.
+
+```ruby
+class UsersController < ApplicationController
+  def index
+    render inertia: {
+      permissions: InertiaRails.defer(rescue: true) { Permission.all },
+    }
+  end
+end
+```
+
+When a deferred prop is rescued, it is omitted from the response and the exception is reported via Rails's [Error Reporter](https://guides.rubyonrails.org/error_reporting.html#using-the-error-reporter).
+
+On the client side, you may provide a `rescue` slot to the `Deferred` component to render a fallback UI when a prop fails to load.
+
+:::tabs key:frameworks
+
+== Vue
+
+```vue
+<script setup>
+import { Deferred, router } from "@inertiajs/vue3";
+</script>
+<template>
+  <Deferred data="permissions">
+    <template #fallback>
+      <div>Loading...</div>
+    </template>
+    <template #rescue="{ reloading }">
+      <div>
+        <p>Failed to load permissions.</p>
+        <button :disabled="reloading" @click="router.reload({ only: ['permissions'] })">Retry</button>
+      </div>
+    </template>
+    <div v-for="permission in permissions">
+      <!-- ... -->
+    </div>
+  </Deferred>
+</template>
+```
+
+== React
+
+```jsx
+import { Deferred, router } from "@inertiajs/react";
+
+export default () => (
+  <Deferred
+    data="permissions"
+    fallback={<div>Loading...</div>}
+    rescue={({ reloading }) => (
+      <div>
+        <p>Failed to load permissions.</p>
+        <button disabled={reloading} onClick={() => router.reload({ only: ["permissions"] })}>Retry</button>
+      </div>
+    )}
+  >
+    <PermissionsChildComponent />
+  </Deferred>
+);
+```
+
+== Svelte
+
+```svelte
+<script>
+    import { Deferred, router } from '@inertiajs/svelte'
+    let { permissions } = $props()
+</script>
+<Deferred data="permissions">
+    {#snippet fallback()}
+        <div>Loading...</div>
+    {/snippet}
+    {#snippet rescue({ reloading })}
+        <div>
+            <p>Failed to load permissions.</p>
+            <button disabled={reloading} onclick={() => router.reload({ only: ['permissions'] })}>Retry</button>
+        </div>
+    {/snippet}
+    {#each permissions as permission}
+        <!-- ... -->
+    {/each}
+</Deferred>
+```
+
+:::
+
+The rescue state is preserved until you explicitly reload the rescued prop. The `rescue` slot receives a `reloading` boolean, allowing you to disable the retry button or show a loading indicator while the reload is in progress.
+
 ## Combining with Once Props
 
 @available_since rails=3.15.0 core=2.2.20

--- a/docs/guide/deferred-props.md
+++ b/docs/guide/deferred-props.md
@@ -245,13 +245,16 @@ By default, exceptions thrown while resolving a deferred prop result in an error
 class UsersController < ApplicationController
   def index
     render inertia: {
-      permissions: InertiaRails.defer(rescue: true) { Permission.all },
+      permissions: InertiaRails.defer(rescue: true) { current_user.permissions },
     }
   end
 end
 ```
 
 When a deferred prop is rescued, it is omitted from the response and the exception is reported via Rails's [Error Reporter](https://guides.rubyonrails.org/error_reporting.html#using-the-error-reporter).
+
+> [!NOTE]
+> To catch errors reliably, Inertia serializes the rescued prop (by calling `as_json` on its value) within the rescued scope. This means lazy values such as `ActiveRecord::Relation`s have their queries executed, and serialization errors are caught too — not just exceptions raised directly within the block.
 
 On the client side, you may provide a `rescue` slot to the `Deferred` component to render a fallback UI when a prop fails to load.
 

--- a/docs/guide/deferred-props.md
+++ b/docs/guide/deferred-props.md
@@ -264,7 +264,7 @@ On the client side, you may provide a `rescue` slot to the `Deferred` component 
 
 ```vue
 <script setup>
-import { Deferred, router } from "@inertiajs/vue3";
+import { Deferred, router } from '@inertiajs/vue3'
 </script>
 <template>
   <Deferred data="permissions">
@@ -274,7 +274,12 @@ import { Deferred, router } from "@inertiajs/vue3";
     <template #rescue="{ reloading }">
       <div>
         <p>Failed to load permissions.</p>
-        <button :disabled="reloading" @click="router.reload({ only: ['permissions'] })">Retry</button>
+        <button
+          :disabled="reloading"
+          @click="router.reload({ only: ['permissions'] })"
+        >
+          Retry
+        </button>
       </div>
     </template>
     <div v-for="permission in permissions">
@@ -287,7 +292,7 @@ import { Deferred, router } from "@inertiajs/vue3";
 == React
 
 ```jsx
-import { Deferred, router } from "@inertiajs/react";
+import { Deferred, router } from '@inertiajs/react'
 
 export default () => (
   <Deferred
@@ -296,35 +301,44 @@ export default () => (
     rescue={({ reloading }) => (
       <div>
         <p>Failed to load permissions.</p>
-        <button disabled={reloading} onClick={() => router.reload({ only: ["permissions"] })}>Retry</button>
+        <button
+          disabled={reloading}
+          onClick={() => router.reload({ only: ['permissions'] })}
+        >
+          Retry
+        </button>
       </div>
     )}
   >
     <PermissionsChildComponent />
   </Deferred>
-);
+)
 ```
 
 == Svelte
 
 ```svelte
 <script>
-    import { Deferred, router } from '@inertiajs/svelte'
-    let { permissions } = $props()
+  import { Deferred, router } from '@inertiajs/svelte'
+  let { permissions } = $props()
 </script>
+
 <Deferred data="permissions">
-    {#snippet fallback()}
-        <div>Loading...</div>
-    {/snippet}
-    {#snippet rescue({ reloading })}
-        <div>
-            <p>Failed to load permissions.</p>
-            <button disabled={reloading} onclick={() => router.reload({ only: ['permissions'] })}>Retry</button>
-        </div>
-    {/snippet}
-    {#each permissions as permission}
-        <!-- ... -->
-    {/each}
+  {#snippet fallback()}
+    <div>Loading...</div>
+  {/snippet}
+  {#snippet rescue({ reloading })}
+    <div>
+      <p>Failed to load permissions.</p>
+      <button
+        disabled={reloading}
+        onclick={() => router.reload({ only: ['permissions'] })}>Retry</button
+      >
+    </div>
+  {/snippet}
+  {#each permissions as permission}
+    <!-- ... -->
+  {/each}
 </Deferred>
 ```
 

--- a/docs/guide/error-handling.md
+++ b/docs/guide/error-handling.md
@@ -8,6 +8,8 @@ The challenge is, if you're making an XHR request (which Inertia does) and you h
 
 Inertia solves this issue by showing all non-Inertia responses in a modal. This means you get the same beautiful error-reporting you're accustomed to, even though you've made that request over XHR.
 
+For applications using a [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) that restricts inline styles, you may pass a `nonce` to `createInertiaApp()` to permit the inline styles the error modal injects. See [Content Security Policy](/guide/client-side-setup#content-security-policy) for details.
+
 ## Dialog element
 
 @available_since core=2.2.13

--- a/docs/guide/events.md
+++ b/docs/guide/events.md
@@ -220,6 +220,92 @@ document.removeEventListener('inertia:start', startEventListener)
 
 :::
 
+
+## One-time Listeners
+
+@available_since core=3.2.0
+
+You may register a listener that fires only once using the `router.once()` method. The listener is automatically removed after the first invocation.
+
+:::tabs key:frameworks
+
+== Vue
+
+```js
+import { router } from "@inertiajs/vue3";
+
+router.once("start", (event) => {
+  console.log(`Starting a visit to ${event.detail.visit.url}`);
+});
+```
+
+== React
+
+```jsx
+import { router } from "@inertiajs/react";
+
+router.once("start", (event) => {
+  console.log(`Starting a visit to ${event.detail.visit.url}`);
+});
+```
+
+== Svelte
+
+```js
+import { router } from "@inertiajs/svelte";
+
+router.once("start", (event) => {
+  console.log(`Starting a visit to ${event.detail.visit.url}`);
+});
+```
+
+:::
+
+Like `router.on()`, this method returns a callback you may invoke to remove the listener before it fires.
+
+:::tabs key:frameworks
+
+== Vue
+
+```js
+import { router } from "@inertiajs/vue3";
+
+let removeStartEventListener = router.once("start", (event) => {
+  console.log(`Starting a visit to ${event.detail.visit.url}`);
+});
+
+// Remove the listener before it fires...
+removeStartEventListener();
+```
+
+== React
+
+```jsx
+import { router } from "@inertiajs/react";
+
+let removeStartEventListener = router.once("start", (event) => {
+  console.log(`Starting a visit to ${event.detail.visit.url}`);
+});
+
+// Remove the listener before it fires...
+removeStartEventListener();
+```
+
+== Svelte
+
+```js
+import { router } from "@inertiajs/svelte";
+
+let removeStartEventListener = router.once("start", (event) => {
+  console.log(`Starting a visit to ${event.detail.visit.url}`);
+});
+
+// Remove the listener before it fires...
+removeStartEventListener();
+```
+
+:::
+
 ## Cancelling Events
 
 Some events, such as `before`, `networkError`, and `httpException`, support cancellation, allowing you to prevent Inertia's default behavior. Just like native events, the event will be cancelled if only one event listener calls `event.preventDefault()`.

--- a/docs/guide/events.md
+++ b/docs/guide/events.md
@@ -220,7 +220,6 @@ document.removeEventListener('inertia:start', startEventListener)
 
 :::
 
-
 ## One-time Listeners
 
 @available_since core=3.2.0
@@ -232,31 +231,31 @@ You may register a listener that fires only once using the `router.once()` metho
 == Vue
 
 ```js
-import { router } from "@inertiajs/vue3";
+import { router } from '@inertiajs/vue3'
 
-router.once("start", (event) => {
-  console.log(`Starting a visit to ${event.detail.visit.url}`);
-});
+router.once('start', (event) => {
+  console.log(`Starting a visit to ${event.detail.visit.url}`)
+})
 ```
 
 == React
 
 ```jsx
-import { router } from "@inertiajs/react";
+import { router } from '@inertiajs/react'
 
-router.once("start", (event) => {
-  console.log(`Starting a visit to ${event.detail.visit.url}`);
-});
+router.once('start', (event) => {
+  console.log(`Starting a visit to ${event.detail.visit.url}`)
+})
 ```
 
 == Svelte
 
 ```js
-import { router } from "@inertiajs/svelte";
+import { router } from '@inertiajs/svelte'
 
-router.once("start", (event) => {
-  console.log(`Starting a visit to ${event.detail.visit.url}`);
-});
+router.once('start', (event) => {
+  console.log(`Starting a visit to ${event.detail.visit.url}`)
+})
 ```
 
 :::
@@ -268,40 +267,40 @@ Like `router.on()`, this method returns a callback you may invoke to remove the 
 == Vue
 
 ```js
-import { router } from "@inertiajs/vue3";
+import { router } from '@inertiajs/vue3'
 
-let removeStartEventListener = router.once("start", (event) => {
-  console.log(`Starting a visit to ${event.detail.visit.url}`);
-});
+let removeStartEventListener = router.once('start', (event) => {
+  console.log(`Starting a visit to ${event.detail.visit.url}`)
+})
 
 // Remove the listener before it fires...
-removeStartEventListener();
+removeStartEventListener()
 ```
 
 == React
 
 ```jsx
-import { router } from "@inertiajs/react";
+import { router } from '@inertiajs/react'
 
-let removeStartEventListener = router.once("start", (event) => {
-  console.log(`Starting a visit to ${event.detail.visit.url}`);
-});
+let removeStartEventListener = router.once('start', (event) => {
+  console.log(`Starting a visit to ${event.detail.visit.url}`)
+})
 
 // Remove the listener before it fires...
-removeStartEventListener();
+removeStartEventListener()
 ```
 
 == Svelte
 
 ```js
-import { router } from "@inertiajs/svelte";
+import { router } from '@inertiajs/svelte'
 
-let removeStartEventListener = router.once("start", (event) => {
-  console.log(`Starting a visit to ${event.detail.visit.url}`);
-});
+let removeStartEventListener = router.once('start', (event) => {
+  console.log(`Starting a visit to ${event.detail.visit.url}`)
+})
 
 // Remove the listener before it fires...
-removeStartEventListener();
+removeStartEventListener()
 ```
 
 :::

--- a/docs/guide/forms.md
+++ b/docs/guide/forms.md
@@ -2254,14 +2254,11 @@ const form = useForm('post', '/users', {
 ```jsx
 import { useForm } from '@inertiajs/react'
 
-const { data, setData, submit, errors, validating, validate, invalid } = useForm(
-  'post',
-  '/users',
-  {
+const { data, setData, submit, errors, validating, validate, invalid } =
+  useForm('post', '/users', {
     name: '',
     email: '',
-  },
-)
+  })
 
 function handleSubmit(e) {
   e.preventDefault()
@@ -2303,7 +2300,12 @@ return (
   })
 </script>
 
-<form onsubmit={(e) => { e.preventDefault(); form.submit() }}>
+<form
+  onsubmit={(e) => {
+    e.preventDefault()
+    form.submit()
+  }}
+>
   <input bind:value={form.name} onchange={() => form.validate('name')} />
   {#if form.invalid('name')}
     <p>{form.errors.name}</p>

--- a/docs/guide/forms.md
+++ b/docs/guide/forms.md
@@ -1626,6 +1626,8 @@ form.post('/profile', {
 
 :::
 
+You may pass the HTTP method and URL as the first two arguments to `useForm()`, then call `submit()` without arguments to dispatch the request. This also unlocks real-time validation. See [Precognition](#precognition-1) for details.
+
 If you need to modify the form data before it's sent to the server, you can do so via the `transform()` method.
 
 :::tabs key:frameworks
@@ -2233,7 +2235,7 @@ const form = useForm('post', '/users', {
 </script>
 
 <template>
-  <form @submit.prevent="form.post('/users')">
+  <form @submit.prevent="form.submit()">
     <input v-model="form.name" @change="form.validate('name')" />
     <p v-if="form.invalid('name')">{{ form.errors.name }}</p>
 
@@ -2252,7 +2254,7 @@ const form = useForm('post', '/users', {
 ```jsx
 import { useForm } from '@inertiajs/react'
 
-const { data, setData, post, errors, validating, validate, invalid } = useForm(
+const { data, setData, submit, errors, validating, validate, invalid } = useForm(
   'post',
   '/users',
   {
@@ -2261,13 +2263,13 @@ const { data, setData, post, errors, validating, validate, invalid } = useForm(
   },
 )
 
-function submit(e) {
+function handleSubmit(e) {
   e.preventDefault()
-  post('/users')
+  submit()
 }
 
 return (
-  <form onSubmit={submit}>
+  <form onSubmit={handleSubmit}>
     <input
       value={data.name}
       onChange={(e) => setData('name', e.target.value)}
@@ -2301,12 +2303,7 @@ return (
   })
 </script>
 
-<form
-  onsubmit={(e) => {
-    e.preventDefault()
-    form.post('/users')
-  }}
->
+<form onsubmit={(e) => { e.preventDefault(); form.submit() }}>
   <input bind:value={form.name} onchange={() => form.validate('name')} />
   {#if form.invalid('name')}
     <p>{form.errors.name}</p>
@@ -2478,7 +2475,7 @@ form.withAllErrors()
 
 :::
 
-With Precognition enabled, you may call `submit()` without arguments to submit to the configured endpoint.
+With Precognition enabled, you may call `submit()` without arguments to dispatch the request to the configured endpoint.
 
 ## Server-Side Responses
 

--- a/docs/guide/http-requests.md
+++ b/docs/guide/http-requests.md
@@ -144,7 +144,11 @@ http.submit(method, url, options)
 
 :::
 
-Each method returns a `Promise` that resolves with the parsed JSON response data. TypeScript users may [type the request data and response](/guide/typescript#http-helper) at the hook level or on a per-request basis.
+Each method returns a `Promise` that resolves with the parsed JSON response data. TypeScript users may [type the request data and response](/v3/advanced/typescript#http-helper).
+
+### Pre-binding the Endpoint
+
+You may pass the HTTP method and URL as the first two arguments to `useHttp()`, then call `submit()` without arguments to dispatch the request. This also unlocks real-time validation. See [Precognition](#precognition) for details.
 
 :::tabs key:frameworks
 
@@ -528,12 +532,14 @@ http.post('/api/users', {
   onProgress: (progress) => {
     /*...*/
   },
-  onSuccess: (response) => {
+  onSuccess: (data, response) => {
     /*...*/
   },
   onError: (errors) => {
     /*...*/
   },
+  onHttpException: (response) => { /*...*/ },
+  onNetworkError: (error) => { /*...*/ },
   onCancel: () => {
     /*...*/
   },
@@ -544,6 +550,50 @@ http.post('/api/users', {
 ```
 
 You may return `false` from `onBefore` to cancel the request.
+
+
+### Accessing the HTTP response
+
+@available_since core=3.0.3
+
+The `onSuccess` callback receives the parsed response data as its first argument and the HTTP response object as its second argument. The response object contains `status`, `data`, and `headers` properties, which is useful when you need to inspect the status code or response headers.
+
+```js
+http.post('/api/users', {
+    onSuccess: (data, response) => {
+        console.log(response.status) // 200, 201, etc.
+    },
+})
+```
+
+### HTTP exceptions
+
+@available_since core=3.0.3
+
+The `onHttpException` callback fires when the server returns a non-422 HTTP error, such as a `500` or `403`. The callback receives the HTTP response object, giving you access to the status code, response body, and headers.
+
+```js
+http.post('/api/users', {
+    onHttpException: (response) => {
+        console.log(response.status) // 500, 403, etc.
+        console.log(response.data)   // Response body
+    },
+})
+```
+
+### Network errors
+
+@available_since core=3.0.3
+
+The `onNetworkError` callback fires when the request fails due to a network issue, such as when the user loses their internet connection. The callback receives the `Error` object.
+
+```js
+http.post('/api/users', {
+    onNetworkError: (error) => {
+        console.log(error.message)
+    },
+})
+```
 
 ## Precognition
 

--- a/docs/guide/http-requests.md
+++ b/docs/guide/http-requests.md
@@ -144,7 +144,7 @@ http.submit(method, url, options)
 
 :::
 
-Each method returns a `Promise` that resolves with the parsed JSON response data. TypeScript users may [type the request data and response](/v3/advanced/typescript#http-helper).
+Each method returns a `Promise` that resolves with the parsed JSON response data. TypeScript users may [type the request data and response](/guide/typescript#http-helper).
 
 ### Pre-binding the Endpoint
 
@@ -538,8 +538,12 @@ http.post('/api/users', {
   onError: (errors) => {
     /*...*/
   },
-  onHttpException: (response) => { /*...*/ },
-  onNetworkError: (error) => { /*...*/ },
+  onHttpException: (response) => {
+    /*...*/
+  },
+  onNetworkError: (error) => {
+    /*...*/
+  },
   onCancel: () => {
     /*...*/
   },
@@ -551,7 +555,6 @@ http.post('/api/users', {
 
 You may return `false` from `onBefore` to cancel the request.
 
-
 ### Accessing the HTTP response
 
 @available_since core=3.0.3
@@ -560,9 +563,9 @@ The `onSuccess` callback receives the parsed response data as its first argument
 
 ```js
 http.post('/api/users', {
-    onSuccess: (data, response) => {
-        console.log(response.status) // 200, 201, etc.
-    },
+  onSuccess: (data, response) => {
+    console.log(response.status) // 200, 201, etc.
+  },
 })
 ```
 
@@ -574,10 +577,10 @@ The `onHttpException` callback fires when the server returns a non-422 HTTP erro
 
 ```js
 http.post('/api/users', {
-    onHttpException: (response) => {
-        console.log(response.status) // 500, 403, etc.
-        console.log(response.data)   // Response body
-    },
+  onHttpException: (response) => {
+    console.log(response.status) // 500, 403, etc.
+    console.log(response.data) // Response body
+  },
 })
 ```
 
@@ -589,9 +592,9 @@ The `onNetworkError` callback fires when the request fails due to a network issu
 
 ```js
 http.post('/api/users', {
-    onNetworkError: (error) => {
-        console.log(error.message)
-    },
+  onNetworkError: (error) => {
+    console.log(error.message)
+  },
 })
 ```
 

--- a/docs/guide/layouts.md
+++ b/docs/guide/layouts.md
@@ -167,7 +167,7 @@ const Welcome = ({ user }) => {
   )
 }
 
-Welcome.layout = Layout
+Welcome.layout = (page) => <Layout>{page}</Layout>
 
 export default Welcome
 ```
@@ -200,6 +200,18 @@ defineOptions({ layout: Layout })
 ```
 
 </Vue>
+
+<React>
+
+Arrow function components should be wrapped in an array. Without the array, Inertia cannot distinguish them from render functions at runtime:
+
+```jsx
+const ArrowLayout = ({ children }) => <main>{children}</main>
+
+Welcome.layout = [ArrowLayout]
+```
+
+</React>
 
 ### Nested Layouts
 
@@ -328,14 +340,14 @@ createInertiaApp({
 
 == React
 
-```js
+```jsx
 import Layout from './Layout'
 
 createInertiaApp({
   resolve: (name) => {
     const pages = import.meta.glob('../pages/**/*.jsx', { eager: true })
     let page = pages[`../pages/${name}.jsx`]
-    page.default.layout = page.default.layout || Layout
+    page.default.layout = page.default.layout || ((page) => <Layout>{page}</Layout>)
     return page
   },
   // ...

--- a/docs/guide/layouts.md
+++ b/docs/guide/layouts.md
@@ -347,7 +347,8 @@ createInertiaApp({
   resolve: (name) => {
     const pages = import.meta.glob('../pages/**/*.jsx', { eager: true })
     let page = pages[`../pages/${name}.jsx`]
-    page.default.layout = page.default.layout || ((page) => <Layout>{page}</Layout>)
+    page.default.layout =
+      page.default.layout || ((page) => <Layout>{page}</Layout>)
     return page
   },
   // ...

--- a/docs/guide/once-props.md
+++ b/docs/guide/once-props.md
@@ -138,7 +138,7 @@ Returning `nil` on signed-out requests overwrites the remembered user on every r
 ```ruby
 class InertiaController < ApplicationController
   inertia_share(
-    auth: Current.user ? -> { Current.user&.as_json(only: [:id, :name, :email]) } : nil
+    auth: Current.user ? InertiaRails.once { Current.user&.as_json(only: [:id, :name, :email]) } : nil
   )
 end
 ```

--- a/docs/guide/once-props.md
+++ b/docs/guide/once-props.md
@@ -129,6 +129,20 @@ class ApplicationController < ActionController::Base
 end
 ```
 
+## Conditional Once Props
+
+Some shared data is mostly stable but changes at specific moments, like the authenticated user. You may return a once prop while a user is authenticated, and `nil` otherwise. Sign in and sign out usually end with a redirect to a page that does not explicitly request the `auth` prop, so a remembered once value would go stale.
+
+Returning `nil` on signed-out requests overwrites the remembered user on every response, while returning a once prop when authenticated lets the client remember the user across visits.
+
+```ruby
+class InertiaController < ApplicationController
+  inertia_share(
+    auth: Current.user ? -> { Current.user&.as_json(only: [:id, :name, :email]) } : nil
+  )
+end
+```
+
 ## Prefetching
 
 Once props are compatible with [prefetching](/guide/prefetching). The client automatically includes any remembered once props in prefetched responses, so navigating to a prefetched page will already have the once props available.

--- a/docs/guide/polling.md
+++ b/docs/guide/polling.md
@@ -98,8 +98,8 @@ You may also pass a function that returns the request options. The function is e
 import { usePoll } from '@inertiajs/vue3'
 const props = defineProps({ counter: Number })
 usePoll(2000, () => ({
-    data: { counter_seen: props.counter },
-    only: ['last_received'],
+  data: { counter_seen: props.counter },
+  only: ['last_received'],
 }))
 </script>
 ```
@@ -110,10 +110,10 @@ usePoll(2000, () => ({
 import { usePoll } from '@inertiajs/react'
 
 export default ({ counter }) => {
-    usePoll(2000, () => ({
-        data: { counter_seen: counter },
-        only: ['last_received'],
-    }))
+  usePoll(2000, () => ({
+    data: { counter_seen: counter },
+    only: ['last_received'],
+  }))
 }
 ```
 
@@ -125,8 +125,8 @@ import { usePoll } from '@inertiajs/svelte'
 let { counter } = $props()
 
 usePoll(2000, () => ({
-    data: { counter_seen: counter },
-    only: ['last_received'],
+  data: { counter_seen: counter },
+  only: ['last_received'],
 }))
 ```
 
@@ -216,9 +216,13 @@ The default `overlap` mode allows requests to run in parallel. The `cancel` mode
 ```js
 import { usePoll } from '@inertiajs/vue3'
 
-usePoll(2000, {}, {
+usePoll(
+  2000,
+  {},
+  {
     mode: 'rest',
-})
+  },
+)
 ```
 
 == React
@@ -226,9 +230,13 @@ usePoll(2000, {}, {
 ```jsx
 import { usePoll } from '@inertiajs/react'
 
-usePoll(2000, {}, {
+usePoll(
+  2000,
+  {},
+  {
     mode: 'rest',
-})
+  },
+)
 ```
 
 == Svelte
@@ -236,9 +244,13 @@ usePoll(2000, {}, {
 ```js
 import { usePoll } from '@inertiajs/svelte'
 
-usePoll(2000, {}, {
+usePoll(
+  2000,
+  {},
+  {
     mode: 'rest',
-})
+  },
+)
 ```
 
 :::

--- a/docs/guide/polling.md
+++ b/docs/guide/polling.md
@@ -85,6 +85,53 @@ usePoll(2000, {
 
 :::
 
+You may also pass a function that returns the request options. The function is evaluated on every tick, allowing the poll to reflect the latest component state.
+
+@available_since core=3.2.0
+
+:::tabs key:frameworks
+
+== Vue
+
+```vue
+<script setup>
+import { usePoll } from '@inertiajs/vue3'
+const props = defineProps({ counter: Number })
+usePoll(2000, () => ({
+    data: { counter_seen: props.counter },
+    only: ['last_received'],
+}))
+</script>
+```
+
+== React
+
+```jsx
+import { usePoll } from '@inertiajs/react'
+
+export default ({ counter }) => {
+    usePoll(2000, () => ({
+        data: { counter_seen: counter },
+        only: ['last_received'],
+    }))
+}
+```
+
+== Svelte
+
+```js
+import { usePoll } from '@inertiajs/svelte'
+
+let { counter } = $props()
+
+usePoll(2000, () => ({
+    data: { counter_seen: counter },
+    only: ['last_received'],
+}))
+```
+
+:::
+
 If you'd like more control over the polling behavior, the poll helper provides `stop` and `start` methods that allow you to manually start and stop polling. You can pass the `autoStart: false` option to the poll helper to prevent it from automatically starting polling when the component is mounted.
 
 :::tabs key:frameworks
@@ -150,6 +197,48 @@ export default () => {
 
 <button onclick={start}>Start polling</button>
 <button onclick={stop}>Stop polling</button>
+```
+
+:::
+
+## Concurrency Mode
+
+@available_since core=3.2.0
+
+By default, the poll helper fires a new request on every tick, even when the previous request is still in flight. You may control this behavior with the `mode` option, which accepts one of three values: `overlap`, `cancel`, or `rest`.
+
+The default `overlap` mode allows requests to run in parallel. The `cancel` mode aborts any in-flight request when the next tick fires. The `rest` mode treats the interval as the time between the end of the previous request and the start of the next one, so requests never overlap.
+
+:::tabs key:frameworks
+
+== Vue
+
+```js
+import { usePoll } from '@inertiajs/vue3'
+
+usePoll(2000, {}, {
+    mode: 'rest',
+})
+```
+
+== React
+
+```jsx
+import { usePoll } from '@inertiajs/react'
+
+usePoll(2000, {}, {
+    mode: 'rest',
+})
+```
+
+== Svelte
+
+```js
+import { usePoll } from '@inertiajs/svelte'
+
+usePoll(2000, {}, {
+    mode: 'rest',
+})
 ```
 
 :::

--- a/docs/guide/progress-indicators.md
+++ b/docs/guide/progress-indicators.md
@@ -24,7 +24,9 @@ createInertiaApp({
 })
 ```
 
-You can disable Inertia's default loading indicator by setting the `progress` property to `false`.
+For applications using a [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) that restricts inline styles, you may pass a `nonce` to `createInertiaApp()` to permit the styles Inertia injects for the progress bar. See [Content Security Policy](/guide/client-side-setup#content-security-policy) for details.
+
+You may disable Inertia's default loading indicator by setting the `progress` property to `false`.
 
 ```js
 createInertiaApp({

--- a/docs/guide/server-side-rendering.md
+++ b/docs/guide/server-side-rendering.md
@@ -49,7 +49,7 @@ inertia({
 })
 ```
 
-You may pass `false` to opt out of the plugin's automatic SSR handling, for example if you prefer to [configure SSR manually](#manual-setup) but still want to use the other features of the Vite plugin.
+You may pass `false` to opt out of the plugin's automatic SSR handling, for example if you prefer to [configure SSR manually](#manual-setup) or [disable SSR entirely](#disabling-ssr).
 
 ```js
 // vite.config.js
@@ -167,6 +167,21 @@ createServer((page) =>
 :::
 
 Be sure to add anything that's missing from your `inertia.js` file that makes sense to run in SSR mode, such as plugins or custom mixins.
+
+### Host
+
+@available_since core=3.1.0
+
+By default, the SSR server binds to `0.0.0.0`, making it accessible on all network interfaces. You may restrict it to a specific interface using the `host` option.
+
+```js
+// vite.config.js
+inertia({
+    ssr: {
+        host: '127.0.0.1',
+    },
+})
+```
 
 ## Manual Setup
 
@@ -336,6 +351,50 @@ createServer(
       // ...
     }),
   { cluster: true },
+)
+```
+
+:::
+
+
+### Host
+
+@available_since core=3.1.0
+
+By default, the SSR server binds to `0.0.0.0`, making it accessible on all network interfaces. You may pass the `host` option to `createServer` to restrict it to a specific interface.
+
+:::tabs key:frameworks
+
+== Vue
+
+```js
+createServer(page =>
+    createInertiaApp({
+        // ...
+    }),
+    { host: '127.0.0.1' },
+)
+```
+
+== React
+
+```jsx
+createServer(page =>
+    createInertiaApp({
+        // ...
+    }),
+    { host: '127.0.0.1' },
+)
+```
+
+== Svelte
+
+```js
+createServer(page =>
+    createInertiaApp({
+        // ...
+    }),
+    { host: '127.0.0.1' },
 )
 ```
 
@@ -556,7 +615,25 @@ SSR caching uses the same [`cache_store`](/guide/configuration#cache_store) as [
 
 ## Disabling SSR
 
-Sometimes you may wish to disable server-side rendering for certain controllers or pages in your application. You may do so by setting the `ssr_enabled` option to `false` using `inertia_config`.
+SSR has two layers: the **Vite plugin** serves SSR during development and builds the SSR bundle for production, while the **Rails adapter** dispatches rendering requests to the SSR server. To fully disable SSR, you should disable both.
+
+```js
+// vite.config.js
+inertia({
+    ssr: false,
+})
+```
+
+```ruby
+# config/initializers/inertia.rb
+InertiaRails.configure do |config|
+  config.ssr_enabled = false
+end
+```
+
+## Excluding Controllers from SSR
+
+Sometimes you may wish to skip server-side rendering for certain controllers while keeping SSR enabled for the rest of your application.
 
 ```ruby
 class AdminController < ApplicationController

--- a/docs/guide/server-side-rendering.md
+++ b/docs/guide/server-side-rendering.md
@@ -177,9 +177,9 @@ By default, the SSR server binds to `0.0.0.0`, making it accessible on all netwo
 ```js
 // vite.config.js
 inertia({
-    ssr: {
-        host: '127.0.0.1',
-    },
+  ssr: {
+    host: '127.0.0.1',
+  },
 })
 ```
 
@@ -356,7 +356,6 @@ createServer(
 
 :::
 
-
 ### Host
 
 @available_since core=3.1.0
@@ -368,33 +367,36 @@ By default, the SSR server binds to `0.0.0.0`, making it accessible on all netwo
 == Vue
 
 ```js
-createServer(page =>
+createServer(
+  (page) =>
     createInertiaApp({
-        // ...
+      // ...
     }),
-    { host: '127.0.0.1' },
+  { host: '127.0.0.1' },
 )
 ```
 
 == React
 
 ```jsx
-createServer(page =>
+createServer(
+  (page) =>
     createInertiaApp({
-        // ...
+      // ...
     }),
-    { host: '127.0.0.1' },
+  { host: '127.0.0.1' },
 )
 ```
 
 == Svelte
 
 ```js
-createServer(page =>
+createServer(
+  (page) =>
     createInertiaApp({
-        // ...
+      // ...
     }),
-    { host: '127.0.0.1' },
+  { host: '127.0.0.1' },
 )
 ```
 
@@ -620,7 +622,7 @@ SSR has two layers: the **Vite plugin** serves SSR during development and builds
 ```js
 // vite.config.js
 inertia({
-    ssr: false,
+  ssr: false,
 })
 ```
 

--- a/docs/guide/the-protocol.md
+++ b/docs/guide/the-protocol.md
@@ -144,6 +144,7 @@ Inertia shares data between the server and client via a page object. This object
 - `matchPropsOn`: Array of prop keys to use for [matching when merging props](/guide/merging-props#matching-items).
 - `scrollProps`: Configuration for [infinite scroll](/guide/infinite-scroll) prop merging behavior.
 - `deferredProps`: Configuration for client-side [lazy loading of props](/guide/deferred-props).
+- `rescuedProps`: Array of [deferred prop](/guide/deferred-props#error-handling) keys that failed to resolve and were rescued server-side. Used by the client to render the `rescue` slot on the `<Deferred>` component.
 - `sharedProps`: Array of top-level prop keys registered via `Inertia::share()`. Used by the client to carry shared props over during [instant visits](/guide/instant-visits).
 - `onceProps`: Configuration for [once props](/guide/once-props) that should only be resolved once and reused on subsequent pages. Each entry maps a key to an object containing the `prop` name and optional `expiresAt` timestamp (in milliseconds).
 
@@ -186,6 +187,22 @@ When using deferred props, the page object includes a `deferredProps` configurat
     "default": ["comments", "analytics"],
     "sidebar": ["relatedPosts"]
   }
+}
+```
+
+### Page Object with Rescued Deferred Props
+
+When a [deferred prop](/guide/deferred-props#error-handling) is resolved with `rescue: true` and throws an exception, the prop is omitted from `props` and its key is included in `rescuedProps`. The client uses this list to render the `rescue` slot on the `<Deferred>` component.
+
+```json
+{
+  "component": "Users/Index",
+  "props": {
+    "errors": {}
+  },
+  "url": "/users",
+  "version": "6b16b94d7c51cbe5b1fa42aac98241d5",
+  "rescuedProps": ["permissions"]
 }
 ```
 

--- a/docs/guide/upgrade-guide.md
+++ b/docs/guide/upgrade-guide.md
@@ -261,6 +261,22 @@ InertiaRails.configure do |config|
 end
 ```
 
+### React Arrow Function Layout Components
+
+The new layout implementation in v3 no longer supports arrow function components assigned directly to `.layout`. Inertia cannot reliably distinguish them from render functions at runtime. Wrapping the component in an array resolves this:
+
+```jsx
+const Layout = ({ children }) => <main>{children}</main>
+
+// ❌ does not work — arrow function component assigned directly
+Dashboard.layout = Layout
+
+// ✅ wrap in an array instead
+Dashboard.layout = [Layout]
+```
+
+Function declaration components continue to work without any changes.
+
 ## Other Changes
 
 ---

--- a/lib/inertia_rails/defer_prop.rb
+++ b/lib/inertia_rails/defer_prop.rb
@@ -14,10 +14,15 @@ module InertiaRails
       super(&block)
 
       @group = props[:group] || DEFAULT_GROUP
+      @rescue = props.fetch(:rescue, false)
     end
 
     def deferred?
       true
+    end
+
+    def rescue?
+      @rescue
     end
   end
 end

--- a/lib/inertia_rails/props_resolver.rb
+++ b/lib/inertia_rails/props_resolver.rb
@@ -24,6 +24,7 @@ module InertiaRails
       @_match_on = []
       @_once = {}
       @_scroll = {}
+      @_rescued = []
 
       props = expand_dot_notation(@props)
       resolved = deep_transform_props(props)
@@ -71,6 +72,7 @@ module InertiaRails
       metadata[:deepMergeProps] = @_deep_merge unless @_deep_merge.empty?
       metadata[:matchPropsOn] = @_match_on unless @_match_on.empty?
       metadata[:onceProps] = @_once unless @_once.empty?
+      metadata[:rescuedProps] = @_rescued unless @_rescued.empty?
 
       metadata
     end
@@ -99,29 +101,39 @@ module InertiaRails
         collect_metadata(prop, path)
         next unless keep_prop?(prop, path, parent_was_resolved: parent_was_resolved)
 
-        value = @evaluator.call(prop)
+        rescue_enabled = prop.try(:rescue?)
 
-        # A closure may return a prop type — unwrap one level
-        if value.is_a?(BaseProp) && !prop.is_a?(BaseProp)
-          collect_metadata(value, path)
-          next unless keep_prop?(value, path, parent_was_resolved: parent_was_resolved)
+        begin
+          value = @evaluator.call(prop)
 
-          value = @evaluator.call(value)
-        end
+          # A closure may return a prop type — unwrap one level
+          if value.is_a?(BaseProp) && !prop.is_a?(BaseProp)
+            collect_metadata(value, path)
+            next unless keep_prop?(value, path, parent_was_resolved: parent_was_resolved)
 
-        # A closure may return a Hash or Array containing prop types — recurse into it
-        if prop.is_a?(Proc)
-          if value.is_a?(Hash) && value.any?
-            nested = deep_transform_props(value, path, parent_was_resolved: true)
-            transformed_props[key] = nested unless nested.empty?
-            next
-          elsif value.is_a?(Array)
-            transformed_props[key] = transform_array(value, path, parent_was_resolved: true)
-            next
+            value = @evaluator.call(value)
           end
-        end
 
-        transformed_props[key] = value
+          # A closure may return a Hash or Array containing prop types — recurse into it
+          if prop.is_a?(Proc)
+            if value.is_a?(Hash) && value.any?
+              nested = deep_transform_props(value, path, parent_was_resolved: true)
+              transformed_props[key] = nested unless nested.empty?
+              next
+            elsif value.is_a?(Array)
+              transformed_props[key] = transform_array(value, path, parent_was_resolved: true)
+              next
+            end
+          end
+
+          transformed_props[key] = rescue_enabled ? value.as_json : value
+        rescue StandardError => e
+          raise unless rescue_enabled
+
+          report_rescued_error(e)
+          @_rescued << path
+          next
+        end
       end
     end
 
@@ -144,6 +156,16 @@ module InertiaRails
       when Hash then value.any? { |_, v| needs_transform?(v) }
       when Array then value.any? { |v| needs_transform?(v) }
       else value.respond_to?(:to_inertia)
+      end
+    end
+
+    def report_rescued_error(error)
+      # `Rails.error` (the Error Reporter) was introduced in Rails 7.0. Fall back
+      # to the logger on older versions so rescued errors are never silently lost.
+      if Rails.respond_to?(:error)
+        Rails.error.report(error, handled: true)
+      else
+        Rails.logger&.error("[inertia-rails] Rescued deferred prop error: #{error.class}: #{error.message}")
       end
     end
 

--- a/spec/dummy/app/controllers/inertia_render_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_render_test_controller.rb
@@ -136,6 +136,13 @@ class InertiaRenderTestController < ApplicationController
     }
   end
 
+  def rescued_deferred_props
+    render inertia: 'TestComponent', props: {
+      name: 'Brian',
+      permissions: InertiaRails.defer(rescue: true) { raise 'boom' },
+    }
+  end
+
   inertia_share only: [:shared_deferred_props] do
     {
       grit: InertiaRails.defer { 'intense' },

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
   get 'except_props' => 'inertia_render_test#except_props'
   get 'merge_props' => 'inertia_render_test#merge_props'
   get 'deferred_props' => 'inertia_render_test#deferred_props'
+  get 'rescued_deferred_props' => 'inertia_render_test#rescued_deferred_props'
   get 'shared_deferred_props' => 'inertia_render_test#shared_deferred_props'
   get 'scroll_test' => 'inertia_render_test#scroll_test'
   get 'shared_scroll_test' => 'inertia_render_test#shared_scroll_test'

--- a/spec/inertia/defer_prop_spec.rb
+++ b/spec/inertia/defer_prop_spec.rb
@@ -58,4 +58,18 @@ RSpec.describe InertiaRails::DeferProp do
       it { is_expected.to eq('custom') }
     end
   end
+
+  describe '#rescue?' do
+    subject(:rescue?) { prop.rescue? }
+
+    let(:prop) { described_class.new { 'block' } }
+
+    it { is_expected.to be false }
+
+    context 'when rescue is set' do
+      let(:prop) { described_class.new(rescue: true) { 'block' } }
+
+      it { is_expected.to be true }
+    end
+  end
 end

--- a/spec/inertia/props_resolver_spec.rb
+++ b/spec/inertia/props_resolver_spec.rb
@@ -566,6 +566,87 @@ RSpec.describe InertiaRails::PropsResolver do
     end
   end
 
+  describe 'DeferProp with rescue' do
+    it 'omits a rescued prop and records it in rescuedProps on partial request' do
+      page = resolve_partial(
+        {
+          name: 'Jonathan',
+          permissions: InertiaRails.defer(rescue: true) { raise 'boom' },
+        },
+        'name', 'permissions'
+      )
+
+      expect(page[:props][:name]).to eq('Jonathan')
+      expect(page[:props]).not_to have_key(:permissions)
+      expect(page[:rescuedProps]).to eq(['permissions'])
+    end
+
+    it 'records nested rescued props using their dot-path' do
+      page = resolve_partial(
+        {
+          auth: {
+            user: 'Jonathan',
+            notifications: InertiaRails.defer(rescue: true) { raise 'boom' },
+          },
+        },
+        'auth.user', 'auth.notifications'
+      )
+
+      expect(page[:props][:auth][:user]).to eq('Jonathan')
+      expect(page[:props][:auth]).not_to have_key(:notifications)
+      expect(page[:rescuedProps]).to eq(['auth.notifications'])
+    end
+
+    it 'resolves a rescued prop normally when no error is raised' do
+      page = resolve_partial(
+        { permissions: InertiaRails.defer(rescue: true) { %w[read write] } },
+        'permissions'
+      )
+
+      expect(page[:props][:permissions]).to eq(%w[read write])
+      expect(page).not_to have_key(:rescuedProps)
+    end
+
+    it 'rescues errors raised while serializing the prop value' do
+      # Mimics a value (e.g. an ActiveRecord::Relation) that only fails when its
+      # query runs / it is serialized, i.e. during as_json rather than in the block.
+      unserializable = Class.new do
+        def as_json(*)
+          raise 'boom while serializing'
+        end
+      end.new
+
+      page = resolve_partial(
+        { permissions: InertiaRails.defer(rescue: true) { unserializable } },
+        'permissions'
+      )
+
+      expect(page[:props]).not_to have_key(:permissions)
+      expect(page[:rescuedProps]).to eq(['permissions'])
+    end
+
+    it 'reports the rescued error via the Rails error reporter' do
+      skip('Requires Rails 7.0 or higher') if Rails.version < '7'
+
+      error = RuntimeError.new('boom')
+      expect(Rails.error).to receive(:report).with(error, handled: true)
+
+      resolve_partial(
+        { permissions: InertiaRails.defer(rescue: true) { raise error } },
+        'permissions'
+      )
+    end
+
+    it 'does not rescue errors for deferred props without the rescue option' do
+      expect do
+        resolve_partial(
+          { permissions: InertiaRails.defer { raise 'boom' } },
+          'permissions'
+        )
+      end.to raise_error('boom')
+    end
+  end
+
   describe 'OnceProp' do
     it 'resolves once prop on initial load' do
       page = resolve({ locale: InertiaRails.once { 'en' } })

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -857,6 +857,26 @@ RSpec.describe 'rendering inertia views', type: :request do
         )
       end
     end
+
+    context 'with a rescued deferred prop' do
+      let(:headers) do
+        {
+          'X-Inertia' => true,
+          'X-Inertia-Partial-Data' => 'permissions',
+          'X-Inertia-Partial-Component' => 'TestComponent',
+        }
+      end
+
+      before { get rescued_deferred_props_path, headers: headers }
+
+      it 'omits the rescued prop from props' do
+        expect(response.parsed_body['props']).not_to have_key('permissions')
+      end
+
+      it 'returns the rescued key in rescuedProps' do
+        expect(response.parsed_body['rescuedProps']).to eq(['permissions'])
+      end
+    end
   end
 
   context 'cached prop rendering' do


### PR DESCRIPTION
## Summary

See inertiajs/inertia-laravel#864.

`InertiaRails.defer(rescue: true) { ... }` catches and reports exceptions raised while resolving a deferred prop instead of failing the whole response. The prop is omitted and its path is returned in a new `rescuedProps` page key so the client can render a fallback (the `rescue` slot/prop on `<Deferred>`).

```ruby
render inertia: {
  permissions: InertiaRails.defer(rescue: true) { current_user.permissions },
}
```

Rails specifics:
- The value is serialized via `as_json` inside the rescued scope, so errors from lazy `ActiveRecord::Relations` / serialization are caught too, not just exceptions raised directly in the block.
- Errors are reported via `Rails.error`, falling back to `Rails.logger` on Rails < 7.

Also syncs assorted guide docs from upstream.

## Checklist

- [x] Tests added or updated
- [x] `CHANGELOG.md` updated (for user-facing changes)
