### PR TITLE
Add @inertiajs/core as a direct dependency for TypeScript installs

### DIFF
--- a/lib/generators/inertia/install/install_generator.rb
+++ b/lib/generators/inertia/install/install_generator.rb
@@ -142,13 +142,8 @@ module Inertia
       def install_typescript
         say 'Adding TypeScript support'
 
-        # @inertiajs/core is only a transitive dependency of the framework
-        # adapters, so it isn't exposed at the top level under pnpm's strict
-        # node_modules layout. The generated `types/globals.d.ts` augments the
-        # `@inertiajs/core` module (to type flash/shared props and errors), and
-        # the React/Svelte scaffolds import types from it directly. Declaring it
-        # as an explicit dependency keeps it resolvable across package managers.
-        # Pin it to the same version as the adapter so the types stay in sync.
+        # globals.d.ts augments @inertiajs/core and scaffolds import its types;
+        # pnpm won't expose the adapters' transitive dep, so declare it directly.
         add_dependencies(
           "@inertiajs/core@#{options[:inertia_version]}",
           *FRAMEWORKS[framework]['packages_ts'],

--- a/lib/generators/inertia/install/install_generator.rb
+++ b/lib/generators/inertia/install/install_generator.rb
@@ -142,7 +142,18 @@ module Inertia
       def install_typescript
         say 'Adding TypeScript support'
 
-        add_dependencies(*FRAMEWORKS[framework]['packages_ts'], dev: true)
+        # @inertiajs/core is only a transitive dependency of the framework
+        # adapters, so it isn't exposed at the top level under pnpm's strict
+        # node_modules layout. The generated `types/globals.d.ts` augments the
+        # `@inertiajs/core` module (to type flash/shared props and errors), and
+        # the React/Svelte scaffolds import types from it directly. Declaring it
+        # as an explicit dependency keeps it resolvable across package managers.
+        # Pin it to the same version as the adapter so the types stay in sync.
+        add_dependencies(
+          "@inertiajs/core@#{options[:inertia_version]}",
+          *FRAMEWORKS[framework]['packages_ts'],
+          dev: true
+        )
 
         say 'Copying tsconfig and types'
 


### PR DESCRIPTION
Fixes #380.

On a fresh React + TypeScript app installed with pnpm, `pnpm check` fails with 6 TypeScript errors; the same app passes with npm.

## Root cause

The generator ships `types/globals.d.ts`, which augments `@inertiajs/core` to type shared props, flash data, and form errors:

```ts
declare module '@inertiajs/core' {
  export interface InertiaConfig {
    sharedPageProps: SharedProps
    flashDataType: FlashData
    errorValueType: string[]
  }
}
```

Module augmentation only applies if TypeScript can resolve `@inertiajs/core` from the augmenting file. The package was never declared in package.json — it's only a transitive dependency of `@inertiajs/react`. npm hoists it to the top of node_modules, so resolution works by accident. pnpm's strict layout keeps it inside `.pnpm`, so resolution fails, the augmentation is silently ignored, and flash/error types revert to their defaults. All 6 errors trace back to that single miss: the failing `import { type FormComponentProps } from '@inertiajs/core'`, `errors.name.join` (errors typed `string` instead of `string[]`), and `flash.notice` not being a valid `ReactNode`.

The scaffold templates are untouched — `.join` is correct once `errorValueType: string[]` applies, and removing it would break npm setups.

## Fix

Declare `@inertiajs/core` as a devDependency when TypeScript is enabled, pinned to the same `--inertia-version` as the adapter (default `latest`). The adapter pins core exactly (`@inertiajs/react@3.5.0` depends on `@inertiajs/core@3.5.0`), so both resolve to one deduped copy. An explicit `--inertia-version=3.4.0` lands as an exact pin for both, with zero room to drift. With the default `latest`, both land as caret ranges; in theory a stale adapter lockfile plus a newer core minor could yield two copies, but core and the adapters ship in lockstep, so the ranges resolve identically in practice.

## Testing

- Reproduced #380 on a fresh React/TS app with pnpm on Rails 8.1: same 6 errors, no `@inertiajs/core` at the top of node_modules.
- After the fix: `pnpm check` passes, core appears at the top of node_modules at the adapter's version, and `npm run check` still passes.
- With `--inertia-version=3.4.0`: core lands as an exact `3.4.0` matching the adapter, one copy installed, check passes.
- Full RSpec suite green (790 examples, 0 failures).