### PR TITLE
Add static props support to the inertia routes helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add `@inertiajs/core` as a direct dev dependency in the TypeScript install generator, so pnpm exposes the adapter types that `globals.d.ts` augments (@heyrobertchang)
 * Fix option handling in the `inertia` routes helper: user-supplied `defaults:` no longer replace the component (previously producing `component: null` responses), the route-to-component pair no longer leaks into `params`, and additional String-keyed pairs define routes instead of being silently dropped (@skryukov)
 * Raise a clear error when `parent_controller` does not inherit from `ActionController::Base` instead of an opaque `NoMethodError` (@skryukov)
+* Add static `props:` support to the `inertia` routes helper: `inertia 'about' => 'About', props: { title: 'About us' }` (@skryukov)
 * Deduplicate `X-Inertia` in the `Vary` response header (@skryukov)
 
 ## [3.21.2] - 2026-06-09

--- a/app/controllers/inertia_rails/static_controller.rb
+++ b/app/controllers/inertia_rails/static_controller.rb
@@ -12,7 +12,7 @@ module InertiaRails
       end
 
       respond_to do |format|
-        format.html { render inertia: params[:component] }
+        format.html { render inertia: params[:component], props: request.path_parameters[:props]&.deep_dup || {} }
       end
     end
   end

--- a/docs/guide/routing.md
+++ b/docs/guide/routing.md
@@ -33,6 +33,14 @@ Rails.application.routes.draw do
 end
 ```
 
+You can also pass static props to the component:
+
+@available_since rails=master
+
+```ruby
+inertia 'about' => 'About', props: { title: 'About us' }
+```
+
 ## Generating URLs
 
 Some server-side frameworks allow you to generate URLs from named routes. However, you will not have access to those helpers client-side. Here are a couple ways to still use named routes with Inertia.

--- a/lib/inertia_rails/extensions/mapper.rb
+++ b/lib/inertia_rails/extensions/mapper.rb
@@ -4,6 +4,7 @@ module InertiaRails
   module InertiaMapper
     def inertia(*args, **options)
       defaults = options.delete(:defaults) || {}
+      defaults = defaults.merge(props: options.delete(:props)) if options.key?(:props)
 
       extract_routes(args, options).each do |route, component|
         get(route, to: StaticController.action(:static), defaults: defaults.merge(component: component), **options)

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -108,6 +108,7 @@ Rails.application.routes.draw do
   inertia 'inertia_route' => 'TestComponent'
   inertia 'inertia_route_with_defaults' => 'TestComponent', defaults: { category: 'static' }
   inertia 'inertia_multi_route_a' => 'MultiA', 'inertia_multi_route_b' => 'MultiB'
+  inertia 'inertia_route_with_props' => 'TestComponent', props: { title: 'Static Page' }
   inertia :inertia_route_with_default_component
   scope :scoped, as: 'scoped' do
     inertia 'inertia_route' => 'TestComponent'

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -98,6 +98,14 @@ RSpec.describe 'rendering inertia views', type: :request do
       end
     end
 
+    context 'via an inertia route with props' do
+      it 'renders the static props' do
+        get inertia_route_with_props_path, headers: { 'X-Inertia' => true }
+
+        expect(response.parsed_body['props']).to include('title' => 'Static Page')
+      end
+    end
+
     context 'via a multi-pair inertia route' do
       context 'with the first pair' do
         let(:page) { InertiaRails::Renderer.new('MultiA', controller, request, response, '').send(:page) }


### PR DESCRIPTION
## Summary

Adds Laravel `Route::inertia` parity to the `inertia` routes helper:

```ruby
inertia 'about' => 'About', props: { title: 'About us' }
```

The hash is stored in the route defaults and handed to the Inertia render by `StaticController`, so static pages can carry static props without a dedicated controller.

## Design notes

- The props hash lives in the route defaults and is therefore shared across requests. `StaticController` passes a `deep_dup` to the render: `expand_dot_notation` in the props resolver can write into nested input hashes (a plain `user: {...}` pair is stored by reference and a later dotted `'user.name'` key mutates it), and a shared hash would persist that mutation across requests.
- Docs updated (`guide/routing.md`) with an `@available_since rails=master` marker.

Stacked on #388 (the option-handling fix); the base branch is set accordingly and this PR should be rebased or retargeted once #388 merges.

## Test plan

- `bundle exec rspec spec/inertia` — 791 examples green.
- New spec asserts the props arrive in the Inertia page JSON.

## Checklist

- [x] Tests added or updated
- [x] `CHANGELOG.md` updated (for user-facing changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)