### PR TITLE
Improve docs site crawler & agent discoverability

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -22,6 +22,10 @@ export default withMermaid({
 
   cleanUrls: true,
 
+  sitemap: {
+    hostname: site,
+  },
+
   vite: {
     plugins: [
       llmstxt({

--- a/docs/public/_headers
+++ b/docs/public/_headers
@@ -1,0 +1,2 @@
+/
+  Link: </llms.txt>; rel="alternate"; type="text/plain"; title="LLM-friendly documentation index", </llms-full.txt>; rel="alternate"; type="text/plain"; title="Full documentation in one file", </guide>; rel="help"

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,25 @@
+# inertia-rails.dev — Inertia Rails documentation.
+# All content is open source (MIT); crawling and AI use are welcome.
+# LLM-friendly index: https://inertia-rails.dev/llms.txt
+
+User-agent: *
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
+Allow: /
+
+# AI crawlers are explicitly welcome
+User-agent: GPTBot
+User-agent: OAI-SearchBot
+User-agent: ChatGPT-User
+User-agent: ClaudeBot
+User-agent: Claude-Web
+User-agent: Claude-User
+User-agent: Claude-SearchBot
+User-agent: Google-Extended
+User-agent: PerplexityBot
+User-agent: Perplexity-User
+User-agent: Applebot-Extended
+User-agent: CCBot
+User-agent: meta-externalagent
+Allow: /
+
+Sitemap: https://inertia-rails.dev/sitemap.xml


### PR DESCRIPTION
Fixes flagged by an [agent-readiness audit](https://isitagentready.com) of inertia-rails.dev:

- **robots.txt** — the site had no robots.txt of its own, so Cloudflare served its comments-only Content Signals boilerplate: invalid per [RFC 9309](https://www.rfc-editor.org/rfc/rfc9309) (no `User-agent` directive). The new `docs/public/robots.txt` allows all crawlers, explicitly welcomes AI crawlers (GPTBot, OAI-SearchBot, ClaudeBot, Google-Extended, PerplexityBot, CCBot, etc.), declares [Content Signals](https://contentsignals.org/) (`search=yes, ai-input=yes, ai-train=yes` — the docs are MIT-licensed and we already publish llms.txt), and references the sitemap.
- **sitemap.xml** — was 404. Enabled VitePress's built-in sitemap generation (59 URLs, regenerated on every build).
- **Link headers** — added a `docs/public/_headers` file (honored by Cloudflare Pages) so the homepage response advertises `/llms.txt`, `/llms-full.txt`, and `/guide` via [RFC 8288](https://www.rfc-editor.org/rfc/rfc8288) Link headers for agent discovery.

Verified locally: `npm run docs:build` emits `robots.txt`, `_headers`, and `sitemap.xml` into dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)