### PR TITLE
Fix stale flash notice and use idiomatic class in Vue scaffolds

### DIFF
--- a/lib/generators/inertia_templates/scaffold/templates/vue/index.ts.vue.tt
+++ b/lib/generators/inertia_templates/scaffold/templates/vue/index.ts.vue.tt
@@ -1,7 +1,7 @@
 <template>
   <Head title="<%= human_name.pluralize %>" />
 
-  <p v-if="flash.notice" class="notice">{{ flash.notice }}</p>
+  <p v-if="page.flash.notice" class="notice">{{ page.flash.notice }}</p>
 
   <h1><%= human_name.pluralize %></h1>
 
@@ -25,7 +25,7 @@ import { <%= inertia_model_type %> } from './types'
 defineProps<{
   <%= plural_table_name %>: <%= inertia_model_type %>[]
 }>()
-const { flash } = usePage()
+const page = usePage()
 </script>
 
 <style scoped>

--- a/lib/generators/inertia_templates/scaffold/templates/vue/index.vue.tt
+++ b/lib/generators/inertia_templates/scaffold/templates/vue/index.vue.tt
@@ -1,7 +1,7 @@
 <template>
   <Head title="<%= human_name.pluralize %>" />
 
-  <p v-if="flash.notice" class="notice">{{ flash.notice }}</p>
+  <p v-if="page.flash.notice" class="notice">{{ page.flash.notice }}</p>
 
   <h1><%= human_name.pluralize %></h1>
 
@@ -22,7 +22,7 @@ import { Head, Link, usePage } from '@inertiajs/vue3'
 import <%= inertia_component_name %> from './<%= singular_name %>.vue'
 
 defineProps(['<%= plural_table_name %>'])
-const { flash } = usePage()
+const page = usePage()
 </script>
 
 <style scoped>

--- a/lib/generators/inertia_templates/scaffold/templates/vue/show.ts.vue.tt
+++ b/lib/generators/inertia_templates/scaffold/templates/vue/show.ts.vue.tt
@@ -1,7 +1,7 @@
 <template>
   <Head :title="`<%= human_name %> #${<%= singular_table_name %>.id}`" />
 
-  <p v-if="flash.notice" class="notice">{{ flash.notice }}</p>
+  <p v-if="page.flash.notice" class="notice">{{ page.flash.notice }}</p>
 
   <h1><%= human_name %> #{{ <%= singular_table_name %>.id }}</h1>
 
@@ -31,7 +31,7 @@ import { <%= inertia_model_type %> } from './types'
 defineProps<{
   <%= singular_table_name %>: <%= inertia_model_type %>
 }>()
-const { flash } = usePage()
+const page = usePage()
 </script>
 
 <style scoped>

--- a/lib/generators/inertia_templates/scaffold/templates/vue/show.vue.tt
+++ b/lib/generators/inertia_templates/scaffold/templates/vue/show.vue.tt
@@ -1,7 +1,7 @@
 <template>
   <Head :title="`<%= human_name %> #${<%= singular_table_name %>.id}`" />
 
-  <p v-if="flash.notice" class="notice">{{ flash.notice }}</p>
+  <p v-if="page.flash.notice" class="notice">{{ page.flash.notice }}</p>
 
   <h1><%= human_name %> #{{ <%= singular_table_name %>.id }}</h1>
 
@@ -28,7 +28,7 @@ import { Head, Link, usePage } from '@inertiajs/vue3'
 import <%= inertia_component_name %> from './<%= singular_name %>.vue'
 
 defineProps(['<%= singular_table_name %>'])
-const { flash } = usePage()
+const page = usePage()
 </script>
 
 <style scoped>

--- a/lib/generators/inertia_tw_templates/scaffold/templates/vue/edit.ts.vue.tt
+++ b/lib/generators/inertia_tw_templates/scaffold/templates/vue/edit.ts.vue.tt
@@ -1,7 +1,7 @@
 <template>
   <Head title="Editing <%= human_name.downcase %>" />
 
-  <div className="mx-auto md:w-2/3 w-full px-8 pt-8">
+  <div class="mx-auto md:w-2/3 w-full px-8 pt-8">
     <h1 class="font-bold text-4xl">Editing <%= human_name.downcase %></h1>
 
     <Form

--- a/lib/generators/inertia_tw_templates/scaffold/templates/vue/edit.vue.tt
+++ b/lib/generators/inertia_tw_templates/scaffold/templates/vue/edit.vue.tt
@@ -1,7 +1,7 @@
 <template>
   <Head title="Editing <%= human_name.downcase %>" />
 
-  <div className="mx-auto md:w-2/3 w-full px-8 pt-8">
+  <div class="mx-auto md:w-2/3 w-full px-8 pt-8">
     <h1 class="font-bold text-4xl">Editing <%= human_name.downcase %></h1>
 
     <Form

--- a/lib/generators/inertia_tw_templates/scaffold/templates/vue/index.ts.vue.tt
+++ b/lib/generators/inertia_tw_templates/scaffold/templates/vue/index.ts.vue.tt
@@ -1,7 +1,7 @@
 <template>
   <Head title="<%= human_name.pluralize %>" />
 
-  <div className="mx-auto md:w-2/3 w-full px-8 pt-8">
+  <div class="mx-auto md:w-2/3 w-full px-8 pt-8">
     <p
       v-if="page.flash.notice"
       class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block"

--- a/lib/generators/inertia_tw_templates/scaffold/templates/vue/index.ts.vue.tt
+++ b/lib/generators/inertia_tw_templates/scaffold/templates/vue/index.ts.vue.tt
@@ -3,10 +3,10 @@
 
   <div className="mx-auto md:w-2/3 w-full px-8 pt-8">
     <p
-      v-if="flash.notice"
+      v-if="page.flash.notice"
       class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block"
     >
-      {{ flash.notice }}
+      {{ page.flash.notice }}
     </p>
 
     <div class="flex justify-between items-center">
@@ -43,5 +43,5 @@ import { <%= inertia_model_type %> } from './types'
 defineProps<{
   <%= plural_table_name %>: <%= inertia_model_type %>[]
 }>()
-const { flash } = usePage()
+const page = usePage()
 </script>

--- a/lib/generators/inertia_tw_templates/scaffold/templates/vue/index.vue.tt
+++ b/lib/generators/inertia_tw_templates/scaffold/templates/vue/index.vue.tt
@@ -1,7 +1,7 @@
 <template>
   <Head title="<%= human_name.pluralize %>" />
 
-  <div className="mx-auto md:w-2/3 w-full px-8 pt-8">
+  <div class="mx-auto md:w-2/3 w-full px-8 pt-8">
     <p
       v-if="page.flash.notice"
       class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block"

--- a/lib/generators/inertia_tw_templates/scaffold/templates/vue/index.vue.tt
+++ b/lib/generators/inertia_tw_templates/scaffold/templates/vue/index.vue.tt
@@ -3,10 +3,10 @@
 
   <div className="mx-auto md:w-2/3 w-full px-8 pt-8">
     <p
-      v-if="flash.notice"
+      v-if="page.flash.notice"
       class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block"
     >
-      {{ flash.notice }}
+      {{ page.flash.notice }}
     </p>
 
     <div class="flex justify-between items-center">
@@ -40,5 +40,5 @@ import { Head, Link, usePage } from '@inertiajs/vue3'
 import <%= inertia_component_name %> from './<%= singular_name %>.vue'
 
 defineProps(['<%= plural_table_name %>'])
-const { flash } = usePage()
+const page = usePage()
 </script>

--- a/lib/generators/inertia_tw_templates/scaffold/templates/vue/new.ts.vue.tt
+++ b/lib/generators/inertia_tw_templates/scaffold/templates/vue/new.ts.vue.tt
@@ -1,7 +1,7 @@
 <template>
   <Head title="New <%= human_name.downcase %>" />
 
-  <div className="mx-auto md:w-2/3 w-full px-8 pt-8">
+  <div class="mx-auto md:w-2/3 w-full px-8 pt-8">
     <h1 class="font-bold text-4xl">New <%= human_name.downcase %></h1>
 
     <Form

--- a/lib/generators/inertia_tw_templates/scaffold/templates/vue/new.vue.tt
+++ b/lib/generators/inertia_tw_templates/scaffold/templates/vue/new.vue.tt
@@ -1,7 +1,7 @@
 <template>
   <Head title="New <%= human_name.downcase %>" />
 
-  <div className="mx-auto md:w-2/3 w-full px-8 pt-8">
+  <div class="mx-auto md:w-2/3 w-full px-8 pt-8">
     <h1 class="font-bold text-4xl">New <%= human_name.downcase %></h1>
 
     <Form

--- a/lib/generators/inertia_tw_templates/scaffold/templates/vue/show.ts.vue.tt
+++ b/lib/generators/inertia_tw_templates/scaffold/templates/vue/show.ts.vue.tt
@@ -1,7 +1,7 @@
 <template>
   <Head :title="`<%= human_name %> #${<%= singular_table_name %>.id}`" />
 
-  <div className="mx-auto md:w-2/3 w-full px-8 pt-8">
+  <div class="mx-auto md:w-2/3 w-full px-8 pt-8">
     <div class="mx-auto">
       <p
         v-if="page.flash.notice"

--- a/lib/generators/inertia_tw_templates/scaffold/templates/vue/show.ts.vue.tt
+++ b/lib/generators/inertia_tw_templates/scaffold/templates/vue/show.ts.vue.tt
@@ -4,10 +4,10 @@
   <div className="mx-auto md:w-2/3 w-full px-8 pt-8">
     <div class="mx-auto">
       <p
-        v-if="flash.notice"
+        v-if="page.flash.notice"
         class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block"
       >
-        {{ flash.notice }}
+        {{ page.flash.notice }}
       </p>
 
       <h1 class="font-bold text-4xl"><%= human_name %> #{{ <%= singular_table_name %>.id }}</h1>
@@ -49,5 +49,5 @@ import { <%= inertia_model_type %> } from './types'
 defineProps<{
   <%= singular_table_name %>: <%= inertia_model_type %>
 }>()
-const { flash } = usePage()
+const page = usePage()
 </script>

--- a/lib/generators/inertia_tw_templates/scaffold/templates/vue/show.vue.tt
+++ b/lib/generators/inertia_tw_templates/scaffold/templates/vue/show.vue.tt
@@ -1,7 +1,7 @@
 <template>
   <Head :title="`<%= human_name %> #${<%= singular_table_name %>.id}`" />
 
-  <div className="mx-auto md:w-2/3 w-full px-8 pt-8">
+  <div class="mx-auto md:w-2/3 w-full px-8 pt-8">
     <div class="mx-auto">
       <p
         v-if="page.flash.notice"

--- a/lib/generators/inertia_tw_templates/scaffold/templates/vue/show.vue.tt
+++ b/lib/generators/inertia_tw_templates/scaffold/templates/vue/show.vue.tt
@@ -4,10 +4,10 @@
   <div className="mx-auto md:w-2/3 w-full px-8 pt-8">
     <div class="mx-auto">
       <p
-        v-if="flash.notice"
+        v-if="page.flash.notice"
         class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block"
       >
-        {{ flash.notice }}
+        {{ page.flash.notice }}
       </p>
 
       <h1 class="font-bold text-4xl"><%= human_name %> #{{ <%= singular_table_name %>.id }}</h1>
@@ -46,5 +46,5 @@ import { Head, Link, usePage } from '@inertiajs/vue3'
 import <%= inertia_component_name %> from './<%= singular_name %>.vue'
 
 defineProps(['<%= singular_table_name %>'])
-const { flash } = usePage()
+const page = usePage()
 </script>


### PR DESCRIPTION
Two changes to the **Vue** scaffold generator templates:

- Fix: stale flash notice on same-component non-GET visits
- Cleanup: use idiomatic `class` instead of `className` in the Tailwind Vue wrappers

🤖 Generated with [Claude Code](https://claude.com/claude-code)