### PR TITLE
Only set the XSRF-TOKEN cookie on HTML and XHR responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Only set the `XSRF-TOKEN` cookie on HTML and XHR responses, so responses no client reads it from — notably ActiveStorage's image endpoints, which also inherit from `ActionController::Base` — no longer carry a `Set-Cookie` that stops CDNs from caching them (@acetinick)
 * Add `xsrf_cookie_refresh` configuration option. Set to `:lazy` to skip rewriting the `XSRF-TOKEN` cookie on safe requests when a valid cookie is already present, keeping conditionally cached (`ETag`/`304`) responses free of `Set-Cookie` churn (@darkamenosa)
 * Fix `inertia: { errors: }` and `inertia: { clear_history: }` being discarded when `redirect_to` is given an explicit non-302 status such as `status: :see_other` (303/307/308) (@skryukov)
 * Fix cross-variant `304 Not Modified` responses under HTTP conditional caching (`fresh_when` / `stale?`) by folding the Inertia request headers into the ETag, so HTML, JSON, and partial-reload representations of the same URL no longer share a validator (@skryukov)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* Only set the `XSRF-TOKEN` cookie on HTML and XHR responses, so responses no client reads it from — notably ActiveStorage's image endpoints, which also inherit from `ActionController::Base` — no longer carry a `Set-Cookie` that stops CDNs from caching them (@acetinick)
+* Only set the `XSRF-TOKEN` cookie on HTML and XHR responses. Other responses no longer carry a `Set-Cookie` that keeps CDNs from caching them — notably ActiveStorage's images, since its controllers also inherit from `ActionController::Base` (@acetinick)
 * Add `xsrf_cookie_refresh` configuration option. Set to `:lazy` to skip rewriting the `XSRF-TOKEN` cookie on safe requests when a valid cookie is already present, keeping conditionally cached (`ETag`/`304`) responses free of `Set-Cookie` churn (@darkamenosa)
 * Fix `inertia: { errors: }` and `inertia: { clear_history: }` being discarded when `redirect_to` is given an explicit non-302 status such as `status: :see_other` (303/307/308) (@skryukov)
 * Fix cross-variant `304 Not Modified` responses under HTTP conditional caching (`fresh_when` / `stale?`) by folding the Inertia request headers into the ETag, so HTML, JSON, and partial-reload representations of the same URL no longer share a validator (@skryukov)

--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -17,11 +17,8 @@ module InertiaRails
 
       after_action do
         next unless protect_against_forgery?
-        # Only clients that can read the cookie and send it back need it: page
-        # loads and XHR (Inertia visits, `useHttp`). Setting it on anything else
-        # puts a `Set-Cookie` on responses that never asked for one — notably
-        # ActiveStorage's image controllers, which also inherit from
-        # ActionController::Base, and which CDNs then refuse to cache.
+        # Included into ActionController::Base, so this runs for non-Inertia
+        # responses too — ActiveStorage images, where it only breaks CDN caching.
         next unless request.format.html? || request.xhr?
         next if XsrfCookieRefreshPolicy.skip?(self)
 

--- a/lib/inertia_rails/controller.rb
+++ b/lib/inertia_rails/controller.rb
@@ -17,6 +17,12 @@ module InertiaRails
 
       after_action do
         next unless protect_against_forgery?
+        # Only clients that can read the cookie and send it back need it: page
+        # loads and XHR (Inertia visits, `useHttp`). Setting it on anything else
+        # puts a `Set-Cookie` on responses that never asked for one — notably
+        # ActiveStorage's image controllers, which also inherit from
+        # ActionController::Base, and which CDNs then refuse to cache.
+        next unless request.format.html? || request.xhr?
         next if XsrfCookieRefreshPolicy.skip?(self)
 
         cookies['XSRF-TOKEN'] = form_authenticity_token

--- a/spec/inertia/request_spec.rb
+++ b/spec/inertia/request_spec.rb
@@ -123,6 +123,21 @@ RSpec.describe 'Inertia::Request', type: :request do
         let(:headers) { { 'X-Inertia' => true } }
         it { is_expected.to include('XSRF-TOKEN') }
       end
+
+      context 'it is an XHR call that is not HTML' do
+        let(:headers) { { 'X-Requested-With' => 'XMLHttpRequest', 'Accept' => 'application/json' } }
+        it { is_expected.to include('XSRF-TOKEN') }
+      end
+
+      # The concern is included into ActionController::Base, so this after_action
+      # also runs for controllers that never render Inertia — ActiveStorage's
+      # image endpoints among them. A Set-Cookie on an image is both useless (no
+      # client reads it) and harmful: CDNs bypass their cache for any response
+      # carrying one, so `public, immutable` images are never edge-cached.
+      context 'it is neither an HTML nor an XHR call' do
+        let(:headers) { { 'Accept' => 'image/png' } }
+        it { is_expected.not_to include('XSRF-TOKEN') }
+      end
     end
 
     describe 'xsrf_cookie_refresh configuration' do

--- a/spec/inertia/request_spec.rb
+++ b/spec/inertia/request_spec.rb
@@ -129,11 +129,6 @@ RSpec.describe 'Inertia::Request', type: :request do
         it { is_expected.to include('XSRF-TOKEN') }
       end
 
-      # The concern is included into ActionController::Base, so this after_action
-      # also runs for controllers that never render Inertia — ActiveStorage's
-      # image endpoints among them. A Set-Cookie on an image is both useless (no
-      # client reads it) and harmful: CDNs bypass their cache for any response
-      # carrying one, so `public, immutable` images are never edge-cached.
       context 'it is neither an HTML nor an XHR call' do
         let(:headers) { { 'Accept' => 'image/png' } }
         it { is_expected.not_to include('XSRF-TOKEN') }


### PR DESCRIPTION
Fixes #394. Implements option 1 from that thread, as @skryukov suggested — including the correction that the guard belongs on the **request**, not the response.

### The problem

`InertiaRails::Controller` is included into `ActionController::Base`, so the `XSRF-TOKEN` after_action runs for every response from every controller — including ones that never render Inertia and whose clients never read the cookie.

ActiveStorage is the clearest case: its image controllers inherit from `ActionController::Base` too, so a **PNG** comes back with `Set-Cookie: XSRF-TOKEN`. CDNs bypass their cache for any response carrying `Set-Cookie`, so images ActiveStorage marks `public, immutable, max-age=100y` are never edge-cached.

Measured on our production CDN — two requests to the same host, same page:

| | ActiveStorage image proxy | static asset (not Rails) |
|---|---|---|
| `vary` | `Origin, accept-encoding` | identical |
| `cache-control` | `max-age=3155695200, public, immutable` | `public, max-age=14400` |
| `set-cookie` | `XSRF-TOKEN=…` | none |
| `cf-cache-status` | **BYPASS** | **HIT** (`age: 2178`) |

The static file asks for 4 hours and is cached; the image asks for 100 years and is not. In a HAR from one real page load, 32 of 33 image requests were `BYPASS`.

### The change

```ruby
next unless request.format.html? || request.xhr?
```

Only page loads and XHR (Inertia visits, `useHttp`) can read the cookie and send it back, so nothing else needs it.

Guarding on `response.media_type` — my original suggestion in the issue — would break conditional responses, since a `304 Not Modified` carries no `Content-Type`. The request-side guard doesn't have that problem, and the existing spec for it (`rewrites the XSRF-TOKEN cookie even on 304 Not Modified responses by default`) still passes unchanged.

### Tests

Two specs added alongside the existing ones in `spec/inertia/request_spec.rb`:

- an XHR call that isn't HTML → still gets the cookie
- a request that is neither HTML nor XHR (`Accept: image/png`) → doesn't

Verified the second one fails without the guard:

```
Failure/Error: it { is_expected.not_to include('XSRF-TOKEN') }
  expected {"XSRF-TOKEN" => "tiEoVzYPyNU_9l-40JkdT28YvO-..."} not to include "XSRF-TOKEN"
```

`spec/inertia` is green locally (58 examples, 0 failures on Ruby 3.4). Leaving the full matrix to CI.

### Notes

- This composes with `xsrf_cookie_refresh: :lazy` (#368) rather than replacing it — the new guard runs first, the policy still decides refresh behaviour for HTML/XHR.
- Happy to adjust the wording of the comment or the spec placement if you'd prefer them elsewhere.