### PR TITLE
Ignore stray X-Inertia header on non-Inertia controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* Fix `NoMethodError` (500) when a request carrying the `X-Inertia` header reaches a non-Inertia controller such as an `ActionController::API` endpoint. The middleware now only applies version negotiation to controllers that include `InertiaRails::Controller` (@say)
+* Fix `NoMethodError` raised when a request carrying the `X-Inertia` header reaches a non-Inertia controller such as an `ActionController::API` endpoint (@SAY-5)
 
 ## [3.22.0] - 2026-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Fix `NoMethodError` (500) when a request carrying the `X-Inertia` header reaches a non-Inertia controller such as an `ActionController::API` endpoint. The middleware now only applies version negotiation to controllers that include `InertiaRails::Controller` (@say)
+
 ## [3.22.0] - 2026-07-17
 
 * Only set the `XSRF-TOKEN` cookie on HTML and XHR responses. Other responses no longer carry a `Set-Cookie` that keeps CDNs from caching them — notably ActiveStorage's images, since its controllers also inherit from `ActionController::Base` (@acetinick)

--- a/lib/inertia_rails/middleware.rb
+++ b/lib/inertia_rails/middleware.rb
@@ -92,7 +92,15 @@ module InertiaRails
       end
 
       def inertia_request?
-        @env['HTTP_X_INERTIA'].present?
+        @env['HTTP_X_INERTIA'].present? && inertia_controller?
+      end
+
+      # The middleware is installed on every request, but Inertia's controller
+      # methods (e.g. inertia_configuration) are only mixed into Inertia-aware
+      # controllers. A stray X-Inertia header on a non-Inertia endpoint (such as
+      # an ActionController::API action) must not trigger version negotiation.
+      def inertia_controller?
+        controller.respond_to?(:inertia_configuration, true)
       end
 
       def version_stale?

--- a/lib/inertia_rails/middleware.rb
+++ b/lib/inertia_rails/middleware.rb
@@ -95,10 +95,6 @@ module InertiaRails
         @env['HTTP_X_INERTIA'].present? && inertia_controller?
       end
 
-      # The middleware is installed on every request, but Inertia's controller
-      # methods (e.g. inertia_configuration) are only mixed into Inertia-aware
-      # controllers. A stray X-Inertia header on a non-Inertia endpoint (such as
-      # an ActionController::API action) must not trigger version negotiation.
       def inertia_controller?
         controller.respond_to?(:inertia_configuration, true)
       end

--- a/spec/dummy/app/controllers/inertia_api_test_controller.rb
+++ b/spec/dummy/app/controllers/inertia_api_test_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Inherits from ActionController::API, which does not receive the
+# InertiaRails::Controller mixin (only ActionController::Base does).
+class InertiaApiTestController < ActionController::API
+  def index
+    render json: { ok: true }
+  end
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -76,6 +76,7 @@ Rails.application.routes.draw do
   get 'cached_props' => 'inertia_render_test#cached_props'
   get 'cached_deferred_props' => 'inertia_render_test#cached_deferred_props'
   get 'non_inertiafied' => 'inertia_test#non_inertiafied'
+  get 'api_test' => 'inertia_api_test#index'
   get 'deeply_nested_props' => 'inertia_render_test#deeply_nested_props'
 
   get 'instance_props_test' => 'inertia_rails_mimic#instance_props_test'

--- a/spec/inertia/middleware_spec.rb
+++ b/spec/inertia/middleware_spec.rb
@@ -41,12 +41,6 @@ RSpec.describe 'InertiaRails::Middleware', type: :request do
 
       expect(response.status).to eq baseline
     end
-
-    it 'still refreshes a stale Inertia GET on a real Inertia controller' do
-      get empty_test_path, headers: { 'X-Inertia' => true, 'X-Inertia-Version' => 'stale' }
-
-      expect(response.status).to eq 409
-    end
   end
 
   context 'session loading guard' do

--- a/spec/inertia/middleware_spec.rb
+++ b/spec/inertia/middleware_spec.rb
@@ -30,6 +30,25 @@ RSpec.describe 'InertiaRails::Middleware', type: :request do
     end
   end
 
+  context 'X-Inertia header on a non-Inertia controller' do
+    with_inertia_config version: '1.0'
+
+    it 'ignores the header on an ActionController::API endpoint' do
+      get api_test_path
+      baseline = response.status
+
+      get api_test_path, headers: { 'X-Inertia' => true, 'X-Inertia-Version' => 'stale' }
+
+      expect(response.status).to eq baseline
+    end
+
+    it 'still refreshes a stale Inertia GET on a real Inertia controller' do
+      get empty_test_path, headers: { 'X-Inertia' => true, 'X-Inertia-Version' => 'stale' }
+
+      expect(response.status).to eq 409
+    end
+  end
+
   context 'session loading guard' do
     it 'does not load the session when the request never accesses it' do
       get non_inertiafied_path


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Summary

Fixes #393.

A request carrying the `X-Inertia` header to a controller that isn't an Inertia controller (e.g. an `ActionController::API` action) raised `NoMethodError: undefined method 'inertia_configuration'` in the middleware, surfacing as a 500. The header alone is enough to trigger it, so any app with the gem installed is exposed regardless of whether it uses Inertia on that endpoint.

The middleware is installed on every request, but `InertiaRails::Controller` (and thus `inertia_configuration`) is only mixed into `ActionController::Base`. `server_version` called `controller&.send(:inertia_configuration)`, and the safe-navigation didn't help because the controller instance is present, just not Inertia-aware.

This gates `inertia_request?` on the controller actually responding to `inertia_configuration`, so a stray `X-Inertia` header on a non-Inertia endpoint no longer enters version negotiation. Real Inertia controllers are unchanged.

## Test plan

- Added a request spec covering an `ActionController::API` endpoint (asserted against its own baseline status) plus a guard that a stale Inertia GET on a real Inertia controller still returns 409.
- `bundle exec rspec spec/inertia/middleware_spec.rb` — 18 examples, 0 failures.
- Reverting only the middleware change reproduces the original `NoMethodError` in the new spec.

## Checklist

- [x] Tests added or updated
- [x] `CHANGELOG.md` updated (for user-facing changes)
