### PR TITLE
Rewrite Inertia Modal cookbook for Inertia Modal 3.x

### DIFF
--- a/docs/cookbook/inertia-modal.md
+++ b/docs/cookbook/inertia-modal.md
@@ -26,18 +26,14 @@ While you can use Inertia Modal without changes on the backend, we recommend usi
 [`inertia_rails-contrib`](https://github.com/skryukov/inertia_rails-contrib) to enhance your modals with base URL support. This ensures that your modals are accessible,
 SEO-friendly, and provide a better user experience.
 
-> [!NOTE] Version compatibility
-> Inertia Modal's major version is aligned with the Inertia.js version it supports: Inertia Modal 3.x requires
-> Inertia.js v3, and Inertia Modal 2.x requires Inertia.js v2. This guide covers Inertia Modal 3.x. If you're still
-> on Inertia.js v2, install `@inertiaui/modal-react@^2.0.0` or `@inertiaui/modal-vue@^2.0.0` and follow the
-> [Inertia Modal 2.x documentation](https://inertiaui.com/inertia-modal/docs/v2/introduction) instead.
-
 > [!NOTE]
 > Svelte is not supported by Inertia Modal.
 
 ## Requirements
 
-- React 19+ with `@inertiajs/react` 3.0+, or Vue 3.4+ with `@inertiajs/vue3` 3.0+
+- React 19+ with `@inertiajs/react` 3.0+, or Vue 3.4+ with `@inertiajs/vue3` 3.0+ — Inertia Modal's major
+  version follows the Inertia.js version it supports, so on Inertia.js v2, install Inertia Modal 2.x and
+  follow the [2.x documentation](https://inertiaui.com/inertia-modal/docs/v2/introduction) instead
 - Tailwind CSS 4 for the default modal UI. If you're on Tailwind CSS 3 (or don't use Tailwind at all), you can
   still use Inertia Modal in [headless mode](https://inertiaui.com/inertia-modal/docs/headless-mode) with your own UI.
 - For base URL support: [`inertia_rails-contrib`](https://github.com/skryukov/inertia_rails-contrib) 0.6+
@@ -61,7 +57,7 @@ npm install @inertiaui/modal-react
 
 :::
 
-Both packages ship with TypeScript type definitions, so no additional `@types` packages are needed.
+Inertia Modal 3.0+ comes with TypeScript support.
 
 ### 2. Configure Inertia
 

--- a/docs/cookbook/inertia-modal.md
+++ b/docs/cookbook/inertia-modal.md
@@ -1,6 +1,6 @@
 # Inertia Modal
 
-[Inertia Modal](https://github.com/inertiaui/modal) is a powerful library that enables you to render any Inertia page
+[Inertia Modal](https://inertiaui.com/inertia-modal) is a powerful library that enables you to render any Inertia page
 as a modal dialog. It seamlessly integrates with your existing Inertia Rails application, allowing you to create modal
 workflows without the complexity of managing modal state manually.
 
@@ -17,14 +17,30 @@ Here's a summary of the features:
 - Multiple sizes and positions
 - Reload props in modals
 - Easy communication between nested/stacked modals
+- Prefetch support for faster modal loading
+- Native HTML dialog support for better accessibility
+- TypeScript type definitions included
 - Highly configurable
 
 While you can use Inertia Modal without changes on the backend, we recommend using the Rails gem
 [`inertia_rails-contrib`](https://github.com/skryukov/inertia_rails-contrib) to enhance your modals with base URL support. This ensures that your modals are accessible,
 SEO-friendly, and provide a better user experience.
 
+> [!NOTE] Version compatibility
+> Inertia Modal's major version is aligned with the Inertia.js version it supports: Inertia Modal 3.x requires
+> Inertia.js v3, and Inertia Modal 2.x requires Inertia.js v2. This guide covers Inertia Modal 3.x. If you're still
+> on Inertia.js v2, install `@inertiaui/modal-react@^2.0.0` or `@inertiaui/modal-vue@^2.0.0` and follow the
+> [Inertia Modal 2.x documentation](https://inertiaui.com/inertia-modal/docs/v2/introduction) instead.
+
 > [!NOTE]
-> Svelte 5 is not yet supported by Inertia Modal.
+> Svelte is not supported by Inertia Modal.
+
+## Requirements
+
+- React 19+ with `@inertiajs/react` 3.0+, or Vue 3.4+ with `@inertiajs/vue3` 3.0+
+- Tailwind CSS 4 for the default modal UI. If you're on Tailwind CSS 3 (or don't use Tailwind at all), you can
+  still use Inertia Modal in [headless mode](https://inertiaui.com/inertia-modal/docs/headless-mode) with your own UI.
+- For base URL support: [`inertia_rails-contrib`](https://github.com/skryukov/inertia_rails-contrib) 0.6+
 
 ## Installation
 
@@ -45,108 +61,110 @@ npm install @inertiaui/modal-react
 
 :::
 
+Both packages ship with TypeScript type definitions, so no additional `@types` packages are needed.
+
 ### 2. Configure Inertia
 
-Update your Inertia app setup to include the modal plugin:
+Update your Inertia app setup to mount the modal root component:
 
 :::tabs key:frameworks
 == Vue
 
 ```js
-// frontend/entrypoints/inertia.js
-import { createApp, h } from 'vue'
+// app/frontend/entrypoints/inertia.js
 import { createInertiaApp } from '@inertiajs/vue3'
-import { renderApp } from '@inertiaui/modal-vue' // [!code ++]
+import { withInertiaModal } from '@inertiaui/modal-vue' // [!code ++]
 
 createInertiaApp({
-  resolve: (name) => {
-    const pages = import.meta.glob('../pages/**/*.vue', { eager: true })
-    return pages[`../pages/${name}.vue`]
-  },
-  setup({ el, App, props, plugin }) {
-    createApp({ render: () => h(App, props) }) // [!code --]
-    createApp({ render: renderApp(App, props) }) // [!code ++]
-      .use(plugin)
-      .mount(el)
+  pages: '../pages',
+  // [!code ++:3]
+  withApp(app) {
+    withInertiaModal(app)
   },
 })
 ```
 
 == React
 
-```js
-// frontend/entrypoints/inertia.js
+```jsx
+// app/frontend/entrypoints/inertia.jsx
 import { createInertiaApp } from '@inertiajs/react'
-import { createElement } from 'react' // [!code --]
-import { renderApp } from '@inertiaui/modal-react' // [!code ++]
-import { createRoot } from 'react-dom/client'
+import { ModalStackProvider, ModalRoot } from '@inertiaui/modal-react' // [!code ++]
+
+// [!code ++:8]
+function ModalLayout({ children }) {
+  return (
+    <>
+      {children}
+      <ModalRoot />
+    </>
+  )
+}
 
 createInertiaApp({
-  resolve: (name) => {
-    const pages = import.meta.glob('../pages/**/*.jsx', { eager: true })
-    return pages[`../pages/${name}.jsx`]
-  },
-  setup({ el, App, props }) {
-    const root = createRoot(el)
-    root.render(createElement(App, props)) // [!code --]
-    root.render(renderApp(App, props)) // [!code ++]
-  },
+  pages: '../pages',
+  withApp: (app) => <ModalStackProvider>{app}</ModalStackProvider>, // [!code ++]
+  layout: () => ModalLayout, // [!code ++]
 })
 ```
 
 :::
+
+> [!NOTE]
+> If your app already defines a `setup` callback, per-page layouts, or a `layout` option in `createInertiaApp`,
+> render `<ModalRoot />` inside your existing layout component instead. See the
+> [Custom App Mounting](https://inertiaui.com/inertia-modal/docs/custom-app-mounting) documentation for details.
+
+> [!TIP]
+> In a TypeScript app, annotate the layout's `children` prop:
+> `function ModalLayout({ children }: { children: React.ReactNode })`.
 
 ### 3. Tailwind CSS Configuration
 
+The default modal UI is built for Tailwind CSS 4. Tell Tailwind to scan the package's source files by adding an
+`@source` directive to your CSS entrypoint:
+
 :::tabs key:frameworks
 == Vue
 
-For Tailwind CSS v4, add the modal styles to your CSS:
-
 ```css
-/* app/entrypoints/frontend/application.css */
-@source '../../../node_modules/@inertiaui/modal-vue';
-```
-
-For Tailwind CSS v3, update your `tailwind.config.js`:
-
-```js
-export default {
-  content: [
-    './node_modules/@inertiaui/modal-vue/src/**/*.{js,vue}',
-    // other paths...
-  ],
-}
+/* app/frontend/entrypoints/application.css */
+@source '../../../node_modules/@inertiaui/modal-vue/src';
 ```
 
 == React
 
-For Tailwind CSS v4, add the modal styles to your CSS:
-
 ```css
-/* app/entrypoints/frontend/application.css */
-@source '../../../node_modules/@inertiaui/modal-react';
-```
-
-For Tailwind CSS v3, update your `tailwind.config.js`:
-
-```js
-export default {
-  content: [
-    './node_modules/@inertiaui/modal-react/src/**/*.{js,jsx}',
-    // other paths...
-  ],
-}
+/* app/frontend/entrypoints/application.css */
+@source '../../../node_modules/@inertiaui/modal-react/src';
 ```
 
 :::
 
+> [!WARNING]
+> The path must point to the `src` directory inside the package and must be relative to the CSS file itself.
+> If your CSS entrypoint is located elsewhere, adjust the number of `../` segments accordingly, otherwise
+> the modal will render without styles.
+
+If you're on Tailwind CSS 3, the default UI is not supported — use
+[headless mode](https://inertiaui.com/inertia-modal/docs/headless-mode) and provide your own markup.
+
 ### 4. Add the Ruby Gem (optional but recommended)
 
-Install the [`inertia_rails-contrib`](https://github.com/skryukov/inertia_rails-contrib) gem to your Rails application to enable base URL support for modals:
+Install the [`inertia_rails-contrib`](https://github.com/skryukov/inertia_rails-contrib) gem to your Rails application
+to enable base URL support for modals:
 
 ```bash
 bundle add inertia_rails-contrib
+```
+
+Then, enable the InertiaUI Modal integration in an initializer:
+
+```ruby
+# config/initializers/inertia_rails_contrib.rb
+InertiaRailsContrib.configure do |config|
+  config.enable_inertia_ui_modal = true
+end
 ```
 
 ## Basic example
@@ -257,7 +275,6 @@ To define the base route for your modal, you need to use the `inertia_modal` ren
 `inertia` one. It accepts the same arguments as the `inertia` renderer:
 
 ```ruby
-
 class UsersController < ApplicationController
   def edit
     render inertia: { # [!code --]
@@ -272,14 +289,13 @@ end
 Then, you can pass the `base_url` parameter to the `inertia_modal` renderer to define the base route for your modal:
 
 ```ruby
-
 class UsersController < ApplicationController
   def edit
     render inertia_modal: {
       user:,
       roles: -> { Role.all },
     } # [!code --]
-    }, base_url : users_path # [!code ++]
+    }, base_url: users_path # [!code ++]
   end
 end
 ```


### PR DESCRIPTION
Closes #249

The Inertia Modal cookbook was written for Inertia Modal 0.x and no longer matched the library. This rewrite targets Inertia Modal 3.x (aligned with Inertia.js v3, which is what the installer sets up today) and addresses all three problems from #249:

1. **CSS import not applying styles** — the `@source` directive must point at the package's `src` directory (`@source '../../../node_modules/@inertiaui/modal-react/src'`). The cookbook now uses the correct path, warns about adjusting the relative segments, and notes that the default UI requires Tailwind CSS 4 (headless mode for Tailwind 3).
2. **Conflicting `createElement` instructions** — the old `renderApp` setup is gone in 3.x. The new snippets use the `withApp` option (`withInertiaModal` for Vue; `ModalStackProvider` + `ModalRoot` layout for React) and diff against the current installer templates, so there's nothing left to reconcile.
3. **TypeScript support** — both packages ship type definitions since 2.0. The cookbook says so and includes the typed `ModalLayout` variant for TS apps.

Also added: a version-compatibility note (modal major follows the Inertia major, with a pointer to the 2.x docs for Inertia v2 apps), a requirements section, the previously missing `enable_inertia_ui_modal` initializer for `inertia_rails-contrib` (0.6+ is aligned with modal 2.x/3.x), and a fix for the invalid `base_url :` syntax in the base-route example.

## Verification

Followed the rewritten cookbook step by step in a fresh React scaffold (React 19, TypeScript, Tailwind CSS 4, `@inertiajs/react` 3.6.1, `@inertiaui/modal-react` 3.1.2) and confirmed in a real browser:

- Styled modal (rounded panel + dimmed backdrop) opens over `/posts` without changing the URL
- With `inertia_modal` + `base_url` + `navigate`: URL updates to `/posts/new`, browser back closes the modal, and visiting `/posts/new` directly renders the index with the modal on top
- `tsc` passes; VitePress build passes and the diff annotations render on the correct lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C2Fcjt9s49QccpuU6fR7q4