### PR TITLE
Add meta_title_template for server driven meta tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Add `config.server_head` to serialize meta tags as HTML strings into the `head` prop for the `serverHead` option of `createInertiaApp` (Inertia.js v3.5+), replacing the client-side cookbook component (@skryukov)
+* Add `meta_title_template` configuration option — a callable applied to the `<title>` tag of server driven meta tags; it receives the current title (or `nil`) and can provide a default for pages without one (@skryukov)
 * Fix meta tags ignoring per-controller `use_data_inertia_head_attribute` set via `inertia_config` (@skryukov)
 * Use SHA256 instead of MD5 for meta tag head key digests, so they no longer raise on FIPS-enabled Rubies (@skryukov)
 * Restart the SSR server promptly in the Puma plugin when the process dies during boot, instead of polling a dead port for the full boot timeout (@skryukov)

--- a/docs/cookbook/server-managed-meta-tags.md
+++ b/docs/cookbook/server-managed-meta-tags.md
@@ -26,7 +26,7 @@ Simply add the `inertia_meta_tags` helper to your layout. This will render the m
 ```
 
 > [!NOTE]
-> Make sure to remove the `<title>` tag in your Rails layout if you plan to manage it with Inertia Rails. Otherwise you will end up with duplicate `<title>` tags. Since the layout no longer provides a fallback, a page that defines no meta tags renders without a `<title>` at all — set a default title in a shared `before_action` (see [Shared Meta Tags](#shared-meta-tags)).
+> Make sure to remove the `<title>` tag in your Rails layout if you plan to manage it with Inertia Rails. Otherwise you will end up with duplicate `<title>` tags. Since the layout no longer provides a fallback, a page that defines no meta tags renders without a `<title>` at all — configure a callable [title template](#title-template) to provide a default.
 
 ### Client Side
 
@@ -294,6 +294,9 @@ inertia_meta.add([
   { tag_name: 'script', type: 'application/ld+json', inner_content: { '@context': 'https://schema.org', '@type': 'Event', name: 'My Event' } }
 ])
 
+# Read the current page title
+inertia_meta.title # => "A title for the page"
+
 # Remove a specific tag by head_key
 inertia_meta.remove("my_custom_head_key")
 
@@ -327,6 +330,23 @@ inertia_meta.add({
   }
 })
 ```
+
+## Title Template
+
+@available_since rails=master
+
+Instead of repeating an app-wide suffix in every action, configure a title template — the server-side counterpart of the [title callback](/guide/title-and-meta#title-callback). It receives the current title (or `nil` when the page sets none), runs in the controller context, and its result becomes the title:
+
+```ruby
+InertiaRails.configure do |config|
+  config.meta_title_template = ->(title) { title ? "#{title} - My App" : 'My App' }
+end
+```
+
+With this template, `inertia_meta.add({ title: 'Events' })` renders `<title>Events - My App</title>` — in the server-rendered HTML too, so crawlers and link previews see the full title without running JavaScript. Because the template runs even when no title is set, it doubles as a default title for pages that define no meta tags at all.
+
+> [!WARNING]
+> Don't combine a server-side title template with the client-side [title callback](/guide/title-and-meta#title-callback) — the client applies its callback on top of the server-provided title, so the suffix would appear twice. Use one or the other.
 
 ## Deduplication
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -362,3 +362,19 @@ createInertiaApp({
 
 > [!NOTE]
 > With this option enabled, head elements are always marked with the `data-inertia` attribute regardless of the `use_data_inertia_head_attribute` setting, since Inertia.js v3 only recognizes `data-inertia`.
+
+### `meta_title_template`
+
+**Default**: `nil`
+
+@available_since rails=master
+
+A callable applied to the `<title>` tag of [server driven meta tags](/cookbook/server-managed-meta-tags). It receives the current title (or `nil` when the page sets none), runs in the controller context, and its result becomes the title — so it can also provide a default for pages without one:
+
+```ruby
+InertiaRails.configure do |config|
+  config.meta_title_template = ->(title) { title ? "#{title} - My App" : 'My App' }
+end
+```
+
+See [Title Template](/cookbook/server-managed-meta-tags#title-template) for details.

--- a/docs/guide/title-and-meta.md
+++ b/docs/guide/title-and-meta.md
@@ -99,6 +99,9 @@ createInertiaApp({
 
 After defining the `title` callback, the callback will automatically be invoked when you set a title using the `<Head>` component.
 
+> [!NOTE]
+> When using [server driven meta tags](/cookbook/server-managed-meta-tags), configure the [title template](/cookbook/server-managed-meta-tags#title-template) on the server instead — the client applies the `title` callback on top of server-provided titles, so combining the two would apply the suffix twice.
+
 :::tabs key:frameworks
 
 == Vue

--- a/lib/inertia_rails/configuration.rb
+++ b/lib/inertia_rails/configuration.rb
@@ -65,6 +65,11 @@ module InertiaRails
       # of `createInertiaApp` (Inertia.js v3.5+). A String sets a custom prop name.
       server_head: false,
 
+      # Callable applied to the page `<title>` meta tag. Receives the current
+      # title (or nil when none is set) and returns the full title, so it can
+      # also provide a default for pages without one.
+      meta_title_template: nil,
+
       # DOM id to use for the root Inertia.js element.
       root_dom_id: 'app',
 
@@ -179,6 +184,15 @@ module InertiaRails
       return :_inertia_meta unless value
 
       value == true ? :head : value.to_sym
+    end
+
+    # Returned without evaluating — the callable takes the current title as an
+    # argument, so the renderer applies it instead of `evaluate_option`.
+    def meta_title_template
+      value = options[:meta_title_template]
+      return value if value.nil? || value.respond_to?(:call)
+
+      raise ArgumentError, "meta_title_template must be callable, got #{value.inspect}"
     end
 
     OPTION_NAMES.each do |option|

--- a/lib/inertia_rails/meta_tag_builder.rb
+++ b/lib/inertia_rails/meta_tag_builder.rb
@@ -10,6 +10,10 @@ module InertiaRails
       @meta_tags.values
     end
 
+    def title
+      @meta_tags['title']&.[](:inner_content)
+    end
+
     def add(meta_tag)
       if meta_tag.is_a?(Array)
         meta_tag.each { |tag| add(tag) }

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -161,7 +161,16 @@ module InertiaRails
       @controller.inertia_meta.meta_tags
     end
 
+    def apply_title_template
+      return unless (template = @configuration.meta_title_template)
+
+      meta = @controller.inertia_meta
+      title = @controller.instance_exec(meta.title, &template)
+      meta.add(title: title) if title.present?
+    end
+
     def merge_meta_tags!(props)
+      apply_title_template
       return if meta_tags.blank?
 
       props[@configuration.meta_prop] = serialized_meta_tags

--- a/spec/dummy/app/controllers/inertia_meta_title_template_controller.rb
+++ b/spec/dummy/app/controllers/inertia_meta_title_template_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class InertiaMetaTitleTemplateController < ApplicationController
+  # Calls a private controller method to prove the template runs in controller context.
+  inertia_config(meta_title_template: ->(title) { title ? "#{title} - #{app_name}" : app_name })
+
+  def with_title
+    render inertia: 'TestComponent', meta: [{ title: 'The Page' }]
+  end
+
+  def default_title
+    render inertia: 'TestComponent'
+  end
+
+  private
+
+  def app_name
+    'Inertia App'
+  end
+end

--- a/spec/dummy/app/controllers/inertia_meta_title_template_invalid_controller.rb
+++ b/spec/dummy/app/controllers/inertia_meta_title_template_invalid_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class InertiaMetaTitleTemplateInvalidController < ApplicationController
+  inertia_config(meta_title_template: '%s - Inertia App')
+
+  def basic
+    render inertia: 'TestComponent', meta: [{ title: 'The Page' }]
+  end
+end

--- a/spec/dummy/app/controllers/inertia_server_head_title_template_controller.rb
+++ b/spec/dummy/app/controllers/inertia_server_head_title_template_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class InertiaServerHeadTitleTemplateController < ApplicationController
+  inertia_config(
+    server_head: true,
+    layout: 'meta',
+    meta_title_template: ->(title) { title ? "#{title} - Inertia App" : 'Inertia App' }
+  )
+
+  def basic
+    render inertia: 'TestComponent', meta: [
+      { title: 'The Page' },
+      { name: 'description', content: 'Inertia rules', head_key: 'desc_key' }
+    ]
+  end
+
+  def default_title
+    render inertia: 'TestComponent'
+  end
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -170,6 +170,11 @@ Rails.application.routes.draw do
   get 'server_head_transformed_collision_meta' => 'inertia_server_head_transformed#collision'
   get 'server_head_custom_meta' => 'inertia_server_head_custom#basic'
   get 'server_head_ssr_meta' => 'inertia_server_head_ssr#basic'
+  get 'title_template_meta' => 'inertia_meta_title_template#with_title'
+  get 'title_template_default_meta' => 'inertia_meta_title_template#default_title'
+  get 'title_template_invalid_meta' => 'inertia_meta_title_template_invalid#basic'
+  get 'server_head_title_template_meta' => 'inertia_server_head_title_template#basic'
+  get 'server_head_title_template_default_meta' => 'inertia_server_head_title_template#default_title'
 
   post 'precognition_basic' => 'inertia_precognition_test#basic'
   post 'precognition_non_bang' => 'inertia_precognition_test#non_bang'

--- a/spec/inertia/meta_tag_rendering_spec.rb
+++ b/spec/inertia/meta_tag_rendering_spec.rb
@@ -288,4 +288,59 @@ RSpec.describe 'rendering inertia meta tags', type: :request do
       )
     end
   end
+
+  describe 'with a title template' do
+    it 'runs in controller context with the current title' do
+      get title_template_meta_path, headers: headers
+
+      expect(response.parsed_body['props']['_inertia_meta']).to eq(
+        [
+          {
+            'tagName' => 'title',
+            'innerContent' => 'The Page - Inertia App',
+            'headKey' => 'title',
+          }
+        ]
+      )
+    end
+
+    it 'synthesizes a default title when the page defines none' do
+      get title_template_default_meta_path, headers: headers
+
+      expect(response.parsed_body['props']['_inertia_meta']).to eq(
+        [
+          {
+            'tagName' => 'title',
+            'innerContent' => 'Inertia App',
+            'headKey' => 'title',
+          }
+        ]
+      )
+    end
+
+    it 'raises when the template is not callable' do
+      expect do
+        get title_template_invalid_meta_path, headers: headers
+      end.to raise_error(ArgumentError, /meta_title_template must be callable/)
+    end
+
+    context 'with server_head enabled' do
+      it 'applies the template before serializing to HTML strings' do
+        get server_head_title_template_meta_path, headers: headers
+
+        expect(response.parsed_body['props']['head']).to eq(
+          [
+            '<title data-inertia="title">The Page - Inertia App</title>',
+            '<meta name="description" content="Inertia rules" data-inertia="desc_key">'
+          ]
+        )
+      end
+
+      it 'renders the default title into the layout on the initial load' do
+        get server_head_title_template_default_meta_path
+
+        expect(response.body).to include('<title data-inertia="title">Inertia App</title>')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #250.

> **Stacked on #384** — based on the `server-head-meta-tags` branch; only the last commit is new. Retarget to `master` (or let GitHub auto-retarget) once #384 merges.

Adds a server-side counterpart of the client `title` callback, so an app-wide title suffix no longer has to be repeated in every action:

```ruby
InertiaRails.configure do |config|
  config.meta_title_template = ->(title) { title ? "#{title} - My App" : 'My App' }
end
```

With this template, `inertia_meta.add({ title: 'Events' })` renders `<title>Events - My App</title>` — including in the server-rendered HTML, so crawlers and link previews see the full title without running JavaScript.

## Behavior

- The callable receives the current title (or `nil` when the page sets none), runs in the controller context, and its result becomes the title. It runs even when a page defines no meta tags at all, so it can synthesize a default `<title>` — resolving the empty-tab-title footgun noted in the #384 docs (the setup note now points here instead of recommending a shared `before_action`).
- Implementation is a thin layer over the existing builder: the renderer re-adds the templated title via `inertia_meta.add`, and title tags already dedupe on their head key. This covers the props payload, the `inertia_meta_tags` layout render, SSR, and both the `server_head` and client-component modes.
- Non-callable values raise a clear `ArgumentError`. Configurable globally or per controller via `inertia_config`.
- Also exposes `inertia_meta.title` to read the current title.

## Interaction with the client-side `title` callback

The Inertia.js head manager applies the client `title` callback *on top of* server-provided titles (see `collect()` in `head.ts`), so combining both would apply the suffix twice. The cookbook and the Title Callback guide section now warn to use one or the other.

## Testing

- 5 new request specs covering template application, controller context, default-title synthesis, `server_head` HTML-string serialization, the initial-load layout render, and the non-callable error.
- `bundle exec rspec spec/inertia`: 841 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mb9KiGTPntkrF5rCybXaBY