### PR TITLE
docs: correct lazy data evaluation claims for AR relations

### DIFF
--- a/docs/guide/partial-reloads.md
+++ b/docs/guide/partial-reloads.md
@@ -161,20 +161,20 @@ export default () => (
 
 ## Lazy Data Evaluation
 
-For partial reloads to be most effective, be sure to also use lazy data evaluation when returning props from your server-side routes or controllers. This can be accomplished by wrapping all optional page data in a lambda.
+For partial reloads to be most effective, be sure to also use lazy data evaluation when returning props from your server-side routes or controllers. This can be accomplished by wrapping page data in a lambda.
 
 ```ruby
 class UsersController < ApplicationController
   def index
     render inertia: {
-      users: -> { User.all },
-      companies: -> { Company.all },
+      users: -> { User.all.as_json },
+      companies: -> { Company.all.as_json },
     }
   end
 end
 ```
 
-When Inertia performs a request, it will determine which data is required and only then will it evaluate the lambda. This can significantly increase the performance of pages that contain a lot of optional data.
+When Inertia performs a request, it will determine which data is required and only then will it evaluate the lambda. This can significantly increase the performance of pages that contain a lot of expensive data.
 
 Additionally, Inertia provides an `InertiaRails.optional` method to specify that a prop should never be included unless explicitly requested using the `only` option:
 
@@ -205,12 +205,15 @@ end
 
 Here's a summary of each approach:
 
-| Approach                                                                      | Standard Visits | Partial Reloads | Evaluated        |
-| :---------------------------------------------------------------------------- | :-------------- | :-------------- | :--------------- |
-| <span style="white-space: nowrap">`User.all`</span>                           | Always          | Optionally      | Always           |
-| <span style="white-space: nowrap">`-> { User.all }`</span>                    | Always          | Optionally      | Only when needed |
-| <span style="white-space: nowrap">`InertiaRails.optional { User.all }`</span> | Never           | Optionally      | Only when needed |
-| <span style="white-space: nowrap">`InertiaRails.always { User.all }`</span>   | Always          | Always          | Always           |
+| Approach                                                                              | Standard Visits | Partial Reloads | Evaluated        |
+| :------------------------------------------------------------------------------------ | :-------------- | :-------------- | :--------------- |
+| <span style="white-space: nowrap">`User.all.as_json`</span>                           | Always          | Optionally      | Always           |
+| <span style="white-space: nowrap">`-> { User.all.as_json }`</span>                    | Always          | Optionally      | Only when needed |
+| <span style="white-space: nowrap">`InertiaRails.optional { User.all.as_json }`</span> | Never           | Optionally      | Only when needed |
+| <span style="white-space: nowrap">`InertiaRails.always { User.all.as_json }`</span>   | Always          | Always          | Always           |
+
+> [!NOTE]
+> A lambda only helps when the block does real work. `User.all` on its own is lazy: the query doesn't run until the prop is serialized, so a skipped prop never hits the database. Wrap calls that execute immediately, like `.as_json`, `.count`, or `.pluck`.
 
 ## Preserving Errors
 


### PR DESCRIPTION
## Problem

The [Lazy Data Evaluation](https://inertia-rails.dev/guide/partial-reloads#lazy-data-evaluation) section used `User.all` — a lazy `ActiveRecord::Relation` — to make the case for wrapping props in a lambda, and the summary table claimed an unwrapped `User.all` is `Always` evaluated.

That's not what happens. A relation only runs its query when it is serialized, and `PropsResolver#deep_transform_props` skips excluded props before ever calling the evaluator, so a relation dropped by a partial reload never touches the database. Wrapping it in a lambda buys nothing.

The guide also contradicted the deferred props guide, which already documents the opposite:

> lazy values such as `ActiveRecord::Relation`s have their queries executed

## Change

- Examples and table rows now use `User.all.as_json`, which does its work eagerly in the controller — so every row of the table is true as written, and the `Always` vs `Only when needed` distinction is real.
- Added a note that self-lazy values cost nothing to leave unwrapped, and that wrapping pays off for eager work: `.to_a`, `.count`, `.map`, serializer calls, or HTTP requests.

No `as_json` recommendation is added as guidance — the encoder calls it anyway, and the two places where the evaluation point matters (`rescue:` and `cache:`) already force it inside the gem.

Docs only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxghyNs3bzLvhPMQRhpTpW