### PR TITLE
Add Inertia DevTools recorder support

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -93,6 +93,23 @@ end
 When enabled, props will be deep merged with shared data, combining hashes
 with the same keys instead of replacing them.
 
+### Inertia DevTools
+
+Inertia Rails includes the server-side recorder used by the Inertia DevTools browser extension. It is enabled and authorized only in the Rails development environment by default. Recorded entries are held in the current process only, capped at 500 entries, and expire after one hour.
+
+```ruby
+InertiaRails.configure do |config|
+  config.devtools_enabled = Rails.env.development?
+  config.devtools_max_entries = 500
+  config.devtools_entry_ttl = 1.hour
+  config.devtools_authorize = ->(request) { Rails.env.development? }
+end
+```
+
+`devtools_authorize` is evaluated for both recording and reads from `/_inertia/devtools/entries`. If DevTools must be enabled outside development, replace it with an application-specific authorization check. Avoid enabling recording broadly in production because entries can include request bodies, response bodies, and page props.
+
+The recorder redacts common credential headers and body keys. Application-specific sensitive values should still be kept out of Inertia props and request payloads.
+
 ### `default_render`
 
 **Default**: `false`

--- a/lib/inertia_rails.rb
+++ b/lib/inertia_rails.rb
@@ -10,6 +10,7 @@ require_relative 'inertia_rails/version'
 require_relative 'inertia_rails/configuration'
 require_relative 'inertia_rails/current'
 require_relative 'inertia_rails/errors'
+require_relative 'inertia_rails/dev_tools'
 
 # props
 require_relative 'inertia_rails/raw_json'

--- a/lib/inertia_rails/configuration.rb
+++ b/lib/inertia_rails/configuration.rb
@@ -91,6 +91,13 @@ module InertiaRails
       # Cache store for prop-level caching and SSR response caching.
       # Defaults to Rails.cache when nil.
       cache_store: nil,
+
+      # Inertia DevTools recorder options. Recording is development-only by
+      # default and entries are kept in a bounded, expiring in-memory store.
+      devtools_enabled: -> { Rails.env.development? },
+      devtools_max_entries: 500,
+      devtools_entry_ttl: 3600,
+      devtools_authorize: ->(_request) { Rails.env.development? },
     }.freeze
 
     OPTION_NAMES = DEFAULTS.keys.freeze
@@ -163,6 +170,11 @@ module InertiaRails
 
     def cache_store
       @options[:cache_store] || Rails.cache
+    end
+
+    # Returned without evaluating — the callable receives the current request.
+    def devtools_authorize
+      @options[:devtools_authorize]
     end
 
     # Normalized and validated at read time — ENV values arrive as strings, and callables are only evaluated here.

--- a/lib/inertia_rails/dev_tools.rb
+++ b/lib/inertia_rails/dev_tools.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+require 'time'
+
+require_relative 'dev_tools/store'
+require_relative 'dev_tools/entry_builder'
+require_relative 'dev_tools/middleware'
+
+module InertiaRails
+  module DevTools
+    ID_HEADER = 'X-Inertia-Devtools-Id'
+    OUTGOING_PARENT_HEADER = 'X-Inertia-Devtools-Parent-Out'
+    INCOMING_PARENT_HEADER = 'X-Inertia-Devtools-Parent'
+    TAB_HEADER = 'X-Inertia-Devtools-Tab'
+    VISIT_HEADER = 'X-Inertia-Devtools-Visit'
+    DEFERRED_HEADER = 'X-Inertia-Devtools-Deferred'
+    POLL_HEADER = 'X-Inertia-Devtools-Poll'
+
+    PAGE_ENV_KEY = 'inertia_rails.devtools.page'
+
+    class << self
+      def enabled?
+        !!InertiaRails.configuration.devtools_enabled
+      rescue StandardError
+        false
+      end
+
+      def authorized?(request)
+        authorizer = InertiaRails.configuration.devtools_authorize
+
+        authorizer.respond_to?(:call) && !!authorizer.call(request)
+      rescue StandardError
+        false
+      end
+
+      def capture_page(request, page)
+        return unless enabled?
+
+        request.set_header(PAGE_ENV_KEY, page)
+      end
+
+      def store
+        @store ||= Store.new
+      end
+
+      def reset!
+        @store&.clear
+      end
+    end
+  end
+end

--- a/lib/inertia_rails/dev_tools/entry_builder.rb
+++ b/lib/inertia_rails/dev_tools/entry_builder.rb
@@ -1,0 +1,380 @@
+# frozen_string_literal: true
+
+module InertiaRails
+  module DevTools
+    class EntryBuilder
+      BODY_LIMIT = 256_000
+      REDACTED = '[REDACTED]'
+      SENSITIVE_HEADERS = %w[
+        authorization cookie set-cookie x-csrf-token x-xsrf-token
+      ].freeze
+      SENSITIVE_KEYS = %w[
+        password password_confirmation current_password token _token access_token refresh_token
+        secret client_secret api_key
+      ].freeze
+
+      def initialize(request:, status:, headers:, body:, id:, batch_id:, started_at:)
+        @request = request
+        @status = status
+        @headers = headers
+        @body = body
+        @id = id
+        @batch_id = batch_id
+        @started_at = started_at
+        @page = request.get_header(PAGE_ENV_KEY)
+      end
+
+      def build
+        now = Time.now
+        component = page_value('component')
+        props, prop_values = build_props
+
+        {
+          '__meta' => {
+            'id' => @id,
+            'tabUuid' => header(TAB_HEADER),
+            'batchId' => @batch_id,
+            'timestamp' => now.utc.iso8601(3),
+            'utime' => now.to_f,
+            'method' => @request.request_method,
+            'url' => redact_url(@request.url),
+            'component' => component,
+            'requestType' => request_type(component),
+            'status' => @status,
+            'redirectLocation' => redirect_location,
+            'serverTimingMs' => elapsed_ms,
+            'visitId' => header(VISIT_HEADER),
+          },
+          'http' => {
+            'requestHeaders' => request_headers,
+            'responseHeaders' => response_headers,
+            'requestBody' => request_body,
+            'responseBody' => response_body,
+          },
+          'props' => props,
+          'propValues' => prop_values,
+          'route' => route,
+          'renderSource' => nil,
+          'componentPath' => nil,
+        }
+      end
+
+      private
+
+      def header(name)
+        value = @request.headers[name]
+        value.is_a?(String) && !value.empty? ? value : nil
+      end
+
+      def page_value(key)
+        return unless @page.is_a?(Hash)
+
+        @page[key] || @page[key.to_sym]
+      end
+
+      def request_type(component)
+        return 'precognition' if header('Precognition')
+        return component ? 'initial' : 'http' unless header('X-Inertia')
+        return 'deferred' if header(DEFERRED_HEADER)
+        return 'poll' if header(POLL_HEADER)
+        return 'partial' if header('X-Inertia-Partial-Component')
+        return 'prefetch' if prefetch?
+
+        'navigate'
+      end
+
+      def prefetch?
+        [header('Purpose'), header('Sec-Purpose')].compact.any? do |value|
+          value.downcase.split(/[;,]\s*/).include?('prefetch')
+        end
+      end
+
+      def elapsed_ms
+        ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - @started_at) * 1000).round(3)
+      end
+
+      def redirect_location
+        location = response_header('X-Inertia-Location') || response_header('Location')
+        return unless @status.between?(300, 399) || response_header('X-Inertia-Location')
+
+        location
+      end
+
+      def request_headers
+        @request.env.each_with_object({}) do |(key, value), result|
+          name = case key
+                 when 'CONTENT_TYPE' then 'Content-Type'
+                 when 'CONTENT_LENGTH' then 'Content-Length'
+                 else
+                   next unless key.start_with?('HTTP_')
+
+                   canonical_header(key.delete_prefix('HTTP_'))
+                 end
+
+          result[name] = sensitive_header?(name) ? REDACTED : value.to_s
+        end
+      end
+
+      def response_headers
+        @headers.each_with_object({}) do |(name, value), result|
+          normalized_name = canonical_header(name)
+          result[normalized_name] = sensitive_header?(name) ? REDACTED : Array(value).join(', ')
+        end
+      end
+
+      def sensitive_header?(name)
+        SENSITIVE_HEADERS.include?(name.to_s.downcase)
+      end
+
+      def canonical_header(name)
+        name.to_s.tr('_', '-').split('-').map(&:capitalize).join('-')
+      end
+
+      def request_body
+        return empty_body if %w[GET HEAD].include?(@request.request_method)
+        return omitted_body('non-inertia-request') unless header('X-Inertia')
+
+        parameters = @request.request_parameters
+        parameters = parameters.except('controller', 'action') if parameters.respond_to?(:except)
+        capture_value(parameters)
+      rescue StandardError
+        omitted_body('unserializable')
+      end
+
+      def response_body
+        return capture_value(@page) if @page.is_a?(Hash)
+        return omitted_body('non-textual') unless textual_response?
+
+        content = response_content
+        return omitted_body('streamed') if content.nil?
+
+        if json_response?
+          capture_value(JSON.parse(content))
+        else
+          capture_value(content)
+        end
+      rescue JSON::ParserError
+        capture_value(content)
+      end
+
+      def response_content
+        chunks = if @body.is_a?(Array)
+                   @body
+                 elsif @body.respond_to?(:to_ary)
+                   @body.to_ary
+                 end
+        return unless chunks&.all?(String)
+
+        chunks.join
+      end
+
+      def textual_response?
+        content_type = response_header('Content-Type').to_s.downcase
+
+        content_type.start_with?('text/') ||
+          content_type.match?(/json|javascript|xml|x-www-form-urlencoded|svg/)
+      end
+
+      def json_response?
+        response_header('Content-Type').to_s.downcase.include?('json')
+      end
+
+      def capture_value(value)
+        normalized = normalize(value)
+        encoded = JSON.generate(normalized)
+        return omitted_body('too-large') if encoded.bytesize > BODY_LIMIT
+
+        return empty_body if normalized.nil? || normalized == '' || normalized == {} || normalized == []
+
+        {
+          'status' => 'present',
+          'value' => redact(normalized),
+        }
+      rescue JSON::GeneratorError, EncodingError
+        omitted_body('unserializable')
+      end
+
+      def normalize(value)
+        JSON.parse(JSON.generate(summarize_uploads(value).as_json))
+      end
+
+      def summarize_uploads(value)
+        case value
+        when Hash
+          value.transform_values { |item| summarize_uploads(item) }
+        when Array
+          value.map { |item| summarize_uploads(item) }
+        when ActionDispatch::Http::UploadedFile
+          {
+            'name' => value.original_filename,
+            'contentType' => value.content_type,
+            'size' => value.size,
+          }
+        else
+          value
+        end
+      end
+
+      def redact(value)
+        case value
+        when Hash
+          value.each_with_object({}) do |(key, item), result|
+            result[key] = sensitive_key?(key) ? REDACTED : redact(item)
+          end
+        when Array
+          value.map { |item| redact(item) }
+        else
+          value
+        end
+      end
+
+      def sensitive_key?(key)
+        SENSITIVE_KEYS.include?(key.to_s.downcase)
+      end
+
+      def redact_url(url)
+        uri = URI.parse(url)
+        return url if uri.query.nil?
+
+        pairs = URI.decode_www_form(uri.query).map do |key, value|
+          [key, sensitive_key?(key) ? REDACTED : value]
+        end
+        uri.query = URI.encode_www_form(pairs)
+        uri.to_s
+      rescue URI::InvalidURIError
+        url
+      end
+
+      def build_props
+        values = page_value('props')
+        values = {} unless values.is_a?(Hash)
+        normalized_values = redact(normalize(values))
+        metadata = {}
+
+        normalized_values.each_key do |key|
+          metadata[key.to_s] = {
+            'shared' => shared_props.include?(key.to_s),
+            'inertiaType' => nil,
+          }
+        end
+
+        add_deferred_metadata(metadata)
+        add_array_metadata(metadata, 'mergeProps', 'merge', 'mergeDirection' => 'append')
+        add_array_metadata(metadata, 'prependProps', 'merge', 'mergeDirection' => 'prepend')
+        add_array_metadata(metadata, 'deepMergeProps', 'merge', 'deepMerge' => true)
+        add_hash_metadata(metadata, 'scrollProps', 'scroll')
+        add_once_metadata(metadata)
+        add_flag_metadata(metadata, 'rescuedProps', 'rescued')
+
+        parse_header_values('X-Inertia-Reset').each do |path|
+          ensure_prop(metadata, path)['reset'] = true
+        end
+
+        prop_values = metadata.each_key.with_object({}) do |path, result|
+          found, value = value_at_path(normalized_values, path)
+          result[path] = value if found
+        end
+
+        [metadata, prop_values]
+      rescue JSON::GeneratorError, EncodingError
+        [{}, {}]
+      end
+
+      def shared_props
+        Array(page_value('sharedProps')).map(&:to_s)
+      end
+
+      def add_deferred_metadata(metadata)
+        deferred = page_value('deferredProps')
+        return unless deferred.is_a?(Hash)
+
+        deferred.each do |group, paths|
+          Array(paths).each do |path|
+            ensure_prop(metadata, path).merge!(
+              'inertiaType' => 'defer',
+              'deferGroup' => group.to_s
+            )
+          end
+        end
+      end
+
+      def add_array_metadata(metadata, page_key, inertia_type, extra = {})
+        Array(page_value(page_key)).each do |path|
+          ensure_prop(metadata, path).merge!({ 'inertiaType' => inertia_type }.merge(extra))
+        end
+      end
+
+      def add_hash_metadata(metadata, page_key, inertia_type)
+        value = page_value(page_key)
+        return unless value.is_a?(Hash)
+
+        value.each_key do |path|
+          ensure_prop(metadata, path).merge!('inertiaType' => inertia_type, 'mergeDirection' => 'append')
+        end
+      end
+
+      def add_once_metadata(metadata)
+        value = page_value('onceProps')
+        return unless value.is_a?(Hash)
+
+        value.each_value do |details|
+          path = details.is_a?(Hash) ? details['prop'] || details[:prop] : nil
+          ensure_prop(metadata, path).merge!('inertiaType' => 'once', 'once' => true) if path
+        end
+      end
+
+      def add_flag_metadata(metadata, page_key, flag)
+        Array(page_value(page_key)).each { |path| ensure_prop(metadata, path)[flag] = true }
+      end
+
+      def ensure_prop(metadata, path)
+        metadata[path.to_s] ||= { 'shared' => shared_props.include?(path.to_s), 'inertiaType' => nil }
+      end
+
+      def parse_header_values(name)
+        header(name).to_s.split(',').map(&:strip).reject(&:empty?)
+      end
+
+      def value_at_path(values, path)
+        current = values
+
+        path.to_s.split('.').each do |part|
+          key = current.is_a?(Array) ? Integer(part, exception: false) : part
+          return [false, nil] unless key && current.respond_to?(:key?) && current.key?(key)
+
+          current = current[key]
+        end
+
+        [true, current]
+      end
+
+      def route
+        controller = @request.get_header('action_controller.instance')
+        action = if controller
+                   "#{controller.class.name}##{controller.action_name}"
+                 elsif @request.path_parameters[:controller]
+                   "#{@request.path_parameters[:controller]}##{@request.path_parameters[:action]}"
+                 end
+
+        {
+          'name' => @request.get_header('action_dispatch.route_name'),
+          'uri' => @request.get_header('action_dispatch.route_uri_pattern') || @request.path,
+          'action' => action,
+        }
+      end
+
+      def response_header(name)
+        pair = @headers.find { |key, _value| key.to_s.casecmp?(name) }
+        pair&.last
+      end
+
+      def empty_body
+        { 'status' => 'empty' }
+      end
+
+      def omitted_body(reason)
+        { 'status' => 'omitted', 'reason' => reason }
+      end
+    end
+  end
+end

--- a/lib/inertia_rails/dev_tools/middleware.rb
+++ b/lib/inertia_rails/dev_tools/middleware.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+module InertiaRails
+  module DevTools
+    class Middleware
+      ENTRIES_PATH = %r{\A/_inertia/devtools/entries(?:/([^/]+))?\z}
+      ID_PATTERN = /\A[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/i
+
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        request = ActionDispatch::Request.new(env)
+
+        return endpoint_response(request) if devtools_path?(request.path)
+
+        started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        status, headers, body = @app.call(env)
+        return [status, headers, body] unless DevTools.enabled? && DevTools.authorized?(request)
+
+        record(request, status, headers, body, started_at)
+      rescue StandardError => e
+        raise if status.nil?
+
+        Rails.logger&.warn("[inertia-rails] DevTools recorder skipped an entry: #{e.class}: #{e.message}")
+        [status, headers, body]
+      end
+
+      private
+
+      def record(request, status, headers, body, started_at)
+        id = SecureRandom.uuid
+        batch_id = request.headers['X-Inertia'] ? present_header(request, INCOMING_PARENT_HEADER) : nil
+        outgoing_parent = prefetch?(request) ? id : batch_id || id
+        inject_initial_id = initial_html_response?(request, status, headers)
+        entry_headers = headers.to_h.dup
+
+        entry_headers[ID_HEADER] = id
+        entry_headers[OUTGOING_PARENT_HEADER] = outgoing_parent
+        delete_injected_body_headers(entry_headers) if inject_initial_id
+
+        entry = EntryBuilder.new(
+          request: request,
+          status: status,
+          headers: entry_headers,
+          body: body,
+          id: id,
+          batch_id: batch_id,
+          started_at: started_at
+        ).build
+        DevTools.store.record(entry)
+
+        headers[ID_HEADER] = id
+        headers[OUTGOING_PARENT_HEADER] = outgoing_parent
+
+        if inject_initial_id
+          delete_injected_body_headers(headers)
+          body = InjectingBody.new(body, devtools_tag(id))
+        end
+
+        [status, headers, body]
+      end
+
+      def endpoint_response(request)
+        return json_response({ message: 'Not found.' }, 404) unless DevTools.enabled?
+        return json_response({ message: 'Forbidden.' }, 403) unless DevTools.authorized?(request)
+        return json_response({ message: 'Not found.' }, 404) unless request.get?
+
+        request.set_header('HTTP_X_REQUESTED_WITH', 'XMLHttpRequest')
+        match = ENTRIES_PATH.match(request.path)
+        id = match && match[1]
+
+        return list_response(request) if match && id.nil?
+        return json_response({ message: 'Not found.' }, 404) unless id&.match?(ID_PATTERN)
+
+        entry = DevTools.store.fetch(id)
+        entry ? json_response(entry) : json_response({ message: 'Not found.' }, 404)
+      end
+
+      def list_response(request)
+        entries = DevTools.store.all
+        component = request.params['component']
+        include_types = comma_list(request.params['type'])
+        exclude_types = comma_list(request.params['exclude'])
+
+        entries = entries.select { |entry| entry.dig('__meta', 'component') == component } if component.present?
+        if include_types.any?
+          entries = entries.select { |entry| include_types.include?(entry.dig('__meta', 'requestType')) }
+        end
+        if exclude_types.any?
+          entries = entries.reject { |entry| exclude_types.include?(entry.dig('__meta', 'requestType')) }
+        end
+
+        offset = [request.params['offset'].to_i, 0].max
+        entries = entries.drop(offset)
+        limit = request.params['limit']
+        entries = entries.first([limit.to_i, 1].max) if limit.present?
+
+        json_response(entries)
+      end
+
+      def comma_list(value)
+        value.to_s.split(',').map(&:strip).reject(&:empty?)
+      end
+
+      def json_response(payload, status = 200)
+        body = JSON.generate(payload)
+        [
+          status,
+          {
+            'Content-Type' => 'application/json; charset=utf-8',
+            'Content-Length' => body.bytesize.to_s,
+            'Cache-Control' => 'no-store',
+            'X-Content-Type-Options' => 'nosniff',
+          },
+          [body]
+        ]
+      end
+
+      def devtools_path?(path)
+        path == '/_inertia/devtools/entries' || path.start_with?('/_inertia/devtools/entries/')
+      end
+
+      def initial_html_response?(request, status, headers)
+        return false if request.headers['X-Inertia']
+        return false unless status == 200
+        return false unless request.get_header(PAGE_ENV_KEY).is_a?(Hash)
+
+        content_type = response_header(headers, 'Content-Type').to_s.downcase
+        content_type.include?('text/html')
+      end
+
+      def devtools_tag(id)
+        %(<script data-inertia-devtools-id type="application/json">#{JSON.generate(id)}</script>)
+      end
+
+      def present_header(request, name)
+        value = request.headers[name]
+        value.is_a?(String) && !value.empty? ? value : nil
+      end
+
+      def prefetch?(request)
+        [request.headers['Purpose'], request.headers['Sec-Purpose']].compact.any? do |value|
+          value.downcase.split(/[;,]\s*/).include?('prefetch')
+        end
+      end
+
+      def response_header(headers, name)
+        pair = headers.find { |key, _value| key.to_s.casecmp?(name) }
+        pair&.last
+      end
+
+      def delete_response_header(headers, name)
+        key = headers.keys.find { |candidate| candidate.to_s.casecmp?(name) }
+        headers.delete(key) if key
+      end
+
+      def delete_injected_body_headers(headers)
+        %w[Content-Length ETag Last-Modified].each do |name|
+          delete_response_header(headers, name)
+        end
+      end
+    end
+
+    class InjectingBody
+      def initialize(body, tag)
+        @body = body
+        @tag = tag
+      end
+
+      def each
+        content = +''
+        @body.each { |chunk| content << chunk.to_s }
+
+        index = content.downcase.rindex('</body>')
+        index ? content.insert(index, @tag) : content << @tag
+        yield content
+      end
+
+      def close
+        return if @closed
+
+        @closed = true
+        @body.close if @body.respond_to?(:close)
+      end
+    end
+  end
+end

--- a/lib/inertia_rails/dev_tools/store.rb
+++ b/lib/inertia_rails/dev_tools/store.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module InertiaRails
+  module DevTools
+    class Store
+      def initialize
+        @entries = {}
+        @mutex = Mutex.new
+      end
+
+      def record(entry)
+        @mutex.synchronize do
+          prune_expired!
+          @entries[entry.dig('__meta', 'id')] = entry
+          @entries.shift while @entries.length > max_entries
+        end
+      end
+
+      def fetch(id)
+        @mutex.synchronize do
+          prune_expired!
+          @entries[id]
+        end
+      end
+
+      def all
+        @mutex.synchronize do
+          prune_expired!
+          @entries.values.dup
+        end
+      end
+
+      def clear
+        @mutex.synchronize { @entries.clear }
+      end
+
+      private
+
+      def max_entries
+        [Integer(InertiaRails.configuration.devtools_max_entries), 1].max
+      rescue ArgumentError, TypeError
+        500
+      end
+
+      def entry_ttl
+        Float(InertiaRails.configuration.devtools_entry_ttl)
+      rescue ArgumentError, TypeError
+        3600.0
+      end
+
+      def prune_expired!
+        ttl = entry_ttl
+        return if ttl <= 0
+
+        cutoff = Time.now.to_f - ttl
+        @entries.delete_if { |_id, entry| entry.dig('__meta', 'utime').to_f < cutoff }
+      end
+    end
+  end
+end

--- a/lib/inertia_rails/engine.rb
+++ b/lib/inertia_rails/engine.rb
@@ -3,6 +3,9 @@
 module InertiaRails
   class Engine < ::Rails::Engine
     initializer 'inertia_rails.configure_rails_initialization', before: :build_middleware_stack do |app|
+      # Wrap conditional response handling so recorded status/headers match what
+      # the browser receives while retaining access to cookies and sessions.
+      app.middleware.insert_before ::Rack::ConditionalGet, ::InertiaRails::DevTools::Middleware
       app.middleware.use ::InertiaRails::Middleware
     end
 

--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -46,6 +46,8 @@ module InertiaRails
     def render
       ActiveSupport::Notifications.instrument('render.inertia_rails',
                                               component: @component, partial: partial_reload?, ssr: false) do |payload|
+        InertiaRails::DevTools.capture_page(@request, page)
+
         vary = @response.headers['Vary'].to_s.split(',').map(&:strip).reject(&:empty?)
         vary << 'X-Inertia' if vary.none? { |value| value.casecmp?('X-Inertia') }
         @response.headers['Vary'] = vary.join(', ')

--- a/spec/inertia/configuration_spec.rb
+++ b/spec/inertia/configuration_spec.rb
@@ -113,6 +113,17 @@ RSpec.describe 'Inertia configuration', type: :request do
         expect(config.meta_prop).to eq :custom_meta
       end
     end
+
+    describe 'DevTools defaults' do
+      it 'is disabled and unauthorized outside development with bounded, expiring storage' do
+        config = InertiaRails::Configuration.default
+
+        expect(config.devtools_enabled).to be(false)
+        expect(config.devtools_authorize.call(ActionDispatch::TestRequest.create)).to be(false)
+        expect(config.devtools_max_entries).to eq(500)
+        expect(config.devtools_entry_ttl).to eq(3600)
+      end
+    end
   end
 
   describe 'inertia_config' do

--- a/spec/inertia/dev_tools_entry_builder_spec.rb
+++ b/spec/inertia/dev_tools_entry_builder_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.describe InertiaRails::DevTools::EntryBuilder do
+  def build_entry(body:, content_type:)
+    request = ActionDispatch::TestRequest.create
+
+    described_class.new(
+      request: request,
+      status: 200,
+      headers: { 'Content-Type' => content_type },
+      body: body,
+      id: SecureRandom.uuid,
+      batch_id: nil,
+      started_at: Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    ).build
+  end
+
+  it 'captures ordinary JSON response bodies' do
+    entry = build_entry(body: ['{"ok":true}'], content_type: 'application/json')
+
+    expect(entry.dig('http', 'responseBody')).to eq(
+      'status' => 'present',
+      'value' => { 'ok' => true }
+    )
+  end
+
+  it 'omits binary response bodies' do
+    entry = build_entry(body: ["\x00\x01"], content_type: 'application/octet-stream')
+
+    expect(entry.dig('http', 'responseBody')).to eq(
+      'status' => 'omitted',
+      'reason' => 'non-textual'
+    )
+  end
+
+  it 'omits streamed response bodies without consuming them' do
+    streamed_body = Class.new do
+      def each
+        yield 'streamed'
+      end
+    end.new
+
+    entry = build_entry(body: streamed_body, content_type: 'text/plain')
+
+    expect(entry.dig('http', 'responseBody')).to eq(
+      'status' => 'omitted',
+      'reason' => 'streamed'
+    )
+  end
+
+  it 'omits response bodies over the capture limit' do
+    body = ['x' * (described_class::BODY_LIMIT + 1)]
+    entry = build_entry(body: body, content_type: 'text/plain')
+
+    expect(entry.dig('http', 'responseBody')).to eq(
+      'status' => 'omitted',
+      'reason' => 'too-large'
+    )
+  end
+end
+
+RSpec.describe InertiaRails::DevTools::InjectingBody do
+  it 'injects before the closing body tag and preserves the remaining response' do
+    source = ['<html><body>hello', '</body></html>']
+    output = described_class.new(source, '<script>id</script>').to_enum.to_a
+
+    expect(output.join).to eq('<html><body>hello<script>id</script></body></html>')
+  end
+end

--- a/spec/inertia/dev_tools_spec.rb
+++ b/spec/inertia/dev_tools_spec.rb
@@ -1,0 +1,224 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Inertia DevTools recorder', type: :request do
+  before { InertiaRails::DevTools.reset! }
+  after { InertiaRails::DevTools.reset! }
+
+  context 'when disabled' do
+    with_inertia_config devtools_enabled: false
+
+    it 'does not record or expose discovery artifacts' do
+      get empty_test_path
+
+      expect(response.headers[InertiaRails::DevTools::ID_HEADER]).to be_nil
+      expect(response.body).not_to include('data-inertia-devtools-id')
+      expect(InertiaRails::DevTools.store.all).to be_empty
+    end
+
+    it 'does not expose the entries endpoint' do
+      get '/_inertia/devtools/entries'
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context 'when enabled and authorized' do
+    with_inertia_config(
+      devtools_enabled: true,
+      devtools_authorize: ->(_request) { true },
+      devtools_max_entries: 500,
+      devtools_entry_ttl: 3600
+    )
+
+    it 'emits a discovery header and injects the initial page discovery tag' do
+      get empty_test_path
+
+      id = response.headers[InertiaRails::DevTools::ID_HEADER]
+
+      expect(id).to match(InertiaRails::DevTools::Middleware::ID_PATTERN)
+      expect(response.headers[InertiaRails::DevTools::OUTGOING_PARENT_HEADER]).to eq(id)
+      expect(response.body).to include(
+        %(<script data-inertia-devtools-id type="application/json">#{id.to_json}</script>)
+      )
+    end
+
+    it 'returns an extension-compatible entry for a known ID' do
+      get props_path, headers: {
+        'X-Inertia' => 'true',
+        'X-Inertia-Devtools-Tab' => 'tab-123',
+        'X-Inertia-Devtools-Visit' => 'visit-456',
+        'X-Inertia-Devtools-Parent' => 'parent-789',
+      }
+
+      id = response.headers[InertiaRails::DevTools::ID_HEADER]
+      expect(response.headers[InertiaRails::DevTools::OUTGOING_PARENT_HEADER]).to eq('parent-789')
+
+      get "/_inertia/devtools/entries/#{id}"
+
+      expect(response).to have_http_status(:ok)
+      entry = response.parsed_body
+
+      expect(entry.dig('__meta', 'id')).to eq(id)
+      expect(entry['__meta']).to include(
+        'tabUuid' => 'tab-123',
+        'visitId' => 'visit-456',
+        'batchId' => 'parent-789',
+        'method' => 'GET',
+        'status' => 200,
+        'requestType' => 'navigate',
+        'component' => 'TestComponent'
+      )
+      expect(entry.dig('__meta', 'url')).to eq("http://www.example.com#{props_path}")
+      expect(entry.dig('__meta', 'timestamp')).to be_present
+      expect(entry.dig('__meta', 'serverTimingMs')).to be_a(Numeric)
+      expect(entry.dig('http', 'requestHeaders')).to be_a(Hash)
+      expect(entry.dig('http', 'responseHeaders', InertiaRails::DevTools::ID_HEADER)).to eq(id)
+      expect(entry.dig('http', 'responseBody', 'status')).to eq('present')
+      expect(entry.dig('http', 'responseBody', 'value', 'component')).to eq('TestComponent')
+      expect(entry['props']).to be_a(Hash)
+      expect(entry['propValues']).to be_a(Hash)
+      expect(entry['route']).to include('uri' => props_path)
+      expect(entry.dig('route', 'action')).to match(/#props\z/)
+      expect(entry).to include('renderSource' => nil, 'componentPath' => nil)
+      expect(InertiaRails::DevTools.store.all.one?).to be(true)
+    end
+
+    it 'captures and redacts Inertia request bodies' do
+      post redirect_test_path,
+           params: { password: 'secret', name: 'Alice' },
+           headers: { 'X-Inertia' => 'true' }
+
+      entry = InertiaRails::DevTools.store.fetch(response.headers[InertiaRails::DevTools::ID_HEADER])
+
+      expect(entry.dig('http', 'requestBody')).to eq(
+        'status' => 'present',
+        'value' => { 'password' => '[REDACTED]', 'name' => 'Alice' }
+      )
+    end
+
+    it 'classifies initial, partial, deferred, poll, and prefetch requests' do
+      get empty_test_path
+      initial_id = response.headers[InertiaRails::DevTools::ID_HEADER]
+
+      get empty_test_path, headers: {
+        'X-Inertia' => 'true',
+        'X-Inertia-Partial-Component' => 'EmptyTestComponent',
+      }
+      partial_id = response.headers[InertiaRails::DevTools::ID_HEADER]
+
+      get empty_test_path, headers: {
+        'X-Inertia' => 'true',
+        'X-Inertia-Partial-Component' => 'EmptyTestComponent',
+        'X-Inertia-Devtools-Deferred' => '1',
+      }
+      deferred_id = response.headers[InertiaRails::DevTools::ID_HEADER]
+
+      get empty_test_path, headers: {
+        'X-Inertia' => 'true',
+        'X-Inertia-Devtools-Poll' => '1',
+      }
+      poll_id = response.headers[InertiaRails::DevTools::ID_HEADER]
+
+      get empty_test_path, headers: {
+        'X-Inertia' => 'true',
+        'Purpose' => 'prefetch',
+      }
+      prefetch_id = response.headers[InertiaRails::DevTools::ID_HEADER]
+
+      expect(recorded_type(initial_id)).to eq('initial')
+      expect(recorded_type(partial_id)).to eq('partial')
+      expect(recorded_type(deferred_id)).to eq('deferred')
+      expect(recorded_type(poll_id)).to eq('poll')
+      expect(recorded_type(prefetch_id)).to eq('prefetch')
+    end
+
+    it 'returns 404 for missing, malformed, and traversal-like IDs' do
+      get "/_inertia/devtools/entries/#{SecureRandom.uuid}"
+      expect(response).to have_http_status(:not_found)
+
+      get '/_inertia/devtools/entries/not-an-entry-id'
+      expect(response).to have_http_status(:not_found)
+
+      get '/_inertia/devtools/entries/../secret'
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'lists and filters recorded entries' do
+      get empty_test_path
+      get empty_test_path, headers: {
+        'X-Inertia' => 'true',
+        'X-Inertia-Partial-Component' => 'EmptyTestComponent',
+      }
+      get empty_test_path, headers: {
+        'X-Inertia' => 'true',
+        'X-Inertia-Devtools-Poll' => '1',
+      }
+
+      get '/_inertia/devtools/entries', params: { type: 'partial,poll', limit: 1 }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.length).to eq(1)
+      expect(%w[partial poll]).to include(response.parsed_body.dig(0, '__meta', 'requestType'))
+    end
+  end
+
+  context 'when enabled but unauthorized' do
+    with_inertia_config(
+      devtools_enabled: true,
+      devtools_authorize: ->(_request) { false }
+    )
+
+    it 'does not record application responses and forbids entry reads' do
+      get empty_test_path
+
+      expect(response.headers[InertiaRails::DevTools::ID_HEADER]).to be_nil
+      expect(InertiaRails::DevTools.store.all).to be_empty
+
+      get "/_inertia/devtools/entries/#{SecureRandom.uuid}"
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  context 'with a small entry limit' do
+    with_inertia_config(
+      devtools_enabled: true,
+      devtools_authorize: ->(_request) { true },
+      devtools_max_entries: 2
+    )
+
+    it 'evicts the oldest entries' do
+      ids = 3.times.map do
+        get empty_test_path, headers: { 'X-Inertia' => 'true' }
+        response.headers[InertiaRails::DevTools::ID_HEADER]
+      end
+
+      expect(InertiaRails::DevTools.store.all.map { |entry| entry.dig('__meta', 'id') }).to eq(ids.last(2))
+
+      get "/_inertia/devtools/entries/#{ids.first}"
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context 'with a short entry lifetime' do
+    with_inertia_config(
+      devtools_enabled: true,
+      devtools_authorize: ->(_request) { true },
+      devtools_entry_ttl: 1
+    )
+
+    it 'expires old entries' do
+      get empty_test_path, headers: { 'X-Inertia' => 'true' }
+      id = response.headers[InertiaRails::DevTools::ID_HEADER]
+
+      travel 2.seconds do
+        get "/_inertia/devtools/entries/#{id}"
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  def recorded_type(id)
+    InertiaRails::DevTools.store.fetch(id).dig('__meta', 'requestType')
+  end
+end


### PR DESCRIPTION
## Summary

Adds server-side Inertia DevTools recorder support to the Rails adapter.

The Chrome DevTools extension is backend-agnostic, but request inspection depends on each server adapter implementing the recorder protocol. Previously, Rails apps did not emit `X-Inertia-Devtools-Id` or expose `/_inertia/devtools/entries/:id`, so the panel could open without showing requests.

This PR implements the Rails side of the current protocol. No changes to `inertiajs/inertia-devtools` are required.

## What changed

- Records request entries in a bounded, expiring, thread-safe in-memory store.
- Emits `X-Inertia-Devtools-Id` and `X-Inertia-Devtools-Parent-Out`.
- Injects `script[data-inertia-devtools-id]` into initial full-page Inertia HTML responses.
- Exposes show and filtered-list endpoints under `/_inertia/devtools/entries`.
- Captures correlation headers, request type, timing, final response status, request/response headers and bodies, page props, Inertia prop metadata, and Rails route/controller metadata.
- Redacts common credential headers and payload keys.
- Deliberately omits streamed, binary, unserializable, and oversized response bodies.

## Safety

- Recording and reads are development-only by default.
- A configurable request authorization hook gates both recording and entry reads.
- Entries default to a 500-entry limit and one-hour TTL.
- DevTools endpoint requests bypass application routing and are never recorded.
- Recorder failures are isolated from normal application responses.

## Validation

- `bundle exec rake`
  - 930 RSpec examples, 0 failures
  - 52 Minitest runs / 98 assertions, 0 failures
  - 175 files inspected by RuboCop, no offenses

The full task was run with Node 24 because the current installer test toolchain requires Node `^20.19.0 || >=22.12.0`.
