### PR TITLE
Add scroll_props and once_props testing helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Add testing helpers for scroll props and once props (@onk)
 * Add `config.server_head` to serialize meta tags as HTML strings into the `head` prop for the `serverHead` option of `createInertiaApp` (Inertia.js v3.5+), replacing the client-side cookbook component (@skryukov)
 * Add `meta_title_template` configuration option — a callable applied to the `<title>` tag of server driven meta tags; it receives the current title (or `nil`) and can provide a default for pages without one (@skryukov)
 * Add `ActiveSupport::Notifications` instrumentation: `render.inertia_rails`, `resolve_props.inertia_rails`, and `ssr.inertia_rails` events (@skryukov)

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -40,7 +40,7 @@ RSpec helpers are automatically available in all request specs. Minitest helpers
 
 Both RSpec and Minitest provide matchers/assertions for testing Inertia responses. In RSpec, negation is done with `not_to`.
 
-The `inertia` helper gives you direct access to `inertia.props`, `inertia.component`, `inertia.view_data`, `inertia.flash`, and `inertia.deferred_props`.
+The `inertia` helper gives you direct access to `inertia.props`, `inertia.component`, `inertia.view_data`, `inertia.flash`, `inertia.deferred_props`, `inertia.scroll_props`, and `inertia.once_props`.
 
 | Description               | RSpec                  | Minitest                                                            |
 | ------------------------- | ---------------------- | ------------------------------------------------------------------- |

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -56,6 +56,12 @@ The `inertia` helper gives you direct access to `inertia.props`, `inertia.compon
 | Flash (exact match)       | `have_exact_flash`     | `assert_inertia_flash_equal` / `refute_inertia_flash_equal`         |
 | Flash key absent          | `have_no_flash`        | `assert_no_inertia_flash`                                           |
 | Deferred props            | `have_deferred_props`  | `assert_inertia_deferred_props` / `refute_inertia_deferred_props`   |
+| Scroll props (partial match) | `have_scroll_props` | `assert_inertia_scroll_props` / `refute_inertia_scroll_props`       |
+| Scroll props (exact match)   | `have_exact_scroll_props` | `assert_inertia_scroll_props_equal` / `refute_inertia_scroll_props_equal` |
+| Scroll prop key absent     | `have_no_scroll_prop`  | `assert_no_inertia_scroll_prop`                                     |
+| Once props (partial match)   | `have_once_props`   | `assert_inertia_once_props` / `refute_inertia_once_props`           |
+| Once props (exact match)     | `have_exact_once_props` | `assert_inertia_once_props_equal` / `refute_inertia_once_props_equal` |
+| Once prop key absent       | `have_no_once_prop`    | `assert_no_inertia_once_prop`                                       |
 
 :::tabs key:tests
 

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -42,26 +42,26 @@ Both RSpec and Minitest provide matchers/assertions for testing Inertia response
 
 The `inertia` helper gives you direct access to `inertia.props`, `inertia.component`, `inertia.view_data`, `inertia.flash`, `inertia.deferred_props`, `inertia.scroll_props`, and `inertia.once_props`.
 
-| Description               | RSpec                  | Minitest                                                            |
-| ------------------------- | ---------------------- | ------------------------------------------------------------------- |
-| Inertia response          | `be_inertia_response`  | `assert_inertia_response` / `refute_inertia_response`               |
-| Component name            | `render_component`     | `assert_inertia_component` / `refute_inertia_component`             |
-| Props (partial match)     | `have_props`           | `assert_inertia_props` / `refute_inertia_props`                     |
-| Props (exact match)       | `have_exact_props`     | `assert_inertia_props_equal` / `refute_inertia_props_equal`         |
-| Prop key absent           | `have_no_prop`         | `assert_no_inertia_prop`                                            |
-| View data (partial match) | `have_view_data`       | `assert_inertia_view_data` / `refute_inertia_view_data`             |
-| View data (exact match)   | `have_exact_view_data` | `assert_inertia_view_data_equal` / `refute_inertia_view_data_equal` |
-| View data key absent      | `have_no_view_data`    | `assert_no_inertia_view_data`                                       |
-| Flash (partial match)     | `have_flash`           | `assert_inertia_flash` / `refute_inertia_flash`                     |
-| Flash (exact match)       | `have_exact_flash`     | `assert_inertia_flash_equal` / `refute_inertia_flash_equal`         |
-| Flash key absent          | `have_no_flash`        | `assert_no_inertia_flash`                                           |
-| Deferred props            | `have_deferred_props`  | `assert_inertia_deferred_props` / `refute_inertia_deferred_props`   |
-| Scroll props (partial match) | `have_scroll_props` | `assert_inertia_scroll_props` / `refute_inertia_scroll_props`       |
+| Description                  | RSpec                     | Minitest                                                                  |
+| ---------------------------- | ------------------------- | ------------------------------------------------------------------------- |
+| Inertia response             | `be_inertia_response`     | `assert_inertia_response` / `refute_inertia_response`                     |
+| Component name               | `render_component`        | `assert_inertia_component` / `refute_inertia_component`                   |
+| Props (partial match)        | `have_props`              | `assert_inertia_props` / `refute_inertia_props`                           |
+| Props (exact match)          | `have_exact_props`        | `assert_inertia_props_equal` / `refute_inertia_props_equal`               |
+| Prop key absent              | `have_no_prop`            | `assert_no_inertia_prop`                                                  |
+| View data (partial match)    | `have_view_data`          | `assert_inertia_view_data` / `refute_inertia_view_data`                   |
+| View data (exact match)      | `have_exact_view_data`    | `assert_inertia_view_data_equal` / `refute_inertia_view_data_equal`       |
+| View data key absent         | `have_no_view_data`       | `assert_no_inertia_view_data`                                             |
+| Flash (partial match)        | `have_flash`              | `assert_inertia_flash` / `refute_inertia_flash`                           |
+| Flash (exact match)          | `have_exact_flash`        | `assert_inertia_flash_equal` / `refute_inertia_flash_equal`               |
+| Flash key absent             | `have_no_flash`           | `assert_no_inertia_flash`                                                 |
+| Deferred props               | `have_deferred_props`     | `assert_inertia_deferred_props` / `refute_inertia_deferred_props`         |
+| Scroll props (partial match) | `have_scroll_props`       | `assert_inertia_scroll_props` / `refute_inertia_scroll_props`             |
 | Scroll props (exact match)   | `have_exact_scroll_props` | `assert_inertia_scroll_props_equal` / `refute_inertia_scroll_props_equal` |
-| Scroll prop key absent     | `have_no_scroll_prop`  | `assert_no_inertia_scroll_prop`                                     |
-| Once props (partial match)   | `have_once_props`   | `assert_inertia_once_props` / `refute_inertia_once_props`           |
-| Once props (exact match)     | `have_exact_once_props` | `assert_inertia_once_props_equal` / `refute_inertia_once_props_equal` |
-| Once prop key absent       | `have_no_once_prop`    | `assert_no_inertia_once_prop`                                       |
+| Scroll prop key absent       | `have_no_scroll_prop`     | `assert_no_inertia_scroll_prop`                                           |
+| Once props (partial match)   | `have_once_props`         | `assert_inertia_once_props` / `refute_inertia_once_props`                 |
+| Once props (exact match)     | `have_exact_once_props`   | `assert_inertia_once_props_equal` / `refute_inertia_once_props_equal`     |
+| Once prop key absent         | `have_no_once_prop`       | `assert_no_inertia_once_prop`                                             |
 
 :::tabs key:tests
 

--- a/lib/inertia_rails/minitest.rb
+++ b/lib/inertia_rails/minitest.rb
@@ -108,6 +108,14 @@ module InertiaRails
     AssertionFactory.define_exact_assertion(Helpers, :flash, :flash)
     AssertionFactory.define_key_absent_assertion(Helpers, :flash, :flash)
 
+    AssertionFactory.define_partial_assertion(Helpers, :scroll_props, :scroll_props)
+    AssertionFactory.define_exact_assertion(Helpers, :scroll_props, :scroll_props)
+    AssertionFactory.define_key_absent_assertion(Helpers, :scroll_prop, :scroll_props)
+
+    AssertionFactory.define_partial_assertion(Helpers, :once_props, :once_props)
+    AssertionFactory.define_exact_assertion(Helpers, :once_props, :once_props)
+    AssertionFactory.define_key_absent_assertion(Helpers, :once_prop, :once_props)
+
     AssertionFactory.define_component_assertion(Helpers)
     AssertionFactory.define_response_assertion(Helpers)
     AssertionFactory.define_deferred_props_assertion(Helpers)

--- a/lib/inertia_rails/rspec.rb
+++ b/lib/inertia_rails/rspec.rb
@@ -98,6 +98,14 @@ InertiaRails::RSpec::MatcherFactory.define_partial_matcher(:have_flash, :flash)
 InertiaRails::RSpec::MatcherFactory.define_exact_matcher(:have_exact_flash, :flash)
 InertiaRails::RSpec::MatcherFactory.define_key_absent_matcher(:have_no_flash, :flash)
 
+InertiaRails::RSpec::MatcherFactory.define_partial_matcher(:have_scroll_props, :scroll_props)
+InertiaRails::RSpec::MatcherFactory.define_exact_matcher(:have_exact_scroll_props, :scroll_props)
+InertiaRails::RSpec::MatcherFactory.define_key_absent_matcher(:have_no_scroll_prop, :scroll_props)
+
+InertiaRails::RSpec::MatcherFactory.define_partial_matcher(:have_once_props, :once_props)
+InertiaRails::RSpec::MatcherFactory.define_exact_matcher(:have_exact_once_props, :once_props)
+InertiaRails::RSpec::MatcherFactory.define_key_absent_matcher(:have_no_once_prop, :once_props)
+
 RSpec::Matchers.define(:have_deferred_props) do |*expected_keys, **options|
   match do |inertia|
     @result = InertiaRails::Testing::Assertions.validate_deferred_props(inertia, *expected_keys, **options)

--- a/lib/inertia_rails/testing.rb
+++ b/lib/inertia_rails/testing.rb
@@ -34,7 +34,7 @@ module InertiaRails
     end
 
     class TestResponse
-      attr_reader :view_data, :props, :component, :flash, :deferred_props
+      attr_reader :view_data, :props, :component, :flash, :deferred_props, :scroll_props, :once_props
 
       def call(params)
         assign_locals(params)
@@ -63,6 +63,8 @@ module InertiaRails
         @component = page[:component]
         @flash = (page[:flash] || {}).with_indifferent_access
         @deferred_props = (page[:deferredProps] || {}).with_indifferent_access
+        @scroll_props = (page[:scrollProps] || {}).with_indifferent_access
+        @once_props = (page[:onceProps] || {}).with_indifferent_access
       end
     end
 

--- a/spec/inertia/rspec_helper_spec.rb
+++ b/spec/inertia/rspec_helper_spec.rb
@@ -491,6 +491,18 @@ RSpec.describe InertiaRails::RSpec, type: :request do
     end
   end
 
+  describe 'scroll_props and once_props direct access' do
+    it 'can retrieve scroll props directly' do
+      get scroll_test_path
+      expect(inertia.scroll_props[:users][:currentPage]).to eq 1
+    end
+
+    it 'can retrieve once props directly' do
+      get once_props_path
+      expect(inertia.once_props[:cached_data][:prop]).to eq 'cached_data'
+    end
+  end
+
   describe 'evaluate_optional_props setting' do
     context 'when enabled' do
       before do

--- a/spec/inertia/rspec_helper_spec.rb
+++ b/spec/inertia/rspec_helper_spec.rb
@@ -491,15 +491,71 @@ RSpec.describe InertiaRails::RSpec, type: :request do
     end
   end
 
-  describe 'scroll_props and once_props direct access' do
-    it 'can retrieve scroll props directly' do
-      get scroll_test_path
-      expect(inertia.scroll_props[:users][:currentPage]).to eq 1
+  describe 'scroll props matchers' do
+    context 'with scroll props' do
+      before { get scroll_test_path }
+
+      it 'has scroll props' do
+        expect(inertia).to have_scroll_props(
+          users: { pageName: 'page', currentPage: 1, nextPage: 2, previousPage: nil, reset: false }
+        )
+      end
+
+      it 'checks a single metadata field via block form' do
+        expect(inertia).to(have_scroll_props { |scroll_props| scroll_props[:users][:nextPage] == 2 })
+      end
+
+      it 'has exact scroll props' do
+        expect(inertia).to have_exact_scroll_props(
+          users: { pageName: 'page', currentPage: 1, nextPage: 2, previousPage: nil, reset: false }
+        )
+      end
+
+      it 'has no scroll prop for an untouched key' do
+        expect(inertia).to have_no_scroll_prop(:nonexistent)
+      end
+
+      it 'can retrieve scroll props directly' do
+        expect(inertia.scroll_props[:users][:currentPage]).to eq 1
+      end
     end
 
-    it 'can retrieve once props directly' do
-      get once_props_path
-      expect(inertia.once_props[:cached_data][:prop]).to eq 'cached_data'
+    context 'without scroll props' do
+      before { get props_path }
+
+      it 'has no scroll props' do
+        expect(inertia.scroll_props).to be_empty
+      end
+    end
+  end
+
+  describe 'once props matchers' do
+    context 'with once props' do
+      before { get once_props_path }
+
+      it 'has once props' do
+        expect(inertia).to have_once_props(cached_data: { prop: 'cached_data' })
+      end
+
+      it 'has exact once props' do
+        expect(inertia).to have_exact_once_props(cached_data: { prop: 'cached_data' })
+      end
+
+      it 'has no once prop for an untouched key' do
+        expect(inertia).to have_no_once_prop(:nonexistent)
+      end
+
+      it 'can retrieve once props directly' do
+        expect(inertia.once_props[:cached_data][:prop]).to eq 'cached_data'
+      end
+    end
+
+    context 'without once props' do
+      before { get props_path }
+
+      it 'has no once props' do
+        expect(inertia.once_props).to be_empty
+      end
     end
   end
 

--- a/test/integration/inertia_test.rb
+++ b/test/integration/inertia_test.rb
@@ -216,6 +216,18 @@ class InertiaMinitestTest < ActionDispatch::IntegrationTest
     assert_equal 'Brian', inertia.props[:name]
   end
 
+  # Scroll props and once props direct access
+
+  test 'inertia.scroll_props returns scroll props directly' do
+    get scroll_test_path
+    assert_equal 1, inertia.scroll_props[:users][:currentPage]
+  end
+
+  test 'inertia.once_props returns once props directly' do
+    get once_props_path
+    assert_equal 'cached_data', inertia.once_props[:cached_data][:prop]
+  end
+
   # Partial reload helpers
 
   test 'inertia_reload_only reloads only specified props' do

--- a/test/integration/inertia_test.rb
+++ b/test/integration/inertia_test.rb
@@ -216,11 +216,52 @@ class InertiaMinitestTest < ActionDispatch::IntegrationTest
     assert_equal 'Brian', inertia.props[:name]
   end
 
-  # Scroll props and once props direct access
+  # Scroll props assertions
+
+  test 'assert_inertia_scroll_props works with partial match' do
+    get scroll_test_path
+    assert_inertia_scroll_props(
+      users: { pageName: 'page', currentPage: 1, nextPage: 2, previousPage: nil, reset: false }
+    )
+  end
+
+  test 'assert_inertia_scroll_props checks a single metadata field via block form' do
+    get scroll_test_path
+    assert_inertia_scroll_props { |scroll_props| scroll_props[:users][:nextPage] == 2 }
+  end
+
+  test 'assert_inertia_scroll_props_equal works with exact match' do
+    get scroll_test_path
+    assert_inertia_scroll_props_equal(
+      users: { pageName: 'page', currentPage: 1, nextPage: 2, previousPage: nil, reset: false }
+    )
+  end
+
+  test 'assert_no_inertia_scroll_prop works for an untouched key' do
+    get scroll_test_path
+    assert_no_inertia_scroll_prop :nonexistent
+  end
 
   test 'inertia.scroll_props returns scroll props directly' do
     get scroll_test_path
     assert_equal 1, inertia.scroll_props[:users][:currentPage]
+  end
+
+  # Once props assertions
+
+  test 'assert_inertia_once_props works with partial match' do
+    get once_props_path
+    assert_inertia_once_props cached_data: { prop: 'cached_data' }
+  end
+
+  test 'assert_inertia_once_props_equal works with exact match' do
+    get once_props_path
+    assert_inertia_once_props_equal cached_data: { prop: 'cached_data' }
+  end
+
+  test 'assert_no_inertia_once_prop works for an untouched key' do
+    get once_props_path
+    assert_no_inertia_once_prop :nonexistent
   end
 
   test 'inertia.once_props returns once props directly' do


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Summary

`InertiaRails::Testing::TestResponse` only expose `deferred_props`, even though `PropsResolver#build_metadata` also makes other prop metadata.

scroll_props and once_props each have their own guide page ([infinite-scroll](https://inertia-rails.dev/guide/infinite-scroll), [once-props](https://inertia-rails.dev/guide/once-props)), so they are probably used a lot, and we want to test them too.

They are hash-shaped, like props/view_data/flash, so they can use the same test helpers already built for it, keeping this change small.

## Test plan

- Added RSpec (`spec/inertia/rspec_helper_spec.rb`) and Minitest (`test/integration/inertia_test.rb`) coverage for direct access and all matcher/assertion variants

## Checklist

- [x] Tests added or updated
- [x] `CHANGELOG.md` updated (for user-facing changes)
