### PR TITLE
Use rubocop:disable-next instead of disable/enable pair

### DIFF
--- a/spec/inertia/ssr_spec.rb
+++ b/spec/inertia/ssr_spec.rb
@@ -12,11 +12,10 @@ RSpec.describe 'inertia ssr', type: :request do
     }.to_json
   end
 
-  # rubocop:disable Layout/LineLength
+  # rubocop:disable-next Layout/LineLength
   let(:client_side_html) do
     '<div id="app" data-page="{&quot;component&quot;:&quot;TestComponent&quot;,&quot;props&quot;:{&quot;name&quot;:&quot;Brandon&quot;,&quot;sport&quot;:&quot;hockey&quot;},&quot;url&quot;:&quot;/props&quot;,&quot;version&quot;:&quot;1.0&quot;,&quot;encryptHistory&quot;:false,&quot;clearHistory&quot;:false}"></div>'
   end
-  # rubocop:enable Layout/LineLength
 
   def stub_ssr_response(url:, body:, status: 200)
     http_response = instance_double(Net::HTTPOK, body: body.to_json, code: status.to_s)


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Summary

RuboCop 1.90.0 adds the `Style/DirectiveScope` cop, which flags a disable/enable comment pair wrapping a single statement and recommends disable-next instead.

Fixed with `bundle exec rubocop -A`.

This is also why CI is currently failing on #408.

## Test plan

- Bumped rubocop locally to 1.90.0 (`bundle update rubocop`) and
  confirmed the offense reproduces with
  `bundle exec rubocop --only Style/DirectiveScope spec/inertia/ssr_spec.rb`
- Fixed with `bundle exec rubocop -A spec/inertia/ssr_spec.rb`


## Checklist

- [ ] Tests added or updated
  - not applicable, this is a lint-only fix with no behavior change
- [ ] `CHANGELOG.md` updated (for user-facing changes)
  - not applicable, not a user-facing change
